### PR TITLE
fix: Use token secret like Prow does

### DIFF
--- a/bdd/bbs/ci.sh
+++ b/bdd/bbs/ci.sh
@@ -43,10 +43,21 @@ export JX_DISABLE_TEST_CHATOPS_COMMANDS="true"
 # TODO temporary hack until the batch mode in jx is fixed...
 export JX_BATCH_MODE="true"
 
+# Push the snapshot chart
+pushd charts/lighthouse
+make snapshot
+popd
+
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
-cp bdd/bbs/jx-requirements.yml boot-source
-cp bdd/bbs/parameters.yaml boot-source/env
 cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
+cp ../bdd/bbs/jx-requirements.yml .
+cp ../bdd/bbs/parameters.yaml env
 
 # Manually interpolate lighthouse version tag
 cat ../bdd/values.yaml.template >> env/lighthouse/values.tmpl.yaml
@@ -54,6 +65,7 @@ cp env/lighthouse/values.tmpl.yaml values.tmpl.yaml.tmp
 sed 's/$VERSION/'"$VERSION"'/' values.tmpl.yaml.tmp > env/lighthouse/values.tmpl.yaml
 cat env/lighthouse/values.tmpl.yaml
 rm values.tmpl.yaml.tmp
+sed -e s/\$VERSION/${VERSION}/g ../bdd/helm-requirements.yaml.template > env/requirements.yaml
 
 echo "Building lighthouse with version $VERSION"
 
@@ -61,7 +73,7 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
-
+set +e
 jx step bdd \
     --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
     --config ../bdd/bbs/cluster.yaml \
@@ -75,4 +87,11 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
+    --tests test-create-spring \
     --tests test-quickstart-golang-http
+
+bdd_result=$?
+cd ../charts/lighthouse
+make delete-from-chartmuseum
+
+exit $bdd_result

--- a/bdd/bbs/jx-requirements.yml
+++ b/bdd/bbs/jx-requirements.yml
@@ -17,6 +17,7 @@ environments:
   - key: production
     owner: ""
     repository: ""
+gitops: true
 ingress:
   domain: ""
   externalDNS: false
@@ -25,13 +26,15 @@ ingress:
     enabled: false
     production: false
 kaniko: true
-secretStorage: local
+secretStorage: vault
 storage:
   logs:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
   reports:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
+vault:
+  disableURLDiscovery: true
 webhook: lighthouse
 

--- a/bdd/ghe/jx-requirements.yml
+++ b/bdd/ghe/jx-requirements.yml
@@ -17,6 +17,7 @@ environments:
   - key: production
     owner: ""
     repository: ""
+gitops: true
 ingress:
   domain: ""
   externalDNS: false
@@ -26,13 +27,15 @@ ingress:
     production: false
 kaniko: true
 repository: nexus
-secretStorage: local
+secretStorage: vault
 storage:
   logs:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
   reports:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
+vault:
+  disableURLDiscovery: true
 webhook: lighthouse
 

--- a/bdd/github/ci.sh
+++ b/bdd/github/ci.sh
@@ -40,10 +40,23 @@ export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
 # TODO temporary hack until the batch mode in jx is fixed...
 export JX_BATCH_MODE="true"
 
+# Push the snapshot chart
+pushd charts/lighthouse
+make snapshot
+popd
+
+export JX_ENABLE_TEST_CHATOPS_COMMANDS="true"
+
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
-cp bdd/github/jx-requirements.yml boot-source
-cp bdd/github/parameters.yaml boot-source/env
 cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
+cp ../bdd/github/jx-requirements.yml .
+cp ../bdd/github/parameters.yaml env
 
 # Manually interpolate lighthouse version tag
 cat ../bdd/values.yaml.template >> env/lighthouse/values.tmpl.yaml
@@ -51,6 +64,7 @@ cp env/lighthouse/values.tmpl.yaml values.tmpl.yaml.tmp
 sed 's/$VERSION/'"$VERSION"'/' values.tmpl.yaml.tmp > env/lighthouse/values.tmpl.yaml
 cat env/lighthouse/values.tmpl.yaml
 rm values.tmpl.yaml.tmp
+sed -e s/\$VERSION/${VERSION}/g ../bdd/helm-requirements.yaml.template > env/requirements.yaml
 
 echo "Building lighthouse with version $VERSION"
 
