### PR TITLE
fix: lets allow nested paths within the webhook URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.1-0.20190801062842-66030988cdca
+	github.com/jenkins-x/go-scm v1.5.1-0.20190801075508-592b017aea50
 	github.com/jenkins-x/jx v0.0.0-20190730101642-1c57a62ad4a8
 	github.com/knative/build v0.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,8 @@ github.com/jenkins-x/go-scm v1.5.1-0.20190730154221-a9215b9691fa h1:xRFbIJF/++TL
 github.com/jenkins-x/go-scm v1.5.1-0.20190730154221-a9215b9691fa/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/go-scm v1.5.1-0.20190801062842-66030988cdca h1:t9DptZcGpR3wavEThvTO+GG7OenQa1s6n7NR88j4ZQM=
 github.com/jenkins-x/go-scm v1.5.1-0.20190801062842-66030988cdca/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
+github.com/jenkins-x/go-scm v1.5.1-0.20190801075508-592b017aea50 h1:5cPxukNOCt1d3ewBCbBj+uxdGDpf2SzcsZfwzI0wWZw=
+github.com/jenkins-x/go-scm v1.5.1-0.20190801075508-592b017aea50/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20190709173743-9710a8bca150 h1:3T2KD3a7Oq7dMqTHfRuvYBh/uoMEYfcqJR6RJDc+B7o=


### PR DESCRIPTION
as some git providers like gitlab sometimes pass in the owner/repo after the hook path