### PR TITLE
fix: lets default to the current bot user being trusted

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c h1:jqLMOnuwp+ac6nI
 github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c/go.mod h1:SELxwZQq/mPnfPCR2mchLmT4TQaPJvYtLcCtDWSM7vM=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135 h1:3zy/Nvdi9V95Jfu6+W4NAJrHDeypB58FSLyzI3XfO/4=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135/go.mod h1:K/L25ViEpDx196rOZyjn433tAM5zr2F/IouK+3g+DkE=
+github.com/jenkins-x/go-scm v1.5.61 h1:1eUp05wFvefdlQpecMQnXH5m0Gix0o5fxG4FVnbnNqw=
+github.com/jenkins-x/go-scm v1.5.61/go.mod h1:MgGRkJScE/rJ30J/bXYqduN5sDPZqZFITJopsnZmTOw=
 github.com/jenkins-x/go-scm v1.5.64 h1:yCcGw/ehRRpnllk4XaqI65EcZO3hF0ptbZYbFwEpK1E=
 github.com/jenkins-x/go-scm v1.5.64/go.mod h1:MgGRkJScE/rJ30J/bXYqduN5sDPZqZFITJopsnZmTOw=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=

--- a/pkg/prow/plugins/trigger/trigger.go
+++ b/pkg/prow/plugins/trigger/trigger.go
@@ -128,6 +128,7 @@ type Client struct {
 type trustedUserClient interface {
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
+	BotName() (string, error)
 }
 
 func getClient(pc plugins.Agent) Client {
@@ -158,6 +159,10 @@ func handlePush(pc plugins.Agent, pe scm.PushHook) error {
 // Trusted users are either repo collaborators, org members or trusted org members.
 // Whether repo collaborators and/or a second org is trusted is configured by trigger.
 func TrustedUser(ghc trustedUserClient, trigger *plugins.Trigger, user, org, repo string) (bool, error) {
+	botUser, err := ghc.BotName()
+	if err == nil && user == botUser {
+		return true, nil
+	}
 	// First check if user is a collaborator, assuming this is allowed
 	if !trigger.OnlyOrgMembers {
 		if ok, err := ghc.IsCollaborator(org, repo, user); err != nil {


### PR DESCRIPTION
in case the bot user can't query the members of an org etc