### PR TITLE
fix: retest and other checks need pr.Head.Ref, not pr.Base.Ref

### DIFF
--- a/pkg/prow/plugins/trigger/generic-comment.go
+++ b/pkg/prow/plugins/trigger/generic-comment.go
@@ -145,7 +145,7 @@ type GitHubClient interface {
 // consider the set of matching presubmits the union of the results from the
 // matching cases.
 func FilterPresubmits(honorOkToTest bool, gitHubClient GitHubClient, body string, pr *scm.PullRequest, presubmits []config.Presubmit, logger *logrus.Entry) ([]config.Presubmit, []config.Presubmit, error) {
-	org, repo, sha := pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Base.Ref
+	org, repo, sha := pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Head.Ref
 
 	contextGetter := func() (sets.String, sets.String, error) {
 		combinedStatus, err := gitHubClient.GetCombinedStatus(org, repo, sha)

--- a/pkg/prow/plugins/trigger/trigger.go
+++ b/pkg/prow/plugins/trigger/trigger.go
@@ -258,7 +258,7 @@ func runRequested(c Client, pr *scm.PullRequest, requestedJobs []config.Presubmi
 		if _, err := c.PlumberClient.Create(&pj, c.MetapipelineClient, pr.Repository()); err != nil {
 			c.Logger.WithError(err).Error("Failed to create plumberJob.")
 			errors = append(errors, err)
-			if _, statusErr := c.GitHubClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Base.Ref, failedStatusForMetapipelineCreation(job.Context, err)); statusErr != nil {
+			if _, statusErr := c.GitHubClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Head.Ref, failedStatusForMetapipelineCreation(job.Context, err)); statusErr != nil {
 				errors = append(errors, statusErr)
 			}
 		}
@@ -274,7 +274,7 @@ func skipRequested(c Client, pr *scm.PullRequest, skippedJobs []config.Presubmit
 			continue
 		}
 		c.Logger.Infof("Skipping %s build.", job.Name)
-		if _, err := c.GitHubClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Base.Ref, skippedStatusFor(job.Context)); err != nil {
+		if _, err := c.GitHubClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Head.Ref, skippedStatusFor(job.Context)); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/pkg/prow/plugins/trigger/trigger_test.go
+++ b/pkg/prow/plugins/trigger/trigger_test.go
@@ -346,7 +346,7 @@ func TestRunAndSkipJobs(t *testing.T) {
 				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 			}
 
-			if actual, expected := fakeGitHubClient.CreatedStatuses[pr.Base.Ref], testCase.expectedStatuses; !reflect.DeepEqual(actual, expected) {
+			if actual, expected := fakeGitHubClient.CreatedStatuses[pr.Head.Ref], testCase.expectedStatuses; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: created incorrect statuses: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 


### PR DESCRIPTION
This is resulting in retest looking at contexts on master, not on the
PR, which is wrong and results in everything getting rebuilt.

fixes https://github.com/jenkins-x/jx/issues/6796

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>