### PR TITLE
fix: remove the expose-controller annotations on hook and tide services

### DIFF
--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -26,9 +26,6 @@ service:
   type: ClusterIP
   externalPort: 80
   internalPort: 8080
-  annotations:
-    fabric8.io/expose: "true"
-    fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
 resources:
   limits:
     cpu: 100m
@@ -83,8 +80,5 @@ tide:
     type: ClusterIP
     externalPort: 80
     internalPort: 8888
-    annotations:
-      fabric8.io/expose: "true"
-      fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx\nnginx.ingress.kubernetes.io/auth-type: basic\nnginx.ingress.kubernetes.io/auth-secret: jx-basic-auth"
   datadog:
     enabled: "true"


### PR DESCRIPTION
The ingress resources are statically created by jxboot-resources chart.
See https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/700-hook-ing.yaml
and https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/700-tide-ing.yaml

This is to prevent that the ingress resources gets accidentally recreated wthen exposecontroller
is executed in the namespace where the Lighthouse is deployed.