### PR TITLE
fix: Switch to metapipeline client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
 	github.com/jenkins-x/go-scm v1.5.23
-	github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251
+	github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707
 	github.com/knative/build v0.5.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251 h1:uu/B6eEP398Gc2K4yr+frwyq0wElZH1/xhzDeWBYEMs=
 github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251/go.mod h1:yysKDX+q8Lt1LH1gyMmcnMx5UKvzZGhrCLFTIZ5IoBo=
+github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707 h1:36Y7flB/v9btX4L9cxldhWn/e5LF/piqgJ62QfaJYPs=
+github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707/go.mod h1:yysKDX+q8Lt1LH1gyMmcnMx5UKvzZGhrCLFTIZ5IoBo=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767 h1:lKtC9uHyWi8wd+EUch3Pfzk3/8XSJvYRJhvk9dK4YKY=
 github.com/jenkins-x/sonobuoy v0.11.7-0.20190318120422-253758214767/go.mod h1:UR3AoCKJHHKi2AoOWeFbZcMKyd5LqQkdCRgwqZkX/io=
 github.com/jetstack/cert-manager v0.5.2 h1:qs74mdAprZ5kcCYF3arzmEAZtbt+9HneldSJrk21tKs=

--- a/pkg/plumber/fake/fake.go
+++ b/pkg/plumber/fake/fake.go
@@ -1,6 +1,7 @@
 package fake
 
 import (
+	"github.com/jenkins-x/jx/pkg/tekton/metapipeline"
 	"github.com/jenkins-x/lighthouse/pkg/plumber"
 )
 
@@ -17,7 +18,7 @@ func NewPlumber() *Plumber {
 }
 
 // Create creates a plumber job
-func (p *Plumber) Create(po *plumber.PipelineOptions) (*plumber.PipelineOptions, error) {
+func (p *Plumber) Create(po *plumber.PipelineOptions, metapipelineClient metapipeline.Client) (*plumber.PipelineOptions, error) {
 	p.Pipelines = append(p.Pipelines, po)
 	return po, nil
 }

--- a/pkg/plumber/interface.go
+++ b/pkg/plumber/interface.go
@@ -1,6 +1,8 @@
 package plumber
 
+import 	"github.com/jenkins-x/jx/pkg/tekton/metapipeline"
+
 // Plumber the interface is the service which creates Pipelines
 type Plumber interface {
-	Create(*PipelineOptions) (*PipelineOptions, error)
+	Create(*PipelineOptions, metapipeline.Client) (*PipelineOptions, error)
 }

--- a/pkg/plumber/plumber.go
+++ b/pkg/plumber/plumber.go
@@ -28,7 +28,7 @@ func NewPlumber(repository scm.Repository, commonOptions *opts.CommonOptions) (P
 }
 
 // Create creates a pipeline
-func (b *PipelineBuilder) Create(request *PipelineOptions) (*PipelineOptions, error) {
+func (b *PipelineBuilder) Create(request *PipelineOptions, metapipelineClient metapipeline.Client) (*PipelineOptions, error) {
 	spec := &request.Spec
 
 	repository := b.repository
@@ -88,17 +88,12 @@ func (b *PipelineBuilder) Create(request *PipelineOptions) (*PipelineOptions, er
 		DefaultImage: "",
 	}
 
-	metaPipelineClient, err := metapipeline.NewMetaPipelineClient()
-	if err != nil {
-		return request, errors.Wrap(err, "couldn't create metapipeline client")
-	}
-
-	pipelineActivity, tektonCRDs, err := metaPipelineClient.Create(pipelineCreateParam)
+	pipelineActivity, tektonCRDs, err := metapipelineClient.Create(pipelineCreateParam)
 	if err != nil {
 		return request, errors.Wrap(err, "unable to create Tekton CRDs")
 	}
 
-	err = metaPipelineClient.Apply(pipelineActivity, tektonCRDs)
+	err = metapipelineClient.Apply(pipelineActivity, tektonCRDs)
 	if err != nil {
 		return request, errors.Wrap(err, "unable to apply Tekton CRDs")
 	}

--- a/pkg/prow/plugins/override/override_test.go
+++ b/pkg/prow/plugins/override/override_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/jenkins-x/lighthouse/pkg/prow/config"
 	"github.com/jenkins-x/lighthouse/pkg/prow/gitprovider"
+	"github.com/jenkins-x/jx/pkg/tekton/metapipeline"
+
 )
 
 const (
@@ -134,7 +136,7 @@ func (c *fakeClient) GetRef(org, repo, ref string) (string, error) {
 	return fakeBaseSHA, nil
 }
 
-func (c *fakeClient) Create(pj *plumber.PipelineOptions) (*plumber.PipelineOptions, error) {
+func (c *fakeClient) Create(pj *plumber.PipelineOptions, metapipelineClient metapipeline.Client) (*plumber.PipelineOptions, error) {
 	if pj.Spec.Context == "fail-create" {
 		return pj, errors.New("injected CreatePlumberJob error")
 	}

--- a/pkg/prow/plugins/trigger/push.go
+++ b/pkg/prow/plugins/trigger/push.go
@@ -77,7 +77,7 @@ func handlePE(c Client, pe scm.PushHook) error {
 		labels[gitprovider.EventGUID] = pe.GUID
 		pj := pjutil.NewPlumberJob(pjutil.PostsubmitSpec(j, refs), labels, j.Annotations)
 		c.Logger.WithFields(pjutil.PlumberJobFields(&pj)).Info("Creating a new plumberJob.")
-		if _, err := c.PlumberClient.Create(&pj); err != nil {
+		if _, err := c.PlumberClient.Create(&pj, c.MetapipelineClient); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This includes support for using the plugin agent to access a cached metapipeline client, although this approach is not implemented in all cases.