### PR TITLE
fix: Always use latest builder-* images in BDD pipelines

### DIFF
--- a/jenkins-x-bbs.yml
+++ b/jenkins-x-bbs.yml
@@ -38,7 +38,7 @@ pipelineConfig:
                 name: test-jenkins-user
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1007-338
+          image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:
           - name: ci
             options:

--- a/jenkins-x-ghe.yml
+++ b/jenkins-x-ghe.yml
@@ -38,7 +38,7 @@ pipelineConfig:
                 name: test-jenkins-user 
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1007-338
+          image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:
           - name: ci
             options:

--- a/jenkins-x-github.yml
+++ b/jenkins-x-github.yml
@@ -38,7 +38,7 @@ pipelineConfig:
                 name: test-jenkins-user 
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1007-338
+          image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:
           - name: ci
             options:

--- a/jenkins-x-gitlab.yml
+++ b/jenkins-x-gitlab.yml
@@ -38,7 +38,7 @@ pipelineConfig:
                 name: test-jenkins-user 
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1007-338
+          image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:
           - name: ci
             options:


### PR DESCRIPTION
Otherwise these will go stale and eventually not work with any changes
we may need to make re: `jx-requirements.yml`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>