### PR TITLE
chore: Remove @dwnusbaum from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - daveconde
 - hferentschik
 - abayer
-- dwnusbaum
 - warrenbailey
 - cagiti
 - dgozalo
@@ -26,7 +25,6 @@ reviewers:
 - daveconde
 - hferentschik
 - abayer
-- dwnusbaum
 - warrenbailey
 - cagiti
 - dgozalo


### PR DESCRIPTION
I am not currently working on JX/lighthouse, but sometimes I get randomly
assigned to review PRs and such. Seems best to remove myself from
OWNERS so that current maintainers are the ones getting assigned as
reviewers instead.

CC @abayer for review