### PR TITLE
fix: Tide needs more permissions

### DIFF
--- a/charts/lighthouse/templates/tide-role.yaml
+++ b/charts/lighthouse/templates/tide-role.yaml
@@ -6,17 +6,24 @@ rules:
   - apiGroups:
       - jenkins.io
     resources:
+      - apps
       - environments
       - pipelineactivities
       - sourcerepositories
+      - pipelinestructures
     verbs:
+      - create
       - get
+      - edit
+      - update
+      - patch
       - list
       - watch
   - apiGroups:
       - ""
     resources:
       - namespaces
+      - configmaps
     verbs:
       - get
       - list

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1386,7 +1386,7 @@ func (c *DefaultController) dividePool(pool map[string]PullRequest, pjs []plumbe
 				WithField("build", labels["build"]).
 				WithField("branch", labels["branch"]).
 				WithField("owner", refs.Org).
-				WithField("repo", refs.Repo).WithField("baseRef", refs.BaseRef).Infof("base sha mismatch")
+				WithField("repo", refs.Repo).WithField("baseRef", refs.BaseRef).Debugf("base sha mismatch")
 		}
 		if sps[fn] == nil || pj.Spec.Refs.BaseSHA != sps[fn].sha {
 			continue


### PR DESCRIPTION
At the least for kicking off PR builds after approval when they need a
rebuild, but I'd guess for master as well.

Also switched a log line to debug rather than info because it was
swamping the logs.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>