@@ -58,9 +72,7 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
-# Just run the node-http import test here
-export BDD_TEST_SINGLE_IMPORT="node-http"
-
+set +e
 jx step bdd \
     --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
     --config ../bdd/github/cluster.yaml \
@@ -72,5 +84,11 @@ jx step bdd \
     --default-admin-password $JENKINS_PASSWORD \
     --no-delete-app \
     --no-delete-repo \
-    --tests test-quickstart-golang-http \
-    --tests test-single-import
+    --tests test-create-spring \
+    --tests test-quickstart-golang-http
+
+bdd_result=$?
+cd ../charts/lighthouse
+make delete-from-chartmuseum
+
+exit $bdd_result

--- a/bdd/github/jx-requirements.yml
+++ b/bdd/github/jx-requirements.yml
@@ -14,6 +14,7 @@ environments:
   - key: production
     owner: ""
     repository: ""
+gitops: true
 ingress:
   domain: ""
   externalDNS: false
@@ -23,13 +24,15 @@ ingress:
     production: false
 kaniko: true
 repository: nexus
-secretStorage: local
+secretStorage: vault
 storage:
   logs:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
   reports:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
+vault:
+  disableURLDiscovery: true
 webhook: lighthouse
 

--- a/bdd/gitlab/ci.sh
+++ b/bdd/gitlab/ci.sh
@@ -87,8 +87,7 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-create-spring \
-    --tests test-quickstart-golang-http
+    --tests test-create-spring
 
 bdd_result=$?
 cd ../charts/lighthouse

--- a/bdd/gitlab/ci.sh
+++ b/bdd/gitlab/ci.sh
@@ -37,16 +37,27 @@ export JX_VALUE_PIPELINEUSER_EMAIL="$GL_EMAIL"
 export JX_VALUE_PIPELINEUSER_TOKEN="$GL_ACCESS_TOKEN"
 export JX_VALUE_PROW_HMACTOKEN="$GL_ACCESS_TOKEN"
 
-# TODO: Disable chatops tests until issue creation and labeling on Gitlab is ready
-export JX_DISABLE_TEST_CHATOPS_COMMANDS="true"
-
 # TODO temporary hack until the batch mode in jx is fixed...
 export JX_BATCH_MODE="true"
 
+# Push the snapshot chart
+pushd charts/lighthouse
+make snapshot
+popd
+
+# TODO: Figure out why chatops doesn't work for gitlab!
+export JX_ENABLE_TEST_CHATOPS_COMMANDS="false"
+
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
-cp bdd/gitlab/jx-requirements.yml boot-source
-cp bdd/gitlab/parameters.yaml boot-source/env
 cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
+cp ../bdd/gitlab/jx-requirements.yml .
+cp ../bdd/gitlab/parameters.yaml env
 
 # Manually interpolate lighthouse version tag
 cat ../bdd/values.yaml.template >> env/lighthouse/values.tmpl.yaml
@@ -54,6 +65,7 @@ cp env/lighthouse/values.tmpl.yaml values.tmpl.yaml.tmp
 sed 's/$VERSION/'"$VERSION"'/' values.tmpl.yaml.tmp > env/lighthouse/values.tmpl.yaml
 cat env/lighthouse/values.tmpl.yaml
 rm values.tmpl.yaml.tmp
+sed -e s/\$VERSION/${VERSION}/g ../bdd/helm-requirements.yaml.template > env/requirements.yaml
 
 echo "Building lighthouse with version $VERSION"
 
@@ -61,7 +73,7 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
-
+set +e
 jx step bdd \
     --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
     --config ../bdd/gitlab/cluster.yaml \
@@ -75,4 +87,11 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
+    --tests test-create-spring \
     --tests test-quickstart-golang-http
+
+bdd_result=$?
+cd ../charts/lighthouse
+make delete-from-chartmuseum
+
+exit $bdd_result

--- a/bdd/gitlab/jx-requirements.yml
+++ b/bdd/gitlab/jx-requirements.yml
@@ -17,6 +17,7 @@ environments:
   - key: production
     owner: ""
     repository: ""
+gitops: true
 ingress:
   domain: ""
   externalDNS: false
@@ -25,13 +26,16 @@ ingress:
     enabled: false
     production: false
 kaniko: true
-secretStorage: local
+repository: nexus
+secretStorage: vault
 storage:
   logs:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
   reports:
-    enabled: true
-    url: "gs://jx-bdd-log-store3"
+    enabled: false
+    url: ""
+vault:
+  disableURLDiscovery: true
 webhook: lighthouse
 

