### PR TITLE
refactor: rename the github package to gitprovider to reflect better its purpose

### DIFF
--- a/pkg/prow/config/config.go
+++ b/pkg/prow/config/config.go
@@ -32,7 +32,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/plumber"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config/org"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/robfig/cron.v2"
 	v1 "k8s.io/api/core/v1"
@@ -938,9 +938,9 @@ func parseProwConfig(c *Config) error {
 	}
 
 	for name, method := range c.Tide.MergeType {
-		if method != github.MergeMerge &&
-			method != github.MergeRebase &&
-			method != github.MergeSquash {
+		if method != gitprovider.MergeMerge &&
+			method != gitprovider.MergeRebase &&
+			method != gitprovider.MergeSquash {
 			return fmt.Errorf("merge type %q for %s is not a valid type", method, name)
 		}
 	}

--- a/pkg/prow/config/tide.go
+++ b/pkg/prow/config/tide.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -79,7 +79,7 @@ type Tide struct {
 
 	// A key/value pair of an org/repo as the key and merge method to override
 	// the default method of merge. Valid options are squash, rebase, and merge.
-	MergeType map[string]github.PullRequestMergeType `json:"merge_method,omitempty"`
+	MergeType map[string]gitprovider.PullRequestMergeType `json:"merge_method,omitempty"`
 
 	// URL for tide status contexts.
 	// We can consider allowing this to be set separately for separate repos, or
@@ -115,7 +115,7 @@ type Tide struct {
 
 // MergeMethod returns the merge method to use for a repo. The default of merge is
 // returned when not overridden.
-func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
+func (t *Tide) MergeMethod(org, repo string) gitprovider.PullRequestMergeType {
 	name := org + "/" + repo
 
 	v, ok := t.MergeType[name]
@@ -124,7 +124,7 @@ func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
 			return ov
 		}
 
-		return github.MergeMerge
+		return gitprovider.MergeMerge
 	}
 
 	return v

--- a/pkg/prow/fakegithub/fakegithub.go
+++ b/pkg/prow/fakegithub/fakegithub.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -134,7 +134,7 @@ func (f *FakeClient) CreateComment(owner, repo string, number int, pr bool, comm
 }
 
 // CreateReview adds a review to a PR
-func (f *FakeClient) CreateReview(org, repo string, number int, r github.DraftReview) error {
+func (f *FakeClient) CreateReview(org, repo string, number int, r gitprovider.DraftReview) error {
 	f.Reviews[number] = append(f.Reviews[number], &scm.Review{
 		ID:     f.ReviewID,
 		Author: scm.User{Login: botName},
@@ -312,7 +312,7 @@ func (f *FakeClient) FindIssues(query, sort string, asc bool) ([]scm.Issue, erro
 
 // AssignIssue adds assignees.
 func (f *FakeClient) AssignIssue(owner, repo string, number int, assignees []string) error {
-	var m github.MissingUsers
+	var m gitprovider.MissingUsers
 	for _, a := range assignees {
 		if a == "not-in-the-org" {
 			m.Users = append(m.Users, a)
@@ -363,7 +363,7 @@ func (f *FakeClient) ListTeams(org string) ([]*scm.Team, error) {
 
 // ListTeamMembers return a fake team with a single "sig-lead" Github teammember
 func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]*scm.TeamMember, error) {
-	if role != github.RoleAll {
+	if role != gitprovider.RoleAll {
 		return nil, fmt.Errorf("unsupported role %v (only all supported)", role)
 	}
 	teams := map[int][]*scm.TeamMember{
@@ -379,9 +379,9 @@ func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]*scm.TeamMember
 
 // IsCollaborator returns true if the user is a collaborator of the repo.
 func (f *FakeClient) IsCollaborator(org, repo, login string) (bool, error) {
-	normed := github.NormLogin(login)
+	normed := gitprovider.NormLogin(login)
 	for _, collab := range f.Collaborators {
-		if github.NormLogin(collab) == normed {
+		if gitprovider.NormLogin(collab) == normed {
 			return true, nil
 		}
 	}
@@ -413,10 +413,10 @@ func (f *FakeClient) SetMilestone(org, repo string, issueNum, milestoneNum int) 
 }
 
 // ListMilestones lists milestones.
-func (f *FakeClient) ListMilestones(org, repo string) ([]github.Milestone, error) {
-	milestones := []github.Milestone{}
+func (f *FakeClient) ListMilestones(org, repo string) ([]gitprovider.Milestone, error) {
+	milestones := []gitprovider.Milestone{}
 	for k, v := range f.MilestoneMap {
-		milestones = append(milestones, github.Milestone{Title: k, Number: v})
+		milestones = append(milestones, gitprovider.Milestone{Title: k, Number: v})
 	}
 	return milestones, nil
 }

--- a/pkg/prow/fakegitprovider/fakegithub.go
+++ b/pkg/prow/fakegitprovider/fakegithub.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fakegithub
+package fakegitprovider
 
 import (
 	"fmt"

--- a/pkg/prow/gitprovider/client.go
+++ b/pkg/prow/gitprovider/client.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/content.go
+++ b/pkg/prow/gitprovider/content.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/git.go
+++ b/pkg/prow/gitprovider/git.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/issues.go
+++ b/pkg/prow/gitprovider/issues.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"bytes"

--- a/pkg/prow/gitprovider/legacy_helpers.go
+++ b/pkg/prow/gitprovider/legacy_helpers.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"fmt"

--- a/pkg/prow/gitprovider/organizations.go
+++ b/pkg/prow/gitprovider/organizations.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/pull_requests.go
+++ b/pkg/prow/gitprovider/pull_requests.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/repositories.go
+++ b/pkg/prow/gitprovider/repositories.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/reviews.go
+++ b/pkg/prow/gitprovider/reviews.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"context"

--- a/pkg/prow/gitprovider/test_helpers.go
+++ b/pkg/prow/gitprovider/test_helpers.go
@@ -1,4 +1,4 @@
-package github
+package gitprovider
 
 import (
 	"github.com/jenkins-x/go-scm/scm"
@@ -7,7 +7,7 @@ import (
 // TestBotName is the default bot name used in tests
 var TestBotName = "jenkins-x-bot"
 
-// ToTestGitHubClient converts the scm client to an API that the prow plugins expect
-func ToTestGitHubClient(client *scm.Client) *Client {
+// ToTestClient converts the scm client to an API that the prow plugins expect
+func ToTestClient(client *scm.Client) *Client {
 	return &Client{client: client, botName: TestBotName}
 }

--- a/pkg/prow/pjutil/pjutil.go
+++ b/pkg/prow/pjutil/pjutil.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/test-infra/prow/kube"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 // NewPlumberJob initializes a PipelineOptions out of a PipelineOptionsSpec.
@@ -83,7 +83,7 @@ func createRefs(pr *scm.PullRequest, baseSHA string) plumber.Refs {
 
 // NewPresubmit converts a config.Presubmit into a builder.PipelineOptions.
 // The builder.Refs are configured correctly per the pr, baseSHA.
-// The eventGUID becomes a github.EventGUID label.
+// The eventGUID becomes a gitprovider.EventGUID label.
 func NewPresubmit(pr *scm.PullRequest, baseSHA string, job config.Presubmit, eventGUID string) plumber.PipelineOptions {
 	refs := createRefs(pr, baseSHA)
 	labels := make(map[string]string)
@@ -94,7 +94,7 @@ func NewPresubmit(pr *scm.PullRequest, baseSHA string, job config.Presubmit, eve
 	for k, v := range job.Annotations {
 		annotations[k] = v
 	}
-	labels[github.EventGUID] = eventGUID
+	labels[gitprovider.EventGUID] = eventGUID
 	return NewPlumberJob(PresubmitSpec(job, refs), labels, annotations)
 }
 
@@ -168,13 +168,13 @@ func PlumberJobFields(pj *plumber.PipelineOptions) logrus.Fields {
 	fields["name"] = pj.ObjectMeta.Name
 	fields["job"] = pj.Spec.Job
 	fields["type"] = pj.Spec.Type
-	if len(pj.ObjectMeta.Labels[github.EventGUID]) > 0 {
-		fields[github.EventGUID] = pj.ObjectMeta.Labels[github.EventGUID]
+	if len(pj.ObjectMeta.Labels[gitprovider.EventGUID]) > 0 {
+		fields[gitprovider.EventGUID] = pj.ObjectMeta.Labels[gitprovider.EventGUID]
 	}
 	if pj.Spec.Refs != nil && len(pj.Spec.Refs.Pulls) == 1 {
-		fields[github.PrLogField] = pj.Spec.Refs.Pulls[0].Number
-		fields[github.RepoLogField] = pj.Spec.Refs.Repo
-		fields[github.OrgLogField] = pj.Spec.Refs.Org
+		fields[gitprovider.PrLogField] = pj.Spec.Refs.Pulls[0].Number
+		fields[gitprovider.RepoLogField] = pj.Spec.Refs.Repo
+		fields[gitprovider.OrgLogField] = pj.Spec.Refs.Org
 	}
 	return fields
 }

--- a/pkg/prow/plugins/approve/approve.go
+++ b/pkg/prow/plugins/approve/approve.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -143,7 +143,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) error {
+func handleGenericCommentEvent(pc plugins.Agent, ce gitprovider.GenericCommentEvent) error {
 	return handleGenericComment(
 		pc.Logger,
 		pc.GitHubClient,
@@ -154,7 +154,7 @@ func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) 
 	)
 }
 
-func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
+func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, ce *gitprovider.GenericCommentEvent) error {
 	if ce.Action != scm.ActionCreate || !ce.IsPR || ce.IssueState == "closed" {
 		return nil
 	}
@@ -464,7 +464,7 @@ func humanAddedApproved(ghc githubClient, log *logrus.Entry, org, repo string, n
 		lastAdded := scm.ListedIssueEvent{}
 		for _, event := range events {
 			// Only consider "approved" label added events.
-			if event.Event != github.IssueActionLabeled || event.Label.Name != labels.Approved {
+			if event.Event != gitprovider.IssueActionLabeled || event.Label.Name != labels.Approved {
 				continue
 			}
 			lastAdded = *event

--- a/pkg/prow/plugins/assign/assign.go
+++ b/pkg/prow/plugins/assign/assign.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -73,7 +73,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	if e.Action != scm.ActionCreate {
 		return nil
 	}
@@ -147,7 +147,7 @@ func handle(h *handler) error {
 	if len(toAdd) > 0 {
 		h.log.Printf("Adding %s to %s/%s#%d: %v", h.userType, org, repo, e.Number, toAdd)
 		if err := h.add(org, repo, e.Number, toAdd); err != nil {
-			if mu, ok := err.(github.MissingUsers); ok {
+			if mu, ok := err.(gitprovider.MissingUsers); ok {
 				msg := h.addFailureResponse(mu)
 				if len(msg) == 0 {
 					return nil
@@ -166,14 +166,14 @@ func handle(h *handler) error {
 // handler is a struct that contains data about a github event and provides functions to help handle it.
 type handler struct {
 	// addFailureResponse generates the body of a response comment in the event that the add function fails.
-	addFailureResponse func(mu github.MissingUsers) string
+	addFailureResponse func(mu gitprovider.MissingUsers) string
 	// remove is the function that is called on the affected logins for a command prefixed with 'un'.
 	remove func(org, repo string, number int, users []string) error
 	// add is the function that is called on the affected logins for a command with no 'un' prefix.
 	add func(org, repo string, number int, users []string) error
 
-	// event is a pointer to the github.GenericCommentEvent struct that triggered the handler.
-	event *github.GenericCommentEvent
+	// event is a pointer to the gitprovider.GenericCommentEvent struct that triggered the handler.
+	event *gitprovider.GenericCommentEvent
 	// regexp is the regular expression describing the command. It must have an optional 'un' prefix
 	// as the first subgroup and the arguments to the command as the second subgroup.
 	regexp *regexp.Regexp
@@ -186,9 +186,9 @@ type handler struct {
 	userType string
 }
 
-func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
+func newAssignHandler(e gitprovider.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
 	org := e.Repo.Namespace
-	addFailureResponse := func(mu github.MissingUsers) string {
+	addFailureResponse := func(mu gitprovider.MissingUsers) string {
 		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people), repo collaborators and people who have commented on this issue/PR can be assigned. Additionally, issues/PRs can only have 10 assignees at the same time.\nFor more information please see [the contributor guide](https://git.k8s.io/community/contributors/guide/#issue-assignment-in-github)", strings.Join(mu.Users, ", "), org, org)
 	}
 
@@ -204,9 +204,9 @@ func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus
 	}
 }
 
-func newReviewHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
+func newReviewHandler(e gitprovider.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
 	org := e.Repo.Namespace
-	addFailureResponse := func(mu github.MissingUsers) string {
+	addFailureResponse := func(mu gitprovider.MissingUsers) string {
 		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) and repo collaborators can review this PR, and authors cannot review their own PRs.", strings.Join(mu.Users, ", "), org, org)
 	}
 

--- a/pkg/prow/plugins/assign/assign_test.go
+++ b/pkg/prow/plugins/assign/assign_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeClient struct {
@@ -46,7 +46,7 @@ func (c *fakeClient) UnassignIssue(owner, repo string, number int, assignees []s
 }
 
 func (c *fakeClient) AssignIssue(owner, repo string, number int, assignees []string) error {
-	var missing github.MissingUsers
+	var missing gitprovider.MissingUsers
 	sort.Strings(assignees)
 	if len(assignees) > 10 {
 		for _, who := range assignees[10:] {
@@ -72,7 +72,7 @@ func (c *fakeClient) AssignIssue(owner, repo string, number int, assignees []str
 }
 
 func (c *fakeClient) RequestReview(org, repo string, number int, logins []string) error {
-	var missing github.MissingUsers
+	var missing gitprovider.MissingUsers
 	for _, user := range logins {
 		if c.contributors[user] {
 			c.requested[user]++
@@ -392,7 +392,7 @@ func TestAssignAndReview(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fc := newFakeClient([]string{"hello-world", "allow_underscore", "cjwagner", "merlin", "kubernetes/sig-testing-misc"})
-		e := github.GenericCommentEvent{
+		e := gitprovider.GenericCommentEvent{
 			Body:   tc.body,
 			Author: scm.User{Login: tc.commenter},
 			Repo:   scm.Repository{Name: "repo", Namespace: "org"},

--- a/pkg/prow/plugins/blockade/blockade_test.go
+++ b/pkg/prow/plugins/blockade/blockade_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
@@ -297,7 +297,7 @@ func TestHandle(t *testing.T) {
 	for _, tc := range tcs {
 		expectAdded := []string{}
 		fakeScmClient, fakeClient := fake.NewDefault()
-		fakeGHClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeGHClient := gitprovider.ToTestClient(fakeScmClient)
 		fakeClient.RepoLabelsExisting = []string{labels.BlockedPaths, otherLabel}
 
 		if tc.hasLabel {

--- a/pkg/prow/plugins/branchcleaner/branchcleaner_test.go
+++ b/pkg/prow/plugins/branchcleaner/branchcleaner_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 )
 
@@ -99,7 +99,7 @@ func TestBranchCleaner(t *testing.T) {
 			}
 
 			fakeScmClient, fgc := fake.NewDefault()
-			fakeClient := github.ToTestGitHubClient(fakeScmClient)
+			fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 			fgc.PullRequests[prNumber] = &scm.PullRequest{
 				Number: prNumber,

--- a/pkg/prow/plugins/cat/cat.go
+++ b/pkg/prow/plugins/cat/cat.go
@@ -32,7 +32,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -165,7 +165,7 @@ func (c *realClowder) readCat(category string, movieCat bool) (string, error) {
 		return "", fmt.Errorf("no image url in response from %s", uri)
 	}
 	// checking size, GitHub doesn't support big images
-	toobig, err := github.ImageTooBig(a.Image)
+	toobig, err := gitprovider.ImageTooBig(a.Image)
 	if err != nil {
 		return "", fmt.Errorf("could not validate image size %s: %v", a.Image, err)
 	} else if toobig {
@@ -174,7 +174,7 @@ func (c *realClowder) readCat(category string, movieCat bool) (string, error) {
 	return a.Format()
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(
 		pc.GitHubClient,
 		pc.Logger,
@@ -184,7 +184,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 	)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, c clowder, setKey func()) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, c clowder, setKey func()) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/cat/cat_test.go
+++ b/pkg/prow/plugins/cat/cat_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeClowder string
@@ -340,7 +340,7 @@ Available variants:
 
 	// github fake client
 	fakeScmClient, fc := fake.NewDefault()
-	fakeClient := github.ToTestGitHubClient(fakeScmClient)
+	fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 	// run test for each case
 	for _, testcase := range testcases {
@@ -358,7 +358,7 @@ Available variants:
 	// fully test handling a comment
 	comment := "/meowvie space"
 
-	e := &github.GenericCommentEvent{
+	e := &gitprovider.GenericCommentEvent{
 		Action:     scm.ActionCreate,
 		Body:       comment,
 		Number:     5,
@@ -457,9 +457,9 @@ func TestCats(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     tc.action,
 			Body:       tc.body,
 			Number:     5,

--- a/pkg/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/pkg/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -106,8 +106,8 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *scm.PullRequestHook, cp co
 	if err != nil {
 		return err
 	}
-	hasCherryPickApprovedLabel := github.HasLabel(labels.CpApproved, issueLabels)
-	hasCherryPickUnapprovedLabel := github.HasLabel(labels.CpUnapproved, issueLabels)
+	hasCherryPickApprovedLabel := gitprovider.HasLabel(labels.CpApproved, issueLabels)
+	hasCherryPickUnapprovedLabel := gitprovider.HasLabel(labels.CpUnapproved, issueLabels)
 
 	// if it has the approved label,
 	// remove the unapproved label (if it exists) and

--- a/pkg/prow/plugins/config.go
+++ b/pkg/prow/plugins/config.go
@@ -376,7 +376,7 @@ type Heart struct {
 // milestonestatus plugins.
 type Milestone struct {
 	// ID of the github team for the milestone maintainers (used for setting status labels)
-	// You can curl the following endpoint in order to determine the github ID of your team
+	// You can curl the following endpoint in order to determine the gitprovider.ID of your team
 	// responsible for maintaining the milestones:
 	// curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
 	MaintainersID           int    `json:"maintainers_id,omitempty"`

--- a/pkg/prow/plugins/dog/dog.go
+++ b/pkg/prow/plugins/dog/dog.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -121,7 +121,7 @@ func (u realPack) readDog(dogURL string) (string, error) {
 		return "", errors.New("unsupported doggo :( unknown filetype: " + dogURL)
 	}
 	// checking size, GitHub doesn't support big images
-	toobig, err := github.ImageTooBig(dogURL)
+	toobig, err := gitprovider.ImageTooBig(dogURL)
 	if err != nil {
 		return "", err
 	} else if toobig {
@@ -130,11 +130,11 @@ func (u realPack) readDog(dogURL string) (string, error) {
 	return FormatURL(dogURL)
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, dogURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p pack) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, p pack) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/dog/dog_test.go
+++ b/pkg/prow/plugins/dog/dog_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakePack string
@@ -220,10 +220,10 @@ func TestHttpResponse(t *testing.T) {
 
 		// github fake client
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		// fully test handling a comment
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     scm.ActionCreate,
 			Body:       testcase.comment,
 			Number:     5,
@@ -323,9 +323,9 @@ func TestDogs(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     tc.action,
 			Body:       tc.body,
 			Number:     5,

--- a/pkg/prow/plugins/help/help.go
+++ b/pkg/prow/plugins/help/help.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -87,7 +87,7 @@ type commentPruner interface {
 	PruneComments(shouldPrune func(*scm.Comment) bool)
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	cp, err := pc.CommentPruner()
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 	return handle(pc.GitHubClient, pc.Logger, cp, &e)
 }
 
-func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.GenericCommentEvent) error {
+func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *gitprovider.GenericCommentEvent) error {
 	// Only consider open issues and new comments.
 	if e.IsPR || e.IssueState != "open" || e.Action != scm.ActionCreate {
 		return nil
@@ -110,8 +110,8 @@ func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.Gene
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get issue labels.")
 	}
-	hasHelp := github.HasLabel(labels.Help, issueLabels)
-	hasGoodFirstIssue := github.HasLabel(labels.GoodFirstIssue, issueLabels)
+	hasHelp := gitprovider.HasLabel(labels.Help, issueLabels)
+	hasGoodFirstIssue := gitprovider.HasLabel(labels.GoodFirstIssue, issueLabels)
 
 	// If PR has help label and we're asking for it to be removed, remove label
 	if hasHelp && helpRemoveRe.MatchString(e.Body) {

--- a/pkg/prow/plugins/help/help_test.go
+++ b/pkg/prow/plugins/help/help_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/sirupsen/logrus"
 )
@@ -176,7 +176,7 @@ func TestLabel(t *testing.T) {
 	for _, tc := range testcases {
 		sort.Strings(tc.expectedNewLabels)
 		fakeScmClient, fakeClient := fake.NewDefault()
-		fakeGHClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeGHClient := gitprovider.ToTestClient(fakeScmClient)
 		fakeClient.RepoLabelsExisting = []string{labels.Help, labels.GoodFirstIssue}
 
 		// Add initial labels
@@ -191,7 +191,7 @@ func TestLabel(t *testing.T) {
 			tc.action = scm.ActionCreate
 		}
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			IsPR:       tc.isPR,
 			IssueState: tc.issueState,
 			Action:     tc.action,

--- a/pkg/prow/plugins/hold/hold.go
+++ b/pkg/prow/plugins/hold/hold.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -70,9 +70,9 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	hasLabel := func(label string, labels []*scm.Label) bool {
-		return github.HasLabel(label, labels)
+		return gitprovider.HasLabel(label, labels)
 	}
 	return handle(pc.GitHubClient, pc.Logger, &e, hasLabel)
 }
@@ -80,7 +80,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 // handle drives the pull request to the desired state. If any user adds
 // a /hold directive, we want to add a label if one does not already exist.
 // If they add /hold cancel, we want to remove the label if it exists.
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, f hasLabelFunc) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, f hasLabelFunc) error {
 	if e.Action != scm.ActionCreate {
 		return nil
 	}

--- a/pkg/prow/plugins/hold/hold_test.go
+++ b/pkg/prow/plugins/hold/hold_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 )
 
@@ -76,7 +76,7 @@ func TestHandle(t *testing.T) {
 	for _, tc := range tests {
 		client, fc := fake.NewDefault()
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 1,
@@ -86,7 +86,7 @@ func TestHandle(t *testing.T) {
 			return tc.hasLabel
 		}
 
-		if err := handle(github.ToTestGitHubClient(client), logrus.WithField("plugin", PluginName), e, hasLabel); err != nil {
+		if err := handle(gitprovider.ToTestClient(client), logrus.WithField("plugin", PluginName), e, hasLabel); err != nil {
 			t.Errorf("For case %s, didn't expect error from hold: %v", tc.name, err)
 			continue
 		}

--- a/pkg/prow/plugins/label/label.go
+++ b/pkg/prow/plugins/label/label.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -72,7 +72,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.Label.AdditionalLabels, &e)
 }
 
@@ -116,7 +116,7 @@ func getLabelsFromGenericMatches(matches [][]string, additionalLabels []string) 
 	return labels
 }
 
-func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *github.GenericCommentEvent) error {
+func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gitprovider.GenericCommentEvent) error {
 	labelMatches := labelRegex.FindAllStringSubmatch(e.Body, -1)
 	removeLabelMatches := removeLabelRegex.FindAllStringSubmatch(e.Body, -1)
 	customLabelMatches := customLabelRegex.FindAllStringSubmatch(e.Body, -1)
@@ -154,7 +154,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 
 	// Add labels
 	for _, labelToAdd := range labelsToAdd {
-		if github.HasLabel(labelToAdd, labels) {
+		if gitprovider.HasLabel(labelToAdd, labels) {
 			continue
 		}
 
@@ -170,7 +170,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 
 	// Remove labels
 	for _, labelToRemove := range labelsToRemove {
-		if !github.HasLabel(labelToRemove, labels) {
+		if !gitprovider.HasLabel(labelToRemove, labels) {
 			noSuchLabelsOnIssue = append(noSuchLabelsOnIssue, labelToRemove)
 			continue
 		}

--- a/pkg/prow/plugins/label/label_test.go
+++ b/pkg/prow/plugins/label/label_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/sirupsen/logrus"
@@ -435,7 +435,7 @@ func TestLabel(t *testing.T) {
 		t.Logf("Running scenario %q", tc.name)
 		sort.Strings(tc.expectedNewLabels)
 		fakeScmClient, fakeData := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 		fakeData.OrgMembers["org"] = []string{orgMember}
 		fakeData.RepoLabelsExisting = tc.repoLabels
 
@@ -443,7 +443,7 @@ func TestLabel(t *testing.T) {
 		for _, label := range tc.issueLabels {
 			fakeClient.AddLabel("org", "repo", 1, label)
 		}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 1,

--- a/pkg/prow/plugins/lgtm/lgtm_test.go
+++ b/pkg/prow/plugins/lgtm/lgtm_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/prow/repoowners"
 )
@@ -260,7 +260,7 @@ func TestLGTMComment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Running scenario %q", tc.name)
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		fc.PullRequests[5] = &scm.PullRequest{
 			Number: 5,
@@ -276,7 +276,7 @@ func TestLGTMComment(t *testing.T) {
 		}
 		fc.Collaborators = []string{"collab1", "collab2"}
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:      scm.ActionCreate,
 			IssueState:  "open",
 			IsPR:        true,
@@ -420,7 +420,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 	SHA := "0bd3ed50c88cd53a09316bf7a298f900e9371652"
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		fc.PullRequests[5] = &scm.PullRequest{
 			Number: 5,
@@ -429,7 +429,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 			},
 		}
 		fc.Collaborators = []string{"collab1", "collab2"}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:      scm.ActionCreate,
 			IssueState:  "open",
 			IsPR:        true,
@@ -626,7 +626,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 	SHA := "0bd3ed50c88cd53a09316bf7a298f900e9371652"
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		fc.PullRequests[5] = &scm.PullRequest{
 			Number: 5,
@@ -926,7 +926,7 @@ func TestHandlePullRequest(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeScmClient, fakeGitHub := fake.NewDefault()
-			fakeClient := github.ToClient(fakeScmClient, fakeBotName)
+			fakeClient := gitprovider.ToClient(fakeScmClient, fakeBotName)
 
 			fakeGitHub.IssueComments = c.issueComments
 			fakeGitHub.PullRequests[101] = &scm.PullRequest{
@@ -1035,7 +1035,7 @@ func TestAddTreeHashComment(t *testing.T) {
 				body:   "/lgtm",
 			}
 			fakeScmClient, fc := fake.NewDefault()
-			fakeClient := github.ToTestGitHubClient(fakeScmClient)
+			fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 			fc.PullRequests[101] = &scm.PullRequest{
 				Number: 101,
@@ -1092,7 +1092,7 @@ func TestRemoveTreeHashComment(t *testing.T) {
 	}
 	fakeBotName := "k8s-ci-robot"
 	fakeScmClient, fc := fake.NewDefault()
-	fakeClient := github.ToClient(fakeScmClient, fakeBotName)
+	fakeClient := gitprovider.ToClient(fakeScmClient, fakeBotName)
 
 	fc.IssueComments[101] = []*scm.Comment{&scm.Comment{
 		Body:   fmt.Sprintf(addLGTMLabelNotification, treeSHA),

--- a/pkg/prow/plugins/lifecycle/close.go
+++ b/pkg/prow/plugins/lifecycle/close.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
 
@@ -43,14 +43,14 @@ func isActive(gc closeClient, org, repo string, number int) (bool, error) {
 		return true, fmt.Errorf("list issue labels error: %v", err)
 	}
 	for _, label := range []string{"lifecycle/stale", "lifecycle/rotten"} {
-		if github.HasLabel(label, labels) {
+		if gitprovider.HasLabel(label, labels) {
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func handleClose(gc closeClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handleClose(gc closeClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 	// Only consider open issues and new comments.
 	if e.IssueState != "open" || e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/lifecycle/close_test.go
+++ b/pkg/prow/plugins/lifecycle/close_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeClientClose struct {
@@ -173,7 +173,7 @@ func TestCloseComment(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fc := &fakeClientClose{labels: tc.labels}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:      tc.action,
 			IssueState:  tc.state,
 			Body:        tc.body,

--- a/pkg/prow/plugins/lifecycle/lifecycle.go
+++ b/pkg/prow/plugins/lifecycle/lifecycle.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -71,7 +71,7 @@ type lifecycleClient interface {
 	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
 }
 
-func lifecycleHandleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func lifecycleHandleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	gc := pc.GitHubClient
 	log := pc.Logger
 	if err := handleReopen(gc, log, &e); err != nil {
@@ -83,7 +83,7 @@ func lifecycleHandleGenericComment(pc plugins.Agent, e github.GenericCommentEven
 	return handle(gc, log, &e)
 }
 
-func handle(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handle(gc lifecycleClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil
@@ -97,7 +97,7 @@ func handle(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEvent
 	return nil
 }
 
-func handleOne(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEvent, mat []string) error {
+func handleOne(gc lifecycleClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, mat []string) error {
 	org := e.Repo.Namespace
 	repo := e.Repo.Name
 	number := e.Number
@@ -114,15 +114,15 @@ func handleOne(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEv
 	}
 
 	// If the label exists and we asked for it to be removed, remove it.
-	if github.HasLabel(lbl, labels) && remove {
+	if gitprovider.HasLabel(lbl, labels) && remove {
 		return gc.RemoveLabel(org, repo, number, lbl)
 	}
 
 	// If the label does not exist and we asked for it to be added,
 	// remove other existing lifecycle labels and add it.
-	if !github.HasLabel(lbl, labels) && !remove {
+	if !gitprovider.HasLabel(lbl, labels) && !remove {
 		for _, label := range lifecycleLabels {
-			if label != lbl && github.HasLabel(label, labels) {
+			if label != lbl && gitprovider.HasLabel(label, labels) {
 				if err := gc.RemoveLabel(org, repo, number, label); err != nil {
 					log.WithError(err).Errorf("GitHub failed to remove the following label: %s", label)
 				}

--- a/pkg/prow/plugins/lifecycle/lifecycle_test.go
+++ b/pkg/prow/plugins/lifecycle/lifecycle_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 )
 
@@ -212,7 +212,7 @@ func TestAddLifecycleLabels(t *testing.T) {
 			added:   []string{},
 			removed: []string{},
 		}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Body:   tc.body,
 			Action: scm.ActionCreate,
 		}

--- a/pkg/prow/plugins/lifecycle/reopen.go
+++ b/pkg/prow/plugins/lifecycle/reopen.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
 
@@ -36,7 +36,7 @@ type githubClient interface {
 	ReopenPR(owner, repo string, number int) error
 }
 
-func handleReopen(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handleReopen(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 	// Only consider closed issues and new comments.
 	if e.IssueState != "closed" || e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/lifecycle/reopen_test.go
+++ b/pkg/prow/plugins/lifecycle/reopen_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeClientReopen struct {
@@ -128,7 +128,7 @@ func TestReopenComment(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fc := &fakeClientReopen{}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:      tc.action,
 			IssueState:  tc.state,
 			Body:        tc.body,

--- a/pkg/prow/plugins/milestone/milestone_test.go
+++ b/pkg/prow/plugins/milestone/milestone_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -118,7 +118,7 @@ func TestMilestoneStatus(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		fakeClient := &fakegithub.FakeClient{IssueComments: make(map[int][]*scm.Comment), MilestoneMap: milestonesMap}
+		fakeClient := &fakegitprovider.FakeClient{IssueComments: make(map[int][]*scm.Comment), MilestoneMap: milestonesMap}
 		fakeClient.Milestone = tc.previousMilestone
 
 		maintainersID := 42

--- a/pkg/prow/plugins/milestone/milestone_test.go
+++ b/pkg/prow/plugins/milestone/milestone_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
 
@@ -123,7 +123,7 @@ func TestMilestoneStatus(t *testing.T) {
 
 		maintainersID := 42
 		maintainersName := "fake-maintainers-team"
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 1,

--- a/pkg/prow/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/prow/plugins/milestonestatus/milestonestatus.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -83,11 +83,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.RepoMilestone)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, repoMilestone map[string]plugins.Milestone) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, repoMilestone map[string]plugins.Milestone) error {
 	if e.Action != scm.ActionCreate {
 		return nil
 	}
@@ -106,7 +106,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		milestone = repoMilestone[""]
 	}
 
-	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, github.RoleAll)
+	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, gitprovider.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/pkg/prow/plugins/milestonestatus/milestonestatus_test.go
+++ b/pkg/prow/plugins/milestonestatus/milestonestatus_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -126,7 +126,7 @@ func TestMilestoneStatus(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		fakeClient := &fakegithub.FakeClient{IssueComments: make(map[int][]*scm.Comment)}
+		fakeClient := &fakegitprovider.FakeClient{IssueComments: make(map[int][]*scm.Comment)}
 		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,

--- a/pkg/prow/plugins/milestonestatus/milestonestatus_test.go
+++ b/pkg/prow/plugins/milestonestatus/milestonestatus_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
 
@@ -127,7 +127,7 @@ func TestMilestoneStatus(t *testing.T) {
 
 	for _, tc := range testcases {
 		fakeClient := &fakegithub.FakeClient{IssueComments: make(map[int][]*scm.Comment)}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 1,

--- a/pkg/prow/plugins/override/override.go
+++ b/pkg/prow/plugins/override/override.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -117,7 +117,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	c := client{
 		gc:            pc.GitHubClient,
 		jc:            pc.Config.JobConfig,
@@ -127,7 +127,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 }
 
 func authorized(gc githubClient, log *logrus.Entry, org, repo, user string) bool {
-	ok, err := gc.HasPermission(org, repo, user, github.RoleAdmin)
+	ok, err := gc.HasPermission(org, repo, user, gitprovider.RoleAdmin)
 	if err != nil {
 		log.WithError(err).Warnf("cannot determine whether %s is an admin of %s/%s", user, org, repo)
 		return false
@@ -147,7 +147,7 @@ func formatList(list []string) string {
 	return strings.Join(lines, "\n")
 }
 
-func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handle(oc overrideClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 
 	if !e.IsPR || e.IssueState != "open" || e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/override/override_test.go
+++ b/pkg/prow/plugins/override/override_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 const (
@@ -119,7 +119,7 @@ func (c *fakeClient) HasPermission(org, repo, user string, roles ...string) (boo
 		return false, fmt.Errorf("bad org: %s", org)
 	case repo != fakeRepo:
 		return false, fmt.Errorf("bad repo: %s", repo)
-	case roles[0] != github.RoleAdmin:
+	case roles[0] != gitprovider.RoleAdmin:
 		return false, fmt.Errorf("bad roles: %s", roles)
 	case user == "fail":
 		return true, errors.New("injected HasPermission error")
@@ -485,7 +485,7 @@ func TestHandle(t *testing.T) {
 	log := logrus.WithField("plugin", pluginName)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var event github.GenericCommentEvent
+			var event gitprovider.GenericCommentEvent
 			event.Repo.Namespace = fakeOrg
 			event.Repo.Name = fakeRepo
 			event.Body = tc.comment

--- a/pkg/prow/plugins/owners-label/owners-label_test.go
+++ b/pkg/prow/plugins/owners-label/owners-label_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
@@ -177,7 +177,7 @@ func TestHandle(t *testing.T) {
 			changes = append(changes, &scm.Change{Path: name})
 		}
 		fakeScmClient, fghc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		fghc.PullRequests[basicPR.Number] = &basicPR
 		fghc.PullRequestChanges[basicPR.Number] = changes

--- a/pkg/prow/plugins/plugins.go
+++ b/pkg/prow/plugins/plugins.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/prow/commentpruner"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	git2 "github.com/jenkins-x/lighthouse/pkg/prow/git"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/repoowners"
 	"github.com/sirupsen/logrus"
@@ -123,7 +123,7 @@ func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler
 }
 
 // GenericCommentHandler defines the function contract for a scm.Comment handler.
-type GenericCommentHandler func(Agent, github.GenericCommentEvent) error
+type GenericCommentHandler func(Agent, gitprovider.GenericCommentEvent) error
 
 // RegisterGenericCommentHandler registers a plugin's scm.Comment handler.
 func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help HelpProvider) {
@@ -133,7 +133,7 @@ func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help H
 
 // Agent may be used concurrently, so each entry must be thread-safe.
 type Agent struct {
-	GitHubClient     *github.Client
+	GitHubClient     *gitprovider.Client
 	PlumberClient    plumber.Plumber
 	GitClient        git2.Client
 	KubernetesClient kubernetes.Interface
@@ -159,7 +159,7 @@ type Agent struct {
 func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientAgent *ClientAgent, logger *logrus.Entry) Agent {
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
-	gitHubClient := github.ToClient(clientAgent.GitHubClient, clientAgent.BotName)
+	gitHubClient := gitprovider.ToClient(clientAgent.GitHubClient, clientAgent.BotName)
 	return Agent{
 		GitHubClient:  gitHubClient,
 		GitClient:     clientAgent.GitClient,

--- a/pkg/prow/plugins/pony/pony.go
+++ b/pkg/prow/plugins/pony/pony.go
@@ -26,7 +26,7 @@ import (
 	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/sirupsen/logrus"
@@ -106,7 +106,7 @@ func (h realHerd) readPony(tags string) (string, error) {
 	}
 
 	embedded := a.Pony.Representations.Small
-	tooBig, err := github.ImageTooBig(embedded)
+	tooBig, err := gitprovider.ImageTooBig(embedded)
 	if err != nil {
 		return "", fmt.Errorf("couldn't fetch pony for size check: %v", err)
 	}
@@ -116,11 +116,11 @@ func (h realHerd) readPony(tags string) (string, error) {
 	return formatURLs(a.Pony.Representations.Small, a.Pony.Representations.Full), nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, ponyURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p herd) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, p herd) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/pony/pony_test.go
+++ b/pkg/prow/plugins/pony/pony_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 )
 
@@ -206,10 +206,10 @@ func TestHttpResponse(t *testing.T) {
 
 		// github fake client
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		// fully test handling a comment
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     scm.ActionCreate,
 			Body:       testcase.comment,
 			Number:     5,
@@ -299,9 +299,9 @@ func TestPonies(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     tc.action,
 			Body:       tc.body,
 			Number:     5,

--- a/pkg/prow/plugins/shrug/shrug.go
+++ b/pkg/prow/plugins/shrug/shrug.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -74,11 +74,11 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 	if e.Action != scm.ActionCreate {
 		return nil
 	}

--- a/pkg/prow/plugins/shrug/shurg_test.go
+++ b/pkg/prow/plugins/shrug/shurg_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 )
 
@@ -73,9 +73,9 @@ func TestShrugComment(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 5,

--- a/pkg/prow/plugins/sigmention/sigmention.go
+++ b/pkg/prow/plugins/sigmention/sigmention.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -71,11 +71,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.PluginConfig.SigMention.Re)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, re *regexp.Regexp) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, re *regexp.Regexp) error {
 	// Ignore bot comments and comments that aren't new.
 	botName, err := gc.BotName()
 	if err != nil {
@@ -117,14 +117,14 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 			nonexistent = append(nonexistent, "sig/"+sigMatch[1])
 			continue
 		}
-		if !github.HasLabel(sigLabel, labels) {
+		if !gitprovider.HasLabel(sigLabel, labels) {
 			if err := gc.AddLabel(org, repo, e.Number, sigLabel); err != nil {
 				log.WithError(err).Errorf("GitHub failed to add the following label: %s", sigLabel)
 			}
 		}
 
 		if len(sigMatch) > 2 {
-			if kindLabel, ok := kindMap[sigMatch[2]]; ok && !github.HasLabel(kindLabel, labels) {
+			if kindLabel, ok := kindMap[sigMatch[2]]; ok && !gitprovider.HasLabel(kindLabel, labels) {
 				if err := gc.AddLabel(org, repo, e.Number, kindLabel); err != nil {
 					log.WithError(err).Errorf("GitHub failed to add the following label: %s", kindLabel)
 				}

--- a/pkg/prow/plugins/sigmention/sigmention_test.go
+++ b/pkg/prow/plugins/sigmention/sigmention_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 )
@@ -152,7 +152,7 @@ func TestSigMention(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		fakeClient := &fakegithub.FakeClient{
+		fakeClient := &fakegitprovider.FakeClient{
 			OrgMembers:         map[string][]string{"org": {orgMember, bot}},
 			RepoLabelsExisting: tc.repoLabels,
 			IssueComments:      make(map[int][]*scm.Comment),

--- a/pkg/prow/plugins/sigmention/sigmention_test.go
+++ b/pkg/prow/plugins/sigmention/sigmention_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 )
 
@@ -161,7 +161,7 @@ func TestSigMention(t *testing.T) {
 		for _, label := range tc.issueLabels {
 			fakeClient.AddLabel("org", "repo", 1, label)
 		}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Body:   tc.body,
 			Number: 1,

--- a/pkg/prow/plugins/size/size.go
+++ b/pkg/prow/plugins/size/size.go
@@ -70,7 +70,7 @@ func handlePullRequest(pc plugins.Agent, pe scm.PullRequestHook) error {
 	return handlePR(pc.GitHubClient, sizesOrDefault(pc.PluginConfig.Size), pc.Logger, pe)
 }
 
-// Strict subset of github.Client methods.
+// Strict subset of gitprovider.Client methods.
 type githubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error

--- a/pkg/prow/plugins/skip/skip.go
+++ b/pkg/prow/plugins/skip/skip.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins/trigger"
@@ -63,12 +63,12 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	honorOkToTest := trigger.HonorOkToTest(pc.PluginConfig.TriggerFor(e.Repo.Namespace, e.Repo.Name))
 	return handle(pc.GitHubClient, pc.Logger, &e, pc.Config.GetPresubmits(e.Repo), honorOkToTest)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, presubmits []config.Presubmit, honorOkToTest bool) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, presubmits []config.Presubmit, honorOkToTest bool) error {
 	if !e.IsPR || e.IssueState != "open" || e.Action != scm.ActionCreate {
 		return nil
 	}

--- a/pkg/prow/plugins/skip/skip_test.go
+++ b/pkg/prow/plugins/skip/skip_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 func TestSkipStatus(t *testing.T) {
@@ -34,7 +34,7 @@ func TestSkipStatus(t *testing.T) {
 
 		presubmits     []config.Presubmit
 		sha            string
-		event          *github.GenericCommentEvent
+		event          *gitprovider.GenericCommentEvent
 		prChanges      map[int][]*scm.Change
 		existing       []*scm.StatusInput
 		combinedStatus scm.State
@@ -61,7 +61,7 @@ func TestSkipStatus(t *testing.T) {
 				},
 			},
 			sha: "shalala",
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,
@@ -117,7 +117,7 @@ func TestSkipStatus(t *testing.T) {
 				},
 			},
 			sha: "shalala",
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,
@@ -161,7 +161,7 @@ func TestSkipStatus(t *testing.T) {
 				},
 			},
 			sha: "shalala",
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,
@@ -185,7 +185,7 @@ func TestSkipStatus(t *testing.T) {
 				},
 			},
 			sha: "shalala",
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,
@@ -221,7 +221,7 @@ func TestSkipStatus(t *testing.T) {
 				},
 			},
 			sha: "shalala",
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,
@@ -262,7 +262,7 @@ func TestSkipStatus(t *testing.T) {
 			},
 			sha:            "shalala",
 			combinedStatus: scm.StateSuccess,
-			event: &github.GenericCommentEvent{
+			event: &gitprovider.GenericCommentEvent{
 				IsPR:       true,
 				IssueState: "open",
 				Action:     scm.ActionCreate,

--- a/pkg/prow/plugins/skip/skip_test.go
+++ b/pkg/prow/plugins/skip/skip_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
@@ -297,7 +297,7 @@ func TestSkipStatus(t *testing.T) {
 			t.Fatalf("%s: could not set presubmit regexes: %v", test.name, err)
 		}
 
-		fghc := &fakegithub.FakeClient{
+		fghc := &fakegitprovider.FakeClient{
 			IssueComments: make(map[int][]*scm.Comment),
 			PullRequests: map[int]*scm.PullRequest{
 				test.event.Number: {

--- a/pkg/prow/plugins/stage/stage_test.go
+++ b/pkg/prow/plugins/stage/stage_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeClient struct {
@@ -204,7 +204,7 @@ func TestStageLabels(t *testing.T) {
 			added:   []string{},
 			removed: []string{},
 		}
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Body:   tc.body,
 			Action: scm.ActionCreate,
 		}

--- a/pkg/prow/plugins/trigger/generic-comment.go
+++ b/pkg/prow/plugins/trigger/generic-comment.go
@@ -23,14 +23,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericCommentEvent) error {
+func handleGenericComment(c Client, trigger *plugins.Trigger, gc gitprovider.GenericCommentEvent) error {
 	org := gc.Repo.Namespace
 	repo := gc.Repo.Name
 	number := gc.Number
@@ -100,12 +100,12 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc github.GenericC
 		}
 	}
 	isOkToTest := HonorOkToTest(trigger) && pjutil.OkToTestRe.MatchString(gc.Body)
-	if isOkToTest && !github.HasLabel(labels.OkToTest, l) {
+	if isOkToTest && !gitprovider.HasLabel(labels.OkToTest, l) {
 		if err := c.GitHubClient.AddLabel(org, repo, number, labels.OkToTest); err != nil {
 			return err
 		}
 	}
-	if (isOkToTest || github.HasLabel(labels.OkToTest, l)) && github.HasLabel(labels.NeedsOkToTest, l) {
+	if (isOkToTest || gitprovider.HasLabel(labels.OkToTest, l)) && gitprovider.HasLabel(labels.NeedsOkToTest, l) {
 		if err := c.GitHubClient.RemoveLabel(org, repo, number, labels.NeedsOkToTest); err != nil {
 			return err
 		}

--- a/pkg/prow/plugins/trigger/generic-comment_test.go
+++ b/pkg/prow/plugins/trigger/generic-comment_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/plumber/fake"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
@@ -779,7 +779,7 @@ func TestHandleGenericComment(t *testing.T) {
 		if tc.Branch == "" {
 			tc.Branch = "master"
 		}
-		g := &fakegithub.FakeClient{
+		g := &fakegitprovider.FakeClient{
 			CreatedStatuses: map[string][]*scm.StatusInput{},
 			IssueComments:   map[int][]*scm.Comment{},
 			OrgMembers:      map[string][]string{"org": {"trusted-member"}},
@@ -887,7 +887,7 @@ func TestHandleGenericComment(t *testing.T) {
 	}
 }
 
-func validate(name string, fakePlumberClient *fake.Plumber, g *fakegithub.FakeClient, tc testcase, t *testing.T) {
+func validate(name string, fakePlumberClient *fake.Plumber, g *fakegitprovider.FakeClient, tc testcase, t *testing.T) {
 	startedContexts := sets.NewString()
 	for _, job := range fakePlumberClient.Pipelines {
 		startedContexts.Insert(job.Spec.Context)

--- a/pkg/prow/plugins/trigger/generic-comment_test.go
+++ b/pkg/prow/plugins/trigger/generic-comment_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/plumber/fake"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -853,7 +853,7 @@ func TestHandleGenericComment(t *testing.T) {
 			t.Fatalf("%s: failed to set presubmits: %v", tc.name, err)
 		}
 
-		event := github.GenericCommentEvent{
+		event := gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,
 			Repo: scm.Repository{
 				Namespace: "org",

--- a/pkg/prow/plugins/trigger/pull-request.go
+++ b/pkg/prow/plugins/trigger/pull-request.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse/pkg/prow/errorutil"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -63,7 +63,7 @@ func handlePR(c Client, trigger *plugins.Trigger, pr scm.PullRequestHook) error 
 		} else if trusted {
 			// Eventually remove need-ok-to-test
 			// Does not work for TrustedUser() == true since labels are not fetched in this case
-			if github.HasLabel(labels.NeedsOkToTest, l) {
+			if gitprovider.HasLabel(labels.NeedsOkToTest, l) {
 				if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest); err != nil {
 					return err
 				}
@@ -119,7 +119,7 @@ func buildAllIfTrusted(c Client, trigger *plugins.Trigger, pr scm.PullRequestHoo
 	} else if trusted {
 		// Eventually remove needs-ok-to-test
 		// Will not work for org members since labels are not fetched in this case
-		if github.HasLabel(labels.NeedsOkToTest, l) {
+		if gitprovider.HasLabel(labels.NeedsOkToTest, l) {
 			if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest); err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 			return l, false, err
 		}
 	}
-	return l, github.HasLabel(labels.OkToTest, l), nil
+	return l, gitprovider.HasLabel(labels.OkToTest, l), nil
 }
 
 // buildAll ensures that all builds that should run and will be required are built

--- a/pkg/prow/plugins/trigger/pull-request_test.go
+++ b/pkg/prow/plugins/trigger/pull-request_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/plumber/fake"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/sirupsen/logrus"
@@ -80,8 +80,8 @@ func TestTrusted(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := &fakegithub.FakeClient{
-				OrgMembers:    map[string][]string{"kubernetes": {sister}, "kubernetes-incubator": {member, fakegithub.Bot}},
+			g := &fakegitprovider.FakeClient{
+				OrgMembers:    map[string][]string{"kubernetes": {sister}, "kubernetes-incubator": {member, fakegitprovider.Bot}},
 				Collaborators: []string{friend},
 				IssueComments: map[int][]*scm.Comment{},
 			}
@@ -259,7 +259,7 @@ func TestHandlePullRequest(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("running scenario %q", tc.name)
 
-		g := &fakegithub.FakeClient{
+		g := &fakegitprovider.FakeClient{
 			IssueComments: map[int][]*scm.Comment{},
 			OrgMembers:    map[string][]string{"org": {"t"}},
 			PullRequests: map[int]*scm.PullRequest{

--- a/pkg/prow/plugins/trigger/push_test.go
+++ b/pkg/prow/plugins/trigger/push_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 )
 
 func TestCreateRefs(t *testing.T) {
@@ -132,7 +132,7 @@ func TestHandlePE(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		g := &fakegithub.FakeClient{}
+		g := &fakegitprovider.FakeClient{}
 		fakePlumberClient := fake.NewPlumber()
 		c := Client{
 			GitHubClient:  g,

--- a/pkg/prow/plugins/trigger/trigger.go
+++ b/pkg/prow/plugins/trigger/trigger.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/plumber"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse/pkg/prow/errorutil"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pjutil"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
@@ -142,7 +142,7 @@ func handlePullRequest(pc plugins.Agent, pr scm.PullRequestHook) error {
 	return handlePR(getClient(pc), pc.PluginConfig.TriggerFor(org, repo), pr)
 }
 
-func handleGenericCommentEvent(pc plugins.Agent, gc github.GenericCommentEvent) error {
+func handleGenericCommentEvent(pc plugins.Agent, gc gitprovider.GenericCommentEvent) error {
 	return handleGenericComment(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Namespace, gc.Repo.Name), gc)
 }
 

--- a/pkg/prow/plugins/trigger/trigger_test.go
+++ b/pkg/prow/plugins/trigger/trigger_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/plumber"
 	"github.com/jenkins-x/lighthouse/pkg/plumber/fake"
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -301,7 +301,7 @@ func TestRunAndSkipJobs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		fakeGitHubClient := fakegithub.FakeClient{}
+		fakeGitHubClient := fakegitprovider.FakeClient{}
 		fakePlumberClient := fake.NewPlumber()
 		fakePlumberClient.PrependReactor("*", "*", func(plumberJob *plumber.PipelineOptions) (handled bool, ret *plumber.PipelineOptions, err error) {
 			if testCase.jobCreationErrs.Has(plumberJob.Spec.Job) {
@@ -407,7 +407,7 @@ func TestRunRequested(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		fakeGitHubClient := fakegithub.FakeClient{}
+		fakeGitHubClient := fakegitprovider.FakeClient{}
 		fakePlumberClient := fake.NewPlumber()
 
 		fakePlumberClient.PrependReactor("*", "*", func(plumberJob *plumber.PipelineOptions) (handled bool, ret *plumber.PipelineOptions, err error) {

--- a/pkg/prow/plugins/wip/wip-label.go
+++ b/pkg/prow/plugins/wip/wip-label.go
@@ -63,7 +63,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-// Strict subset of github.Client methods.
+// Strict subset of gitprovider.Client methods.
 type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
 	AddLabel(owner, repo string, number int, label string) error

--- a/pkg/prow/plugins/wip/wip-label_test.go
+++ b/pkg/prow/plugins/wip/wip-label_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/labels"
@@ -92,7 +92,7 @@ func TestWipLabel(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 		org, repo, number := "org", "repo", 5
 		e := &event{

--- a/pkg/prow/plugins/yuks/yuks.go
+++ b/pkg/prow/plugins/yuks/yuks.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
@@ -98,11 +98,11 @@ func (url realJoke) readJoke() (string, error) {
 	return a.Joke, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
+func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, &e, jokeURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, j joker) error {
+func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, j joker) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil

--- a/pkg/prow/plugins/yuks/yuks_test.go
+++ b/pkg/prow/plugins/yuks/yuks_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 )
 
 type fakeJoke string
@@ -58,11 +58,11 @@ func TestJokesMedium(t *testing.T) {
 	}))
 	defer ts.Close()
 	fakeScmClient, fc := fake.NewDefault()
-	fakeClient := github.ToTestGitHubClient(fakeScmClient)
+	fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
 	comment := "/joke"
 
-	e := &github.GenericCommentEvent{
+	e := &gitprovider.GenericCommentEvent{
 		Action:     scm.ActionCreate,
 		Body:       comment,
 		Number:     5,
@@ -142,9 +142,9 @@ func TestJokes(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := github.ToTestGitHubClient(fakeScmClient)
+		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		e := &github.GenericCommentEvent{
+		e := &gitprovider.GenericCommentEvent{
 			Action:     tc.action,
 			Body:       tc.body,
 			Number:     5,

--- a/pkg/prow/repoowners/repoowners.go
+++ b/pkg/prow/repoowners/repoowners.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	git2 "github.com/jenkins-x/lighthouse/pkg/prow/git"
-	"github.com/jenkins-x/lighthouse/pkg/prow/github"
+	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
@@ -271,7 +271,7 @@ func (a RepoAliases) ExpandAlias(alias string) sets.String {
 	if a == nil {
 		return nil
 	}
-	return a[github.NormLogin(alias)]
+	return a[gitprovider.NormLogin(alias)]
 }
 
 // ExpandAliases returns members of multiple aliases, duplicates are pruned
@@ -310,7 +310,7 @@ func loadAliasesFrom(baseDir string, log *logrus.Entry) RepoAliases {
 
 	result := make(RepoAliases)
 	for alias, expanded := range config.Data {
-		result[github.NormLogin(alias)] = normLogins(expanded)
+		result[gitprovider.NormLogin(alias)] = normLogins(expanded)
 	}
 	log.Infof("Loaded %d aliases from %q.", len(result), path)
 	return result
@@ -461,7 +461,7 @@ func decodeOwnersMdConfig(path string, config *SimpleConfig) error {
 func normLogins(logins []string) sets.String {
 	normed := sets.NewString()
 	for _, login := range logins {
-		normed.Insert(github.NormLogin(login))
+		normed.Insert(gitprovider.NormLogin(login))
 	}
 	return normed
 }
@@ -504,7 +504,7 @@ func (o *RepoOwners) applyOptionsToPath(path string, opts dirOptions) {
 func (o *RepoOwners) filterCollaborators(toKeep []scm.User) *RepoOwners {
 	collabs := sets.NewString()
 	for _, keeper := range toKeep {
-		collabs.Insert(github.NormLogin(keeper.Login))
+		collabs.Insert(gitprovider.NormLogin(keeper.Login))
 	}
 
 	filter := func(ownerMap map[string]map[*regexp.Regexp]sets.String) map[string]map[*regexp.Regexp]sets.String {

--- a/pkg/prow/repoowners/repoowners_test.go
+++ b/pkg/prow/repoowners/repoowners_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jenkins-x/lighthouse/pkg/prow/fakegithub"
+	"github.com/jenkins-x/lighthouse/pkg/prow/fakegitprovider"
 	"github.com/jenkins-x/lighthouse/pkg/prow/git/localgit"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -146,7 +146,7 @@ func getTestClient(
 
 	return &Client{
 			git:    git,
-			ghc:    &fakegithub.FakeClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}},
+			ghc:    &fakegitprovider.FakeClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}},
 			logger: logrus.WithField("client", "repoowners"),
 			cache:  make(map[string]cacheEntry),
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -488,13 +488,13 @@ func (o *Options) createHookServer() (*hook.Server, error) {
 			logrus.WithError(err).Fatal("Error starting secrets agent.")
 		}
 
-		var githubClient *github.Client
+		var githubClient *gitprovider.Client
 		var kubeClient *kube.Client
 		if o.dryRun {
-			githubClient = github.NewDryRunClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.githubEndpoint.Strings()...)
+			githubClient = gitprovider.NewDryRunClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.githubEndpoint.Strings()...)
 			kubeClient = kube.NewFakeClient(o.deckURL)
 		} else {
-			githubClient = github.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.githubEndpoint.Strings()...)
+			githubClient = gitprovider.NewClient(secretAgent.GetTokenGenerator(o.githubTokenFile), o.githubEndpoint.Strings()...)
 			if o.cluster == "" {
 				kubeClient, err = kube.NewClientInCluster(configAgent.Config().PlumberJobNamespace)
 				if err != nil {


### PR DESCRIPTION
This package is now a generic wrapper over the go-scm which keeps the existing interface used through out the prow plugins.

part of #77 