### PR TITLE
chore: Bump go-scm dependency to 1.5.70

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 approvers:
 - rawlingsj
 - jstrachan
-- rajdavies
 - ccojocar
 - garethjevans
 - pmuir
@@ -12,13 +11,11 @@ approvers:
 - warrenbailey
 - cagiti
 - dgozalo
-- joseblas
 - macox
 - mrageh
 reviewers:
 - rawlingsj
 - jstrachan
-- rajdavies
 - ccojocar
 - garethjevans
 - pmuir
@@ -29,6 +26,5 @@ reviewers:
 - warrenbailey
 - cagiti
 - dgozalo
-- joseblas
 - macox
 - mrageh

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.61
+	github.com/jenkins-x/go-scm v1.5.70
 	github.com/jenkins-x/jx v0.0.0-20200117201507-71b85633cd04
 	github.com/knative/build v0.7.0
 	github.com/pkg/errors v0.8.1
@@ -59,5 +59,3 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.15.5+in
 
 replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults v0.0.0-20190508130850-5673d28c46bd
 
-// TODO: Remove once https://github.com/jenkins-x/go-scm/pull/65 is merged and we can update the real dependency
-replace github.com/jenkins-x/go-scm => github.com/abayer/go-scm v1.5.1-0.20200117190616-8db331f9cc60

--- a/go.mod
+++ b/go.mod
@@ -58,3 +58,6 @@ replace github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.15.5+incompatible
 
 replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults v0.0.0-20190508130850-5673d28c46bd
+
+// TODO: Remove once https://github.com/jenkins-x/go-scm/pull/65 is merged and we can update the real dependency
+replace github.com/jenkins-x/go-scm => github.com/abayer/go-scm v1.5.1-0.20200117190616-8db331f9cc60

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/abayer/go-scm v1.5.1-0.20200117190616-8db331f9cc60 h1:Vkn4GQciObd4a83A07Hr7Ababq5VRMVph5IiQ4pxRa0=
+github.com/abayer/go-scm v1.5.1-0.20200117190616-8db331f9cc60/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=

--- a/pkg/prow/commentpruner/commentpruner_test.go
+++ b/pkg/prow/commentpruner/commentpruner_test.go
@@ -40,7 +40,12 @@ func (f *fakeGHClient) ListIssueComments(_, _ string, _ int) ([]*scm.Comment, er
 	return f.comments, nil
 }
 
