### PR TITLE
chore(deps): bump https://github.com/jenkins-x/go-scm from v1.5.25 to 1.5.26

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) |  | [1.5.26]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x
+  repo: go-scm
+  url: https://github.com/jenkins-x/go-scm
+  version: 1.5.26
+  versionURL: ""

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.25
+	github.com/jenkins-x/go-scm v1.5.26
 	github.com/jenkins-x/jx v0.0.0-20190824122948-bb59278c2707
 	github.com/knative/build v0.5.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/jenkins-x/go-scm v1.5.23 h1:U+KbplKBhtWjW7IbQD1IfRG07yhvx2jVsrZxxHu3r
 github.com/jenkins-x/go-scm v1.5.23/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/go-scm v1.5.25 h1:54pdfyKMwRuvERKdksIzZ5l7X7oJyjqXwd+j/8e0cEM=
 github.com/jenkins-x/go-scm v1.5.25/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
+github.com/jenkins-x/go-scm v1.5.26 h1:FK3USnBjV2XbVq7ND6XD3djnckNaH3ZOyk24dvud0CE=
+github.com/jenkins-x/go-scm v1.5.26/go.mod h1:IGz2tEc64kTBSAh/dYppH1Hw74onK2aeRTsxC2x3A6Q=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
 github.com/jenkins-x/jx v0.0.0-20190807091323-2bcf1b1e4251 h1:uu/B6eEP398Gc2K4yr+frwyq0wElZH1/xhzDeWBYEMs=


### PR DESCRIPTION
Update [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) from v1.5.25 to 1.5.26

Command run was `jx step create pr go --name github.com/jenkins-x/go-scm --version 1.5.26 --build make build --repo https://github.com/jenkins-x/lighthouse.git`
<hr />

Update [jenkins-x/go-scm](https://github.com/jenkins-x/go-scm) from v1.5.25 to 1.5.26

Command run was `/workspace/go/src/github.com/jenkins-x/jx/build/jx step create pr go --name github.com/jenkins-x/go-scm --version v1.5.26 --build echo make build --repo https://github.com/jenkins-x/lighthouse.git`