### PR TITLE
chore(deps): bump https://github.com/jenkins-x/go-scm to v1.5.26

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) |  | [v1.5.26]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x
+  repo: go-scm
+  url: https://github.com/jenkins-x/go-scm
+  version: v1.5.26
+  versionURL: ""


### PR DESCRIPTION
Update [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) to v1.5.26

Command run was `jx step create pr go --name github.com/jenkins-x/go-scm --version v1.5.26 --build make build --repo https://github.com/jenkins-x/lighthouse.git`