### PR TITLE
fix: overridden status takes precedence over latest build result

### DIFF
--- a/bdd/github/ci.sh
+++ b/bdd/github/ci.sh
@@ -85,7 +85,7 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests test-create-spring \
-    --tests test-quickstart-golang-http \
+    --tests test-lighthouse \
     --tests test-app-lifecycle
 
 bdd_result=$?

--- a/bdd/github/jx-requirements.yml
+++ b/bdd/github/jx-requirements.yml
@@ -1,5 +1,7 @@
 cluster:
   clusterName: lh-bdd-github
+  devEnvApprovers:
+    - jenkins-x-bot-test
   environmentGitOwner: jenkins-x-versions-bot-test
   project: jenkins-x-bdd3
   provider: gke

--- a/jenkins-x-github.yml
+++ b/jenkins-x-github.yml
@@ -47,6 +47,16 @@ pipelineConfig:
               secretKeyRef:
                 name: test-jenkins-user 
                 key: password
+          - name: BDD_APPROVER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-bot-test-github
+                key: username
+          - name: BDD_APPROVER_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-bot-test-github
+                key: password
         agent:
           image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -90,46 +90,6 @@ pipelineConfig:
             args:
             - build
             dir: /workspace/source/charts/lighthouse
-          - name: kaniko-credentials
-            image: jenkinsxio/jx:1.3.963
-            command: jx
-            args:
-              - step 
-              - credential
-              - -s
-              - kaniko-secret
-              - -k
-              - kaniko-secret
-              - -f
-              - /builder/home/kaniko-secret.json
-
-          - name: build-and-push-image
-            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
-            command: /kaniko/executor
-            args: 
-            - --dockerfile=/workspace/source/Dockerfile
-            - --destination=gcr.io/jenkinsxio/lighthouse:${inputs.params.version}
-            - --context=/workspace/source
-            - --cache-dir=/workspace
-            - --build-arg=VERSION=${inputs.params.version}
-          - name: build-and-push-image2
-            image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
-            command: /kaniko/executor
-            args:
-            - --dockerfile=/workspace/source/Dockerfile.tide
-            - --destination=gcr.io/jenkinsxio/lh-tide:${inputs.params.version}
-            - --context=/workspace/source
-            - --cache-dir=/workspace
-            - --build-arg=VERSION=${inputs.params.version}
-          - command: make preview
-            dir: /workspace/source/charts/preview
-            image: go
-            name: promote-make-preview
-
-          - command: jx preview --app $APP_NAME --dir ../..
-            dir: /workspace/source/charts/preview
-            image: go
-            name: promote-jx-preview
 
     release:
       pipeline:

--- a/pkg/plumber/plumber.go
+++ b/pkg/plumber/plumber.go
@@ -199,6 +199,7 @@ func ToPipelineOptions(activity *v1.PipelineActivity) PipelineOptions {
 			Context:        spec.Context,
 			RerunCommand:   "",
 			MaxConcurrency: 0,
+			LastCommitSHA:  spec.LastCommitSHA,
 		},
 		Status: PipelineStatus{State: ToPipelineState(spec.Status)},
 	}

--- a/pkg/plumber/test_data/convert/batch/expected.yaml
+++ b/pkg/plumber/test_data/convert/batch/expected.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   context: promotion-build
   job: Abayer-UpperCase-Org/environment-lh-tide-rerun-dev/PR-6
+  lastCommitSHA: 6cf1b84eefb280171676f26dd43adf95a4a0b679
   namespace: jx
   refs:
     base_ref: master

--- a/pkg/plumber/test_data/convert/presubmit/expected.yaml
+++ b/pkg/plumber/test_data/convert/presubmit/expected.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   context: pr-build
   job: jstrachan/godemo25/PR-1
+  lastCommitSHA: 49e54b4ab808d780fd86abb25dc725112b6fd9ee
   namespace: jx
   refs:
     base_ref: master

--- a/pkg/plumber/types.go
+++ b/pkg/plumber/types.go
@@ -114,6 +114,8 @@ type PipelineOptionsSpec struct {
 	// MaxConcurrency restricts the total number of instances
 	// of this job that can run in parallel at once
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
+	// LastCommitSHA is the commit that will be/has been reported to on the SCM provider
+	LastCommitSHA string `json:"lastCommitSHA,omitempty"`
 }
 
 // GetEnvVars gets a map of the environment variables we'll set in the pipeline for this spec.

--- a/pkg/prow/plugins/override/override.go
+++ b/pkg/prow/plugins/override/override.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/jx/pkg/jxfactory"
+	"github.com/jenkins-x/lighthouse/pkg/util"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -119,7 +120,7 @@ func authorized(gc githubClient, log *logrus.Entry, org, repo, user string) bool
 }
 
 func description(user string) string {
-	return fmt.Sprintf("Overridden by %s", user)
+	return fmt.Sprintf("%s %s", util.OverriddenByPrefix, user)
 }
 
 func formatList(list []string) string {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -3,4 +3,7 @@ package util
 const (
 	// CommitStatusPendingDescription is the description used for PR commit status for pipelines we have just kicked off.
 	CommitStatusPendingDescription = "Pipeline pending"
+
+	// OverriddenByPrefix is the beginning of the description for commit statuses set by /override
+	OverriddenByPrefix = "Overridden by"
 )


### PR DESCRIPTION
This gets the user-facing behavior to more closely match Prow - `/override` creates a commit status with an `Overridden by ...` description, and even if the latest `PipelineActivity` for that context is failed or pending and hasn't reported since the `/override` went in, Tide should treat this context as successful/ready to merge.

In Prow, `/override` creates a new `ProwJob` - one that doesn't actually kick off a pipeline but just sets the commit status and sets its own status to successful. Since Prow uses `ProwJob`s as the "build status" source, where Lighthouse currently uses `PipelineActivity`s, Prow's Tide will see the override-created and successful `ProwJob` as the latest for the given context, rather than the created-earlier failed or pending `ProwJob`, and the PR (assuming all contexts are successful, of course!) will happily merge.

In Lighthouse, we don't create a `PipelineActivity` via `/override`, because `PipelineActivity` doesn't just serve Lighthouse's purposes - its main purpose is build status/reporting/etc for Jenkins X, so we really don't want to mess around with it. Without this change, we'd just see the latest failed or pending `PipelineActivity` for the PR+context, and then things would get silly and it would insist on running a new build. With this change, we check the commit status for the context to see if it's successful and starts with `Overridden by`, and if so, we override the `PipelineActivity`-driven status with success.

This will all probably end up getting wiped away in the future when we rearchitect to have a `ProwJob` equivalent (which I think we also need for batch - it's possible this change _may_ fix batch, but I don't think it will), but for the time being, I'd really like `/override` to work. =)

fixes #557

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>