### PR TITLE
fix: Simple state for running pipeline should be pending, not failure

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -566,7 +566,7 @@ const (
 )
 
 func toSimpleState(s plumber.PipelineState) simpleState {
-	if s == plumber.TriggeredState || s == plumber.PendingState {
+	if s == plumber.TriggeredState || s == plumber.PendingState || s == plumber.RunningState {
 		return pendingState
 	} else if s == plumber.SuccessState {
 		return successState


### PR DESCRIPTION
This isn't actually breaking anything right now, but still, let's be
more accurate.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>