### PR TITLE
fix: Get chartmuseum password, not just user

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -166,7 +166,7 @@ pipelineConfig:
                   - -f
                   - /builder/home/git-token
 
-              - name: chartmuseum-credentials 
+              - name: chartmuseum-credentials-user
                 image: jenkinsxio/jx:1.3.963
                 command: jx
                 args:
@@ -178,6 +178,19 @@ pipelineConfig:
                   - BASIC_AUTH_USER
                   - -f
                   - /builder/home/basic-auth-user
+
+              - name: chartmuseum-credentials-password
+                image: gcr.io/jenkinsxio/builder-jx:0.1.639
+                command: jx
+                args:
+                  - step
+                  - credential
+                  - -s
+                  - jenkins-x-chartmuseum
+                  - -k
+                  - BASIC_AUTH_PASS
+                  - -f
+                  - /builder/home/basic-auth-pass
 
               - name: build-and-push-image
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6


### PR DESCRIPTION
Without this, chart deploys on release are failing.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>