-func (f *fakeGHClient) DeleteComment(_, _ string, number, ID int) error {
+func (f *fakeGHClient) ListPullRequestComments(_, _ string, _ int) ([]*scm.Comment, error) {
+	f.listCallCount++
+	return f.comments, nil
+}
+
+func (f *fakeGHClient) DeleteComment(_, _ string, number, ID int, _ bool) error {
 	f.deletedComments = append(f.deletedComments, ID)
 	return nil
 }
@@ -129,7 +134,7 @@ func TestPruneComments(t *testing.T) {
 		fgc := newFakeGHClient(tc.comments)
 		client := NewEventClient(fgc, logrus.WithField("client", "commentpruner"), "org", "repo", 1)
 		for _, call := range tc.callers {
-			client.PruneComments(call)
+			client.PruneComments(true, call)
 		}
 
 		if fgc.listCallCount != 1 {

--- a/pkg/prow/plugins/approve/approve_test.go
+++ b/pkg/prow/plugins/approve/approve_test.go
@@ -130,9 +130,9 @@ func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments 
 
 	fakeClient := gitprovider.ToClient(fakeScmClient, testBotName)
 
-	fc.IssueLabelsAdded = labels
+	fc.PullRequestLabelsAdded = labels
 	fc.PullRequestChanges[prNumber] = changes
-	fc.IssueComments[prNumber] = comments
+	fc.PullRequestComments[prNumber] = comments
 	fc.IssueEvents[prNumber] = events
 	fc.Reviews[prNumber] = reviews
 	return fakeClient, fc
@@ -1077,30 +1077,30 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 		}
 
 		if test.expectDelete {
-			if len(fghc.IssueCommentsDeleted) != 1 {
+			if len(fghc.PullRequestCommentsDeleted) != 1 {
 				t.Errorf(
 					"[%s] Expected 1 notification to be deleted but %d notifications were deleted.",
 					test.name,
-					len(fghc.IssueCommentsDeleted),
+					len(fghc.PullRequestCommentsDeleted),
 				)
 			}
 		} else {
-			if len(fghc.IssueCommentsDeleted) != 0 {
+			if len(fghc.PullRequestCommentsDeleted) != 0 {
 				t.Errorf(
 					"[%s] Expected 0 notifications to be deleted but %d notification was deleted.",
 					test.name,
-					len(fghc.IssueCommentsDeleted),
+					len(fghc.PullRequestCommentsDeleted),
 				)
 			}
 		}
 		if test.expectComment {
-			if len(fghc.IssueCommentsAdded) != 1 {
+			if len(fghc.PullRequestCommentsAdded) != 1 {
 				t.Errorf(
 					"[%s] Expected 1 notification to be added but %d notifications were added.",
 					test.name,
-					len(fghc.IssueCommentsAdded),
+					len(fghc.PullRequestCommentsAdded),
 				)
-			} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fghc.IssueCommentsAdded[0]; test.expectedComment != "" && got != expect {
+			} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fghc.PullRequestCommentsAdded[0]; test.expectedComment != "" && got != expect {
 				t.Errorf(
 					"[%s] Expected the created notification to be:\n%s\n\nbut got:\n%s\n\n",
 					test.name,
@@ -1109,17 +1109,17 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 				)
 			}
 		} else {
-			if len(fghc.IssueCommentsAdded) != 0 {
+			if len(fghc.PullRequestCommentsAdded) != 0 {
 				t.Errorf(
 					"[%s] Expected 0 notifications to be added but %d notification was added.",
 					test.name,
-					len(fghc.IssueCommentsAdded),
+					len(fghc.PullRequestCommentsAdded),
 				)
 			}
 		}
 
 		labelAdded := false
-		for _, l := range fghc.IssueLabelsAdded {
+		for _, l := range fghc.PullRequestLabelsAdded {
 			if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
 				if labelAdded {
 					t.Errorf("[%s] The approved label was applied to a PR that already had it!", test.name)
@@ -1131,7 +1131,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			labelAdded = false
 		}
 		toggled := labelAdded
-		for _, l := range fghc.IssueLabelsRemoved {
+		for _, l := range fghc.PullRequestLabelsRemoved {
 			if l == fmt.Sprintf("org/repo#%v:approved", prNumber) {
 				if !test.hasLabel {
 					t.Errorf("[%s] The approved label was removed from a PR that doesn't have it!", test.name)

--- a/pkg/prow/plugins/cat/cat_test.go
+++ b/pkg/prow/plugins/cat/cat_test.go
@@ -474,18 +474,24 @@ func TestCats(t *testing.T) {
 			t.Errorf("%s: expected an error to occur", tc.name)
 			continue
 		}
-		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+		var comments map[int][]*scm.Comment
+		if tc.pr {
+			comments = fc.PullRequestComments
+		} else {
+			comments = fc.IssueComments
+		}
+		if tc.shouldComment && len(comments[5]) != 1 {
 			t.Errorf("%s: should have commented.", tc.name)
 		} else if tc.shouldComment {
 			shouldImage := !tc.shouldError
-			body := fc.IssueComments[5][0].Body
+			body := comments[5][0].Body
 			hasImage := strings.Contains(body, "![")
 			if hasImage && !shouldImage {
 				t.Errorf("%s: unexpected image in %s", tc.name, body)
 			} else if !hasImage && shouldImage {
 				t.Errorf("%s: no image in %s", tc.name, body)
 			}
-		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+		} else if !tc.shouldComment && len(comments[5]) != 0 {
 			t.Errorf("%s: should not have commented.", tc.name)
 		}
 	}

--- a/pkg/prow/plugins/cherrypickunapproved/cherrypick-unapproved_test.go
+++ b/pkg/prow/plugins/cherrypickunapproved/cherrypick-unapproved_test.go
@@ -39,14 +39,14 @@ type fakeClient struct {
 }
 
 // AddLabel adds a label to the specified PR or issue
-func (fc *fakeClient) AddLabel(owner, repo string, number int, label string) error {
+func (fc *fakeClient) AddLabel(owner, repo string, number int, label string, pr bool) error {
 	fc.added = append(fc.added, label)
 	fc.labels = append(fc.labels, label)
 	return nil
 }
 
 // RemoveLabel removes the label from the specified PR or issue
-func (fc *fakeClient) RemoveLabel(owner, repo string, number int, label string) error {
+func (fc *fakeClient) RemoveLabel(owner, repo string, number int, label string, pr bool) error {
 	fc.removed = append(fc.removed, label)
 
 	// remove from existing labels
@@ -61,7 +61,7 @@ func (fc *fakeClient) RemoveLabel(owner, repo string, number int, label string) 
 }
 
 // GetIssueLabels gets the current labels on the specified PR or issue
-func (fc *fakeClient) GetIssueLabels(owner, repo string, number int) ([]*scm.Label, error) {
+func (fc *fakeClient) GetIssueLabels(owner, repo string, number int, pr bool) ([]*scm.Label, error) {
 	la := []*scm.Label{}
 	for _, l := range fc.labels {
 		la = append(la, &scm.Label{Name: l})
@@ -86,7 +86,7 @@ func (fc *fakeClient) NumComments() int {
 
 type fakePruner struct{}
 
-func (fp *fakePruner) PruneComments(shouldPrune func(*scm.Comment) bool) {}
+func (fp *fakePruner) PruneComments(pr bool, shouldPrune func(*scm.Comment) bool) {}
 
 func makeFakePullRequestEvent(action scm.Action, branch string) scm.PullRequestHook {
 	return scm.PullRequestHook{

--- a/pkg/prow/plugins/dog/dog_test.go
+++ b/pkg/prow/plugins/dog/dog_test.go
@@ -336,9 +336,15 @@ func TestDogs(t *testing.T) {
 		if err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
 		}
-		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+		var comments map[int][]*scm.Comment
+		if tc.pr {
+			comments = fc.PullRequestComments
+		} else {
+			comments = fc.IssueComments
+		}
+		if tc.shouldComment && len(comments[5]) != 1 {
 			t.Errorf("For case %s, should have commented.", tc.name)
-		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+		} else if !tc.shouldComment && len(comments[5]) != 0 {
 			t.Errorf("For case %s, should not have commented.", tc.name)
 		}
 	}

--- a/pkg/prow/plugins/help/help_test.go
+++ b/pkg/prow/plugins/help/help_test.go
@@ -31,7 +31,7 @@ import (
 
 type fakePruner struct{}
 
-func (fp *fakePruner) PruneComments(shouldPrune func(*scm.Comment) bool) {}
+func (fp *fakePruner) PruneComments(pr bool, shouldPrune func(*scm.Comment) bool) {}
 
 func formatLabels(labels ...string) []string {
 	r := []string{}
@@ -181,7 +181,7 @@ func TestLabel(t *testing.T) {
 
 		// Add initial labels
 		for _, label := range tc.issueLabels {
-			fakeGHClient.AddLabel("org", "repo", 1, label)
+			fakeGHClient.AddLabel("org", "repo", 1, label, false)
 		}
 
 		if len(tc.issueState) == 0 {

--- a/pkg/prow/plugins/label/label.go
+++ b/pkg/prow/plugins/label/label.go
@@ -78,10 +78,10 @@ func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) e
 
 type githubClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
+	AddLabel(owner, repo string, number int, label string, pr bool) error
+	RemoveLabel(owner, repo string, number int, label string, pr bool) error
 	GetRepoLabels(owner, repo string) ([]*scm.Label, error)
-	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
+	GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.Label, error)
 }
 
 // Get Labels from Regexp matches
@@ -132,7 +132,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 	if err != nil {
 		return err
 	}
-	labels, err := gc.GetIssueLabels(org, repo, e.Number)
+	labels, err := gc.GetIssueLabels(org, repo, e.Number, e.IsPR)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 			continue
 		}
 
-		if err := gc.AddLabel(org, repo, e.Number, RepoLabelsExisting[labelToAdd]); err != nil {
+		if err := gc.AddLabel(org, repo, e.Number, RepoLabelsExisting[labelToAdd], e.IsPR); err != nil {
 			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labelToAdd)
 		}
 	}
@@ -180,7 +180,7 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 			continue
 		}
 
-		if err := gc.RemoveLabel(org, repo, e.Number, labelToRemove); err != nil {
+		if err := gc.RemoveLabel(org, repo, e.Number, labelToRemove, e.IsPR); err != nil {
 			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", labelToRemove)
 		}
 	}

--- a/pkg/prow/plugins/label/label_test.go
+++ b/pkg/prow/plugins/label/label_test.go
@@ -441,7 +441,7 @@ func TestLabel(t *testing.T) {
 
 		// Add initial labels
 		for _, label := range tc.issueLabels {
-			fakeClient.AddLabel("org", "repo", 1, label)
+			fakeClient.AddLabel("org", "repo", 1, label, false)
 		}
 		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,

--- a/pkg/prow/plugins/lifecycle/close.go
+++ b/pkg/prow/plugins/lifecycle/close.go
@@ -34,11 +34,11 @@ type closeClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 	CloseIssue(owner, repo string, number int) error
 	ClosePR(owner, repo string, number int) error
-	GetIssueLabels(owner, repo string, number int) ([]*scm.Label, error)
+	GetIssueLabels(owner, repo string, number int, pr bool) ([]*scm.Label, error)
 }
 
-func isActive(gc closeClient, org, repo string, number int) (bool, error) {
-	labels, err := gc.GetIssueLabels(org, repo, number)
+func isActive(gc closeClient, org, repo string, number int, pr bool) (bool, error) {
+	labels, err := gc.GetIssueLabels(org, repo, number, pr)
 	if err != nil {
 		return true, fmt.Errorf("list issue labels error: %v", err)
 	}
@@ -72,7 +72,7 @@ func handleClose(gc closeClient, log *logrus.Entry, e *gitprovider.GenericCommen
 		log.WithError(err).Errorf("Failed IsCollaborator(%s, %s, %s)", org, repo, commentAuthor)
 	}
 
-	active, err := isActive(gc, org, repo, number)
+	active, err := isActive(gc, org, repo, number, e.IsPR)
 	if err != nil {
 		log.Infof("Cannot determine if issue is active: %v", err)
 		active = true // Fail active

--- a/pkg/prow/plugins/lifecycle/close_test.go
+++ b/pkg/prow/plugins/lifecycle/close_test.go
@@ -55,7 +55,7 @@ func (c *fakeClientClose) IsCollaborator(owner, repo, login string) (bool, error
 	return false, nil
 }
 
-func (c *fakeClientClose) GetIssueLabels(owner, repo string, number int) ([]*scm.Label, error) {
+func (c *fakeClientClose) GetIssueLabels(owner, repo string, number int, pr bool) ([]*scm.Label, error) {
 	var labels []*scm.Label
 	for _, l := range c.labels {
 		if l == "error" {

--- a/pkg/prow/plugins/lifecycle/lifecycle_test.go
+++ b/pkg/prow/plugins/lifecycle/lifecycle_test.go
@@ -36,13 +36,13 @@ type fakeClient struct {
 	removed []string
 }
 
-func (c *fakeClient) AddLabel(owner, repo string, number int, label string) error {
+func (c *fakeClient) AddLabel(owner, repo string, number int, label string, pr bool) error {
 	c.added = append(c.added, label)
 	c.labels = append(c.labels, label)
 	return nil
 }
 
-func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string) error {
+func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string, pr bool) error {
 	c.removed = append(c.removed, label)
 
 	// remove from existing labels
@@ -56,7 +56,7 @@ func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string) e
 	return nil
 }
 
-func (c *fakeClient) GetIssueLabels(owner, repo string, number int) ([]*scm.Label, error) {
+func (c *fakeClient) GetIssueLabels(owner, repo string, number int, pr bool) ([]*scm.Label, error) {
 	la := []*scm.Label{}
 	for _, l := range c.labels {
 		la = append(la, &scm.Label{Name: l})

--- a/pkg/prow/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/prow/plugins/milestonestatus/milestonestatus.go
@@ -46,7 +46,7 @@ var (
 
 type githubClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
-	AddLabel(owner, repo string, number int, label string) error
+	AddLabel(owner, repo string, number int, label string, pr bool) error
 	ListTeamMembers(id int, role string) ([]*scm.TeamMember, error)
 }
 
@@ -129,7 +129,7 @@ func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEve
 		if !validStatus {
 			continue
 		}
-		if err := gc.AddLabel(org, repo, e.Number, sLabel); err != nil {
+		if err := gc.AddLabel(org, repo, e.Number, sLabel, e.IsPR); err != nil {
 			log.WithError(err).Errorf("Error adding the label %q to %s/%s#%d.", sLabel, org, repo, e.Number)
 		}
 	}

--- a/pkg/prow/plugins/owners-label/owners-label.go
+++ b/pkg/prow/plugins/owners-label/owners-label.go
@@ -48,8 +48,8 @@ type ownersClient interface {
 }
 
 type githubClient interface {
-	AddLabel(org, repo string, number int, label string) error
-	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
+	AddLabel(org, repo string, number int, label string, pr bool) error
+	GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.Label, error)
 	GetRepoLabels(owner, repo string) ([]*scm.Label, error)
 	GetPullRequestChanges(org, repo string, number int) ([]*scm.Change, error)
 }
@@ -90,7 +90,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *scm.PullR
 	if err != nil {
 		return err
 	}
-	issuelabels, err := ghc.GetIssueLabels(org, repo, number)
+	issuelabels, err := ghc.GetIssueLabels(org, repo, number, true)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *scm.PullR
 			nonexistent.Insert(labelToAdd)
 			continue
 		}
-		if err := ghc.AddLabel(org, repo, number, labelToAdd); err != nil {
+		if err := ghc.AddLabel(org, repo, number, labelToAdd, true); err != nil {
 			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labelToAdd)
 		}
 	}

--- a/pkg/prow/plugins/pony/pony_test.go
+++ b/pkg/prow/plugins/pony/pony_test.go
@@ -312,9 +312,15 @@ func TestPonies(t *testing.T) {
 		if err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
 		}
-		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+		var comments map[int][]*scm.Comment
+		if tc.pr {
+			comments = fc.PullRequestComments
+		} else {
+			comments = fc.IssueComments
+		}
+		if tc.shouldComment && len(comments[5]) != 1 {
 			t.Errorf("For case %s, should have commented.", tc.name)
-		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+		} else if !tc.shouldComment && len(comments[5]) != 0 {
 			t.Errorf("For case %s, should not have commented.", tc.name)
 		}
 	}

--- a/pkg/prow/plugins/sigmention/sigmention_test.go
+++ b/pkg/prow/plugins/sigmention/sigmention_test.go
@@ -159,7 +159,7 @@ func TestSigMention(t *testing.T) {
 		}
 		// Add initial labels to issue.
 		for _, label := range tc.issueLabels {
-			fakeClient.AddLabel("org", "repo", 1, label)
+			fakeClient.AddLabel("org", "repo", 1, label, false)
 		}
 		e := &gitprovider.GenericCommentEvent{
 			Action: scm.ActionCreate,

--- a/pkg/prow/plugins/size/size.go
+++ b/pkg/prow/plugins/size/size.go
@@ -72,9 +72,9 @@ func handlePullRequest(pc plugins.Agent, pe scm.PullRequestHook) error {
 
 // Strict subset of gitprovider.Client methods.
 type githubClient interface {
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
+	AddLabel(owner, repo string, number int, label string, pr bool) error
+	RemoveLabel(owner, repo string, number int, label string, pr bool) error
+	GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.Label, error)
 	GetFile(org, repo, filepath, commit string) ([]byte, error)
 	GetPullRequestChanges(org, repo string, number int) ([]*scm.Change, error)
 }
@@ -122,7 +122,7 @@ func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe scm.Pull
 		count += change.Additions + change.Deletions
 	}
 
-	labels, err := gc.GetIssueLabels(owner, repo, num)
+	labels, err := gc.GetIssueLabels(owner, repo, num, true)
 	if err != nil {
 		le.Warnf("while retrieving labels, error: %v", err)
 	}
@@ -137,7 +137,7 @@ func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe scm.Pull
 		}
 
 		if strings.HasPrefix(label.Name, labelPrefix) {
-			if err := gc.RemoveLabel(owner, repo, num, label.Name); err != nil {
+			if err := gc.RemoveLabel(owner, repo, num, label.Name, true); err != nil {
 				le.Warnf("error while removing label %q: %v", label.Name, err)
 			}
 		}
@@ -147,7 +147,7 @@ func handlePR(gc githubClient, sizes plugins.Size, le *logrus.Entry, pe scm.Pull
 		return nil
 	}
 
-	if err := gc.AddLabel(owner, repo, num, newLabel); err != nil {
+	if err := gc.AddLabel(owner, repo, num, newLabel, true); err != nil {
 		return fmt.Errorf("error adding label to %s/%s PR #%d: %v", owner, repo, num, err)
 	}
 

--- a/pkg/prow/plugins/size/size_test.go
+++ b/pkg/prow/plugins/size/size_test.go
@@ -35,14 +35,14 @@ type ghc struct {
 	getFileErr, getPullRequestChangesErr error
 }
 
-func (c *ghc) AddLabel(_, _ string, _ int, label string) error {
+func (c *ghc) AddLabel(_, _ string, _ int, label string, _ bool) error {
 	c.T.Logf("AddLabel: %s", label)
 	c.labels[scm.Label{Name: label}] = true
 
 	return c.addLabelErr
 }
 
-func (c *ghc) RemoveLabel(_, _ string, _ int, label string) error {
+func (c *ghc) RemoveLabel(_, _ string, _ int, label string, _ bool) error {
 	c.T.Logf("RemoveLabel: %s", label)
 	for k := range c.labels {
 		if k.Name == label {
@@ -53,7 +53,7 @@ func (c *ghc) RemoveLabel(_, _ string, _ int, label string) error {
 	return c.removeLabelErr
 }
 
-func (c *ghc) GetIssueLabels(_, _ string, _ int) (ls []*scm.Label, err error) {
+func (c *ghc) GetIssueLabels(_, _ string, _ int, _ bool) (ls []*scm.Label, err error) {
 	c.T.Log("GetIssueLabels")
 	for k, ok := range c.labels {
 		if ok {

--- a/pkg/prow/plugins/stage/stage.go
+++ b/pkg/prow/plugins/stage/stage.go
@@ -57,9 +57,9 @@ func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.Plu
 }
 
 type stageClient interface {
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
+	AddLabel(owner, repo string, number int, label string, pr bool) error
+	RemoveLabel(owner, repo string, number int, label string, pr bool) error
+	GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.Label, error)
 }
 
 func stageHandleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
@@ -91,14 +91,14 @@ func handleOne(gc stageClient, log *logrus.Entry, e *gitprovider.GenericCommentE
 
 	// Let's start simple and allow anyone to add/remove alpha, beta and stable labels.
 	// Adjust if we find evidence of the community abusing these labels.
-	labels, err := gc.GetIssueLabels(org, repo, number)
+	labels, err := gc.GetIssueLabels(org, repo, number, e.IsPR)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get labels.")
 	}
 
 	// If the label exists and we asked for it to be removed, remove it.
 	if gitprovider.HasLabel(lbl, labels) && remove {
-		return gc.RemoveLabel(org, repo, number, lbl)
+		return gc.RemoveLabel(org, repo, number, lbl, e.IsPR)
 	}
 
 	// If the label does not exist and we asked for it to be added,
@@ -106,13 +106,13 @@ func handleOne(gc stageClient, log *logrus.Entry, e *gitprovider.GenericCommentE
 	if !gitprovider.HasLabel(lbl, labels) && !remove {
 		for _, label := range stageLabels {
 			if label != lbl && gitprovider.HasLabel(label, labels) {
-				if err := gc.RemoveLabel(org, repo, number, label); err != nil {
+				if err := gc.RemoveLabel(org, repo, number, label, e.IsPR); err != nil {
 					log.WithError(err).Errorf("GitHub failed to remove the following label: %s", label)
 				}
 			}
 		}
 
-		if err := gc.AddLabel(org, repo, number, lbl); err != nil {
+		if err := gc.AddLabel(org, repo, number, lbl, e.IsPR); err != nil {
 			log.WithError(err).Errorf("GitHub failed to add the following label: %s", lbl)
 		}
 	}

--- a/pkg/prow/plugins/stage/stage_test.go
+++ b/pkg/prow/plugins/stage/stage_test.go
@@ -35,13 +35,13 @@ type fakeClient struct {
 	removed []string
 }
 
-func (c *fakeClient) AddLabel(owner, repo string, number int, label string) error {
+func (c *fakeClient) AddLabel(owner, repo string, number int, label string, _ bool) error {
 	c.added = append(c.added, label)
 	c.labels = append(c.labels, label)
 	return nil
 }
 
-func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string) error {
+func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string, _ bool) error {
 	c.removed = append(c.removed, label)
 
 	// remove from existing labels
@@ -55,7 +55,7 @@ func (c *fakeClient) RemoveLabel(owner, repo string, number int, label string) e
 	return nil
 }
 
-func (c *fakeClient) GetIssueLabels(owner, repo string, number int) ([]*scm.Label, error) {
+func (c *fakeClient) GetIssueLabels(owner, repo string, number int, _ bool) ([]*scm.Label, error) {
 	la := []*scm.Label{}
 	for _, l := range c.labels {
 		la = append(la, &scm.Label{Name: l})

--- a/pkg/prow/plugins/trigger/generic-comment.go
+++ b/pkg/prow/plugins/trigger/generic-comment.go
@@ -94,19 +94,19 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc gitprovider.Gen
 	// Ensure we have labels before test, because TrustedPullRequest() won't be called
 	// when commentAuthor is trusted.
 	if l == nil {
-		l, err = c.GitHubClient.GetIssueLabels(org, repo, number)
+		l, err = c.GitHubClient.GetIssueLabels(org, repo, number, gc.IsPR)
 		if err != nil {
 			return err
 		}
 	}
 	isOkToTest := HonorOkToTest(trigger) && pjutil.OkToTestRe.MatchString(gc.Body)
 	if isOkToTest && !gitprovider.HasLabel(labels.OkToTest, l) {
-		if err := c.GitHubClient.AddLabel(org, repo, number, labels.OkToTest); err != nil {
+		if err := c.GitHubClient.AddLabel(org, repo, number, labels.OkToTest, gc.IsPR); err != nil {
 			return err
 		}
 	}
 	if (isOkToTest || gitprovider.HasLabel(labels.OkToTest, l)) && gitprovider.HasLabel(labels.NeedsOkToTest, l) {
-		if err := c.GitHubClient.RemoveLabel(org, repo, number, labels.NeedsOkToTest); err != nil {
+		if err := c.GitHubClient.RemoveLabel(org, repo, number, labels.NeedsOkToTest, gc.IsPR); err != nil {
 			return err
 		}
 	}

--- a/pkg/prow/plugins/trigger/pull-request.go
+++ b/pkg/prow/plugins/trigger/pull-request.go
@@ -64,7 +64,7 @@ func handlePR(c Client, trigger *plugins.Trigger, pr scm.PullRequestHook) error 
 			// Eventually remove need-ok-to-test
 			// Does not work for TrustedUser() == true since labels are not fetched in this case
 			if gitprovider.HasLabel(labels.NeedsOkToTest, l) {
-				if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest); err != nil {
+				if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest, true); err != nil {
 					return err
 				}
 			}
@@ -122,7 +122,7 @@ func buildAllIfTrusted(c Client, trigger *plugins.Trigger, pr scm.PullRequestHoo
 		// Eventually remove needs-ok-to-test
 		// Will not work for org members since labels are not fetched in this case
 		if gitprovider.HasLabel(labels.NeedsOkToTest, l) {
-			if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest); err != nil {
+			if err := c.GitHubClient.RemoveLabel(org, repo, num, labels.NeedsOkToTest, true); err != nil {
 				return err
 			}
 		}
@@ -176,7 +176,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 %s
 </details>
 `, author, org, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
-		if err := ghc.AddLabel(org, repo, pr.Number, labels.NeedsOkToTest); err != nil {
+		if err := ghc.AddLabel(org, repo, pr.Number, labels.NeedsOkToTest, true); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -203,7 +203,7 @@ func TrustedPullRequest(ghc githubClient, trigger *plugins.Trigger, author, org,
 	// Then check if PR has ok-to-test label
 	if l == nil {
 		var err error
-		l, err = ghc.GetIssueLabels(org, repo, num)
+		l, err = ghc.GetIssueLabels(org, repo, num, true)
 		if err != nil {
 			return l, false, err
 		}

--- a/pkg/prow/plugins/trigger/pull-request_test.go
+++ b/pkg/prow/plugins/trigger/pull-request_test.go
@@ -260,8 +260,8 @@ func TestHandlePullRequest(t *testing.T) {
 		t.Logf("running scenario %q", tc.name)
 
 		g := &fakegitprovider.FakeClient{
-			IssueComments: map[int][]*scm.Comment{},
-			OrgMembers:    map[string][]string{"org": {"t"}},
+			PullRequestComments: map[int][]*scm.Comment{},
+			OrgMembers:          map[string][]string{"org": {"t"}},
 			PullRequests: map[int]*scm.PullRequest{
 				0: {
 					Number: 0,
@@ -299,7 +299,7 @@ func TestHandlePullRequest(t *testing.T) {
 		}
 
 		if tc.HasOkToTest {
-			g.IssueLabelsExisting = append(g.IssueLabelsExisting, issueLabels(labels.OkToTest)...)
+			g.PullRequestLabelsExisting = append(g.PullRequestLabelsExisting, issueLabels(labels.OkToTest)...)
 		}
 		pr := scm.PullRequestHook{
 			Action: tc.prAction,
@@ -346,9 +346,9 @@ func TestHandlePullRequest(t *testing.T) {
 		} else if numStarted == 0 && tc.ShouldBuild {
 			t.Errorf("Not built but should have: %+v", tc)
 		}
-		if tc.ShouldComment && len(g.IssueCommentsAdded) == 0 {
+		if tc.ShouldComment && len(g.PullRequestCommentsAdded) == 0 {
 			t.Error("Expected comment to github")
-		} else if !tc.ShouldComment && len(g.IssueCommentsAdded) > 0 {
+		} else if !tc.ShouldComment && len(g.PullRequestCommentsAdded) > 0 {
 			t.Errorf("Expected no comments to github, but got %d", len(g.CreatedStatuses))
 		}
 	}

--- a/pkg/prow/plugins/trigger/trigger.go
+++ b/pkg/prow/plugins/trigger/trigger.go
@@ -94,7 +94,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 }
 
 type githubClient interface {
-	AddLabel(org, repo string, number int, label string) error
+	AddLabel(org, repo string, number int, label string, pr bool) error
 	BotName() (string, error)
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
@@ -105,9 +105,9 @@ type githubClient interface {
 	CreateStatus(org, repo, ref string, s *scm.StatusInput) (*scm.Status, error)
 	GetCombinedStatus(org, repo, ref string) (*scm.CombinedStatus, error)
 	GetPullRequestChanges(org, repo string, number int) ([]*scm.Change, error)
-	RemoveLabel(org, repo string, number int, label string) error
-	DeleteStaleComments(org, repo string, number int, comments []*scm.Comment, isStale func(*scm.Comment) bool) error
-	GetIssueLabels(org, repo string, number int) ([]*scm.Label, error)
+	RemoveLabel(org, repo string, number int, label string, pr bool) error
+	DeleteStaleComments(org, repo string, number int, comments []*scm.Comment, pr bool, isStale func(*scm.Comment) bool) error
+	GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.Label, error)
 }
 
 type plumberClient interface {

--- a/pkg/prow/plugins/wip/wip-label_test.go
+++ b/pkg/prow/plugins/wip/wip-label_test.go
@@ -111,18 +111,18 @@ func TestWipLabel(t *testing.T) {
 
 		fakeLabel := fmt.Sprintf("%s/%s#%d:%s", org, repo, number, labels.WorkInProgress)
 		if tc.shouldLabel {
-			if len(fc.IssueLabelsAdded) != 1 || fc.IssueLabelsAdded[0] != fakeLabel {
-				t.Errorf("For case %s: expected to add %q Label but instead added: %v", tc.name, labels.WorkInProgress, fc.IssueLabelsAdded)
+			if len(fc.PullRequestLabelsAdded) != 1 || fc.PullRequestLabelsAdded[0] != fakeLabel {
+				t.Errorf("For case %s: expected to add %q Label but instead added: %v", tc.name, labels.WorkInProgress, fc.PullRequestLabelsAdded)
 			}
-		} else if len(fc.IssueLabelsAdded) > 0 {
-			t.Errorf("For case %s, expected to not add %q Label but added: %v", tc.name, labels.WorkInProgress, fc.IssueLabelsAdded)
+		} else if len(fc.PullRequestLabelsAdded) > 0 {
+			t.Errorf("For case %s, expected to not add %q Label but added: %v", tc.name, labels.WorkInProgress, fc.PullRequestLabelsAdded)
 		}
 		if tc.shouldUnlabel {
-			if len(fc.IssueLabelsRemoved) != 1 || fc.IssueLabelsRemoved[0] != fakeLabel {
-				t.Errorf("For case %s: expected to remove %q Label but instead removed: %v", tc.name, labels.WorkInProgress, fc.IssueLabelsRemoved)
+			if len(fc.PullRequestLabelsRemoved) != 1 || fc.PullRequestLabelsRemoved[0] != fakeLabel {
+				t.Errorf("For case %s: expected to remove %q Label but instead removed: %v", tc.name, labels.WorkInProgress, fc.PullRequestLabelsRemoved)
 			}
-		} else if len(fc.IssueLabelsRemoved) > 0 {
-			t.Errorf("For case %s, expected to not remove %q Label but removed: %v", tc.name, labels.WorkInProgress, fc.IssueLabelsRemoved)
+		} else if len(fc.PullRequestLabelsRemoved) > 0 {
+			t.Errorf("For case %s, expected to not remove %q Label but removed: %v", tc.name, labels.WorkInProgress, fc.PullRequestLabelsRemoved)
 		}
 	}
 }

--- a/pkg/prow/plugins/yuks/yuks_test.go
+++ b/pkg/prow/plugins/yuks/yuks_test.go
@@ -159,9 +159,15 @@ func TestJokes(t *testing.T) {
 			t.Errorf("For case %s, expected an error to occur", tc.name)
 			continue
 		}
-		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+		var comments map[int][]*scm.Comment
+		if tc.pr {
+			comments = fc.PullRequestComments
+		} else {
+			comments = fc.IssueComments
+		}
+		if tc.shouldComment && len(comments[5]) != 1 {
 			t.Errorf("For case %s, should have commented.", tc.name)
-		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+		} else if !tc.shouldComment && len(comments[5]) != 0 {
 			t.Errorf("For case %s, should not have commented.", tc.name)
 		}
 	}


### PR DESCRIPTION
~~Note that right now, 1.5.69 doesn't exist, hence the `replace` in `go.mod`. Need to get https://github.com/jenkins-x/go-scm/pull/65 merged and released and this PR updated.~~

It’s merged, 1.5.70 is latest release.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>