--- a/bdd/helm-requirements.yaml.template
+++ b/bdd/helm-requirements.yaml.template
@@ -1,0 +1,21 @@
+dependencies:
+  - name: jxboot-resources
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: tekton
+    name: tekton
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: prow
+    condition: prow.enabled
+    name: prow
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: lighthouse
+    condition: lighthouse.enabled
+    name: lighthouse
+    repository: https://chartmuseum-jx.jenkins-x.live
+    version: $VERSION
+  - alias: bucketrepo
+    condition: bucketrepo.enabled
+    name: bucketrepo
+    repository: http://chartmuseum.jenkins-x.io
+  - name: jenkins-x-platform
+    repository: http://chartmuseum.jenkins-x.io

--- a/bdd/values.yaml.template
+++ b/bdd/values.yaml.template
@@ -3,3 +3,23 @@ image:
   repository: gcr.io/jenkinsxio/lighthouse
   tag: $VERSION
   pullPolicy: IfNotPresent
+
+# Override the tide image tag
+tide:
+  image:
+    repository: gcr.io/jenkinsxio/lh-tide
+    tag: $VERSION
+    pullPolicy: IfNotPresent
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+clusterName: {{ .Requirements.cluster.clusterName }}
+
+user: "{{ .Parameters.pipelineUser.username }}"
+
+oauthToken: "{{ .Parameters.pipelineUser.token }}"

--- a/charts/lighthouse/Makefile
+++ b/charts/lighthouse/Makefile
@@ -2,9 +2,6 @@ CHART_REPO := http://jenkins-x-chartmuseum:8080
 CURRENT=$(pwd)
 NAME := lighthouse
 OS := $(shell uname)
-VERSION := $(shell cat ../../VERSION)
-CHARTMUSEUM_CREDS_USR := $(shell cat /builder/home/basic-auth-user)
-CHARTMUSEUM_CREDS_PSW := $(shell cat /builder/home/basic-auth-pass)
 
 build: clean
 	rm -rf requirements.lock
@@ -24,27 +21,34 @@ clean:
 	rm -rf charts
 	rm -rf ${NAME}*.tgz
 
+.PHONY: snapshot
+snapshot: update-version release
+
 release: clean
 	helm dependency build
 	helm lint
 	helm init --client-only
 	helm package .
-	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
 	rm -rf ${NAME}*.tgz%
 
-tag:
+update-version:
 ifeq ($(OS),Darwin)
 	sed -i "" -e "s/version:.*/version: $(VERSION)/" Chart.yaml
 	sed -i "" -e "s/tag:.*/tag: $(VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/jenkins-x-infra\/$(NAME)|" values.yaml
 	sed -i -e "s/tag:.*/tag: $(VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to tag with"
 	exit -1
 endif
+
+tag: update-version
 	git add --all
 	git commit -m "release $(VERSION)" --allow-empty # if first release then no verion update is performed
 	git tag -fa v$(VERSION) -m "Release version $(VERSION)"
 	git push origin v$(VERSION)
+
+delete-from-chartmuseum:
+	curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) -X DELETE $(CHART_REPO)/api/charts/$(NAME)/$(VERSION)

--- a/charts/lighthouse/templates/deployment.yaml
+++ b/charts/lighthouse/templates/deployment.yaml
@@ -36,16 +36,12 @@ spec:
           - name: "GIT_SERVER"
             value: "{{ .Values.git.server }}"
           - name: "GIT_USER"
-            valueFrom:
-              secretKeyRef:
-                name: "jx-pipeline-git-{{ .Values.git.kind }}-{{ .Values.git.name }}"
-                key: username
+            value: {{ .Values.user }}
           - name: "GIT_TOKEN"
             valueFrom:
               secretKeyRef:
-                name: "jx-pipeline-git-{{ .Values.git.kind }}-{{ .Values.git.name }}"
-                key: password
-            value: "{{ .Values.git.token }}"
+                name: lighthouse-oauth-token
+                key: oauth
           - name: "HMAC_TOKEN"
             valueFrom:
               secretKeyRef:

--- a/charts/lighthouse/templates/oauthsecret.yaml
+++ b/charts/lighthouse/templates/oauthsecret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: lighthouse-oauth-token
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:  
+  oauth: {{ default "" .Values.oauthToken | b64enc | quote }}

