### PR TITLE
chore: Update BDD tests with extra log capturing

### DIFF
--- a/bdd/bbs/jx-requirements.yml
+++ b/bdd/bbs/jx-requirements.yml
@@ -26,6 +26,7 @@ ingress:
     enabled: false
     production: false
 kaniko: true
+repository: nexus
 secretStorage: vault
 storage:
   logs:

--- a/bdd/github/ci.sh
+++ b/bdd/github/ci.sh
@@ -45,8 +45,6 @@ pushd charts/lighthouse
 make snapshot
 popd
 
-export JX_ENABLE_TEST_CHATOPS_COMMANDS="true"
-
 # Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
 # boot fetches always the latest version available in the version stream.
 git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
@@ -72,6 +70,8 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
+export BDD_ENABLE_TEST_CHATOPS_COMMANDS="true"
+
 set +e
 jx step bdd \
     --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
@@ -85,9 +85,24 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests test-create-spring \
-    --tests test-quickstart-golang-http
+    --tests test-quickstart-golang-http \
+    --tests test-app-lifecycle
 
 bdd_result=$?
+if [[ $bdd_result != 0 ]]; then
+  pushd ..
+  mkdir -p extra-logs
+  kubectl logs --tail=-1 "$(kubectl get pod -l app=controllerbuild -o jsonpath='{.items[*].metadata.name}')" > extra-logs/controllerbuild.log
+  kubectl logs --tail=-1 "$(kubectl get pod -l app=tide -o jsonpath='{.items[*].metadata.name}')" > extra-logs/tide.log
+  lh_cnt=0
+  for lh_pod in $(kubectl get pod -l app=jenkins-x-lighthouse -o jsonpath='{.items[*].metadata.name}'); do
+    ((lh_cnt=lh_cnt+1))
+    kubectl logs --tail=-1 "${lh_pod}" > extra-logs/lh.${lh_cnt}.log
+  done
+
+  jx step stash -c lighthouse-tests -p "extra-logs/*.log" --bucket-url gs://jx-prod-logs
+  popd
+fi
 cd ../charts/lighthouse
 make delete-from-chartmuseum
 

--- a/bdd/gitlab/ci.sh
+++ b/bdd/gitlab/ci.sh
@@ -45,9 +45,6 @@ pushd charts/lighthouse
 make snapshot
 popd
 
-# TODO: Figure out why chatops doesn't work for gitlab!
-export JX_ENABLE_TEST_CHATOPS_COMMANDS="false"
-
 # Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
 # boot fetches always the latest version available in the version stream.
 git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
@@ -73,6 +70,9 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
+# TODO: Figure out why chatops doesn't work for gitlab!
+export BDD_ENABLE_TEST_CHATOPS_COMMANDS="false"
+
 set +e
 jx step bdd \
     --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
@@ -89,7 +89,23 @@ jx step bdd \
     --tests install \
     --tests test-create-spring
 
+# Gitlab labels on pull requests aren't properly implemented yet on our side, so no quickstart tests - they depend on them.
+
 bdd_result=$?
+if [[ $bdd_result != 0 ]]; then
+  pushd ..
+  mkdir -p extra-logs
+  kubectl logs --tail=-1 "$(kubectl get pod -l app=controllerbuild -o jsonpath='{.items[*].metadata.name}')" > extra-logs/controllerbuild.log
+  kubectl logs --tail=-1 "$(kubectl get pod -l app=tide -o jsonpath='{.items[*].metadata.name}')" > extra-logs/tide.log
+  lh_cnt=0
+  for lh_pod in $(kubectl get pod -l app=jenkins-x-lighthouse -o jsonpath='{.items[*].metadata.name}'); do
+    ((lh_cnt=lh_cnt+1))
+    kubectl logs --tail=-1 "${lh_pod}" > extra-logs/lh.${lh_cnt}.log
+  done
+
+  jx step stash -c lighthouse-tests -p "extra-logs/*.log" --bucket-url gs://jx-prod-logs
+  popd
+fi
 cd ../charts/lighthouse
 make delete-from-chartmuseum
 


### PR DESCRIPTION
Also re-enable chatops tests on GHE and GitHub with the right env var
name, and don't try running quickstart tests on BitBucket Server at
all due to the lack of labels there.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>