### PR TITLE
chore(deps): bump https://github.com/jenkins-x/go-scm from v1.5.18 to v1.5.16

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) |  | [v1.5.16]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x
+  repo: go-scm
+  url: https://github.com/jenkins-x/go-scm
+  version: v1.5.16
+  versionURL: ""

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.18
+	github.com/jenkins-x/go-scm v1.5.16
 	github.com/jenkins-x/jx v0.0.0-20190730101642-1c57a62ad4a8
 	github.com/knative/build v0.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/jenkins-x/go-scm v1.5.1-0.20190801075508-592b017aea50 h1:5cPxukNOCt1d
 github.com/jenkins-x/go-scm v1.5.1-0.20190801075508-592b017aea50/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/go-scm v1.5.1-0.20190801154224-e7a6e6f74306 h1:K32M6Qe+nwMQjJ5+cn/4lF11XTRo4pv/eLGm0diVL9k=
 github.com/jenkins-x/go-scm v1.5.1-0.20190801154224-e7a6e6f74306/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
+github.com/jenkins-x/go-scm v1.5.16 h1:SlHBecSzfQxE1ZBKBf7pYEuK3teGQRXJLVoy64OU1/o=
+github.com/jenkins-x/go-scm v1.5.16/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/go-scm v1.5.18 h1:HrCtzvTCGVhgUGuTcuK6XBUoB+ETTuOSDHp2alKmW04=
 github.com/jenkins-x/go-scm v1.5.18/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=


### PR DESCRIPTION
Update [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) from v1.5.18 to v1.5.16

Command run was `jx step create pr go --name github.com/jenkins-x/go-scm --version v1.5.16 --repo https://github.com/jenkins-x/lighthouse.git`