### PR TITLE
WIP: fix: Switch to metapipeline client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
 	github.com/jenkins-x/go-scm v1.5.23
-	github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251
+	github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707
 	github.com/knative/build v0.5.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251 h1:uu/B6eEP398Gc2K4yr+frwyq0wElZH1/xhzDeWBYEMs=
 github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251/go.mod h1:yysKDX+q8Lt1LH1gyMmcnMx5UKvzZGhrCLFTIZ5IoBo=
+github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707 h1:36Y7flB/v9btX4L9cxldhWn/e5LF/piqgJ62QfaJYPs=
+github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707/go.mod h1:yysKDX+q8Lt1LH1gyMmcnMx5UKvzZGhrCLFTIZ5IoBo=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767/go.mod h1:UR3AoCKJHHKi2AoOWeFbZcMKyd5LqQkdCRgwqZkX/io=
 github.com/jetstack/cert-manager v0.5.2 h1:qs74mdAprZ5kcCYF3arzmEAZtbt+9HneldSJrk21tKs=


### PR DESCRIPTION
This is...well, an attempt. I'm not sure it's right, I'm not sure it'll fix the `jenkins-x-versions` `boot-lh` and `boot-lh-ghe` tests (which are failing at least since the metapipeline client was introduced), but it's something?

I can't for the life of me figure out how Lighthouse is updating the status of a running pipeline on a PR, though, which is the real problem in the `jenkins-x-versions` tests.

/assign @wbrefvem 
/assign @ccojocar 

fixes: #81