--- a/charts/lighthouse/templates/tide-deployment.yaml
+++ b/charts/lighthouse/templates/tide-deployment.yaml
@@ -61,17 +61,11 @@ spec:
         - name: "GITHUB_APP_SECRET_DIR"
           value: "/secrets/githubapp/tokens"
 {{- else }}
-        - name: "GIT_USER"
-          valueFrom:
-            secretKeyRef:
-              name: "jx-pipeline-git-{{ .Values.git.kind }}-{{ .Values.git.name }}"
-              key: username
         - name: "GIT_TOKEN"
           valueFrom:
             secretKeyRef:
-              name: "jx-pipeline-git-{{ .Values.git.kind }}-{{ .Values.git.name }}"
-              key: password
-          value: "{{ .Values.git.token }}"
+              name: lighthouse-oauth-token
+              key: oauth
 {{- end }}
 {{- if .Values.tide.env }}
 {{- range $pkey, $pval := .Values.tide.env }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -82,3 +82,10 @@ tide:
     internalPort: 8888
   datadog:
     enabled: "true"
+
+vault:
+  enabled: false
+
+clusterName: ""
+
+user: ""

--- a/jenkins-x-bbs.yml
+++ b/jenkins-x-bbs.yml
@@ -27,6 +27,16 @@ pipelineConfig:
             value: http://jenkins-x-athens-proxy:80
           - name: GKE_SA
             value: /secrets/bdd/sa.json
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
           - name: BB_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/jenkins-x-ghe.yml
+++ b/jenkins-x-ghe.yml
@@ -27,7 +27,17 @@ pipelineConfig:
             value: http://jenkins-x-athens-proxy:80
           - name: GKE_SA
             value: /secrets/bdd/sa.json
-          - name: GHE_ACCESS_TOKEN 
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
+          - name: GHE_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: jx-pipeline-git-github-ghe

--- a/jenkins-x-github.yml
+++ b/jenkins-x-github.yml
@@ -27,7 +27,17 @@ pipelineConfig:
             value: http://jenkins-x-athens-proxy:80
           - name: GKE_SA
             value: /secrets/bdd/sa.json
-          - name: GH_ACCESS_TOKEN 
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
+          - name: GH_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: jenkins-x-versions-bot-test-github

--- a/jenkins-x-gitlab.yml
+++ b/jenkins-x-gitlab.yml
@@ -27,6 +27,16 @@ pipelineConfig:
             value: http://jenkins-x-athens-proxy:80
           - name: GKE_SA
             value: /secrets/bdd/sa.json
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
           - name: GL_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -38,6 +38,16 @@ pipelineConfig:
               secretKeyRef:
                 name: test-jenkins-user 
                 key: password
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
           options:
             volumes:
               - name: sa
@@ -144,6 +154,16 @@ pipelineConfig:
                 value: /builder/home/kaniko-secret.json
               - name: ORG
                 value: jenkinsxio
+              - name: CHARTMUSEUM_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: jenkins-x-chartmuseum
+                    key: BASIC_AUTH_USER
+              - name: CHARTMUSEUM_PASS
+                valueFrom:
+                  secretKeyRef:
+                    name: jenkins-x-chartmuseum
+                    key: BASIC_AUTH_PASS
             steps:
               - name: lint-check
                 image: gcr.io/jenkinsxio/builder-go
@@ -200,32 +220,6 @@ pipelineConfig:
                   - password
                   - -f
                   - /builder/home/git-token
-
-              - name: chartmuseum-credentials-user
-                image: jenkinsxio/jx:1.3.963
-                command: jx
-                args:
-                  - step
-                  - credential
-                  - -s
-                  - jenkins-x-chartmuseum
-                  - -k
-                  - BASIC_AUTH_USER
-                  - -f
-                  - /builder/home/basic-auth-user
-
-              - name: chartmuseum-credentials-password
-                image: gcr.io/jenkinsxio/builder-jx:0.1.639
-                command: jx
-                args:
-                  - step
-                  - credential
-                  - -s
-                  - jenkins-x-chartmuseum
-                  - -k
-                  - BASIC_AUTH_PASS
-                  - -f
-                  - /builder/home/basic-auth-pass
 
               - name: build-and-push-image
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6


### PR DESCRIPTION
Down the road, this should change to pulling the token from vault dynamically, but we need the vault mutating webhook to make that work, so for now...tada.

Also, turns on vault and gitops for all contexts.

fixes #465
