### PR TITLE
chore: Stop using github and prow in type/interface/field/variable names

### DIFF
--- a/pkg/prow/config/jobs.go
+++ b/pkg/prow/config/jobs.go
@@ -385,14 +385,14 @@ func (ps Presubmit) ContextRequired() bool {
 // ChangedFilesProvider returns a slice of modified files.
 type ChangedFilesProvider func() ([]string, error)
 
-type githubClient interface {
+type scmClient interface {
 	GetPullRequestChanges(org, repo string, number int) ([]*scm.Change, error)
 }
 
 // NewGitHubDeferredChangedFilesProvider uses a closure to lazily retrieve the file changes only if they are needed.
 // We only have to fetch the changes if there is at least one RunIfChanged job that is not being force run (due to
 // a `/retest` after a failure or because it is explicitly triggered with `/test foo`).
-func NewGitHubDeferredChangedFilesProvider(client githubClient, org, repo string, num int) ChangedFilesProvider {
+func NewGitHubDeferredChangedFilesProvider(client scmClient, org, repo string, num int) ChangedFilesProvider {
 	var changedFiles []string
 	return func() ([]string, error) {
 		// Fetch the changed files from github at most once.

--- a/pkg/prow/plugins/blockade/blockade_test.go
+++ b/pkg/prow/plugins/blockade/blockade_test.go
@@ -297,7 +297,7 @@ func TestHandle(t *testing.T) {
 	for _, tc := range tcs {
 		expectAdded := []string{}
 		fakeScmClient, fakeClient := fake.NewDefault()
-		fakeGHClient := gitprovider.ToTestClient(fakeScmClient)
+		fakeSCMProviderClient := gitprovider.ToTestClient(fakeScmClient)
 		fakeClient.RepoLabelsExisting = []string{labels.BlockedPaths, otherLabel}
 
 		if tc.hasLabel {
@@ -325,7 +325,7 @@ func TestHandle(t *testing.T) {
 				Number: 1,
 			},
 		}
-		if err := handle(fakeGHClient, logrus.WithField("plugin", PluginName), tc.config, &fakePruner{}, calcF, pre); err != nil {
+		if err := handle(fakeSCMProviderClient, logrus.WithField("plugin", PluginName), tc.config, &fakePruner{}, calcF, pre); err != nil {
 			t.Errorf("[%s] Unexpected error from handle: %v.", tc.name, err)
 			continue
 		}

--- a/pkg/prow/plugins/branchcleaner/branchcleaner.go
+++ b/pkg/prow/plugins/branchcleaner/branchcleaner.go
@@ -40,14 +40,14 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 }
 
 func handlePullRequest(pc plugins.Agent, pre scm.PullRequestHook) error {
-	return handle(pc.GitHubClient, pc.Logger, pre)
+	return handle(pc.SCMProviderClient, pc.Logger, pre)
 }
 
-type githubClient interface {
+type scmProviderClient interface {
 	DeleteRef(owner, repo, ref string) error
 }
 
-func handle(gc githubClient, log *logrus.Entry, pre scm.PullRequestHook) error {
+func handle(spc scmProviderClient, log *logrus.Entry, pre scm.PullRequestHook) error {
 	// Only consider closed PRs that got merged
 	if pre.Action != scm.ActionClose || !pre.PullRequest.Merged {
 		return nil
@@ -60,7 +60,7 @@ func handle(gc githubClient, log *logrus.Entry, pre scm.PullRequestHook) error {
 		return nil
 	}
 
-	if err := gc.DeleteRef(pr.Base.Repo.Namespace, pr.Base.Repo.Name, fmt.Sprintf("heads/%s", pr.Head.Ref)); err != nil {
+	if err := spc.DeleteRef(pr.Base.Repo.Namespace, pr.Base.Repo.Name, fmt.Sprintf("heads/%s", pr.Head.Ref)); err != nil {
 		return fmt.Errorf("failed to delete branch %s on repo %s/%s after Pull Request #%d got merged: %v",
 			pr.Head.Ref, pr.Base.Repo.Namespace, pr.Base.Repo.Name, pre.PullRequest.Number, err)
 	}

--- a/pkg/prow/plugins/dog/dog.go
+++ b/pkg/prow/plugins/dog/dog.go
@@ -68,7 +68,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-type githubClient interface {
+type scmProviderClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 }
 
@@ -131,10 +131,10 @@ func (u realPack) readDog(dogURL string) (string, error) {
 }
 
 func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, &e, dogURL)
+	return handle(pc.SCMProviderClient, pc.Logger, &e, dogURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, p pack) error {
+func handle(spc scmProviderClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, p pack) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil
@@ -167,7 +167,7 @@ func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEve
 			log.WithError(err).Println("Failed to get dog img")
 			continue
 		}
-		return gc.CreateComment(org, repo, number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp))
+		return spc.CreateComment(org, repo, number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp))
 	}
 
 	return errors.New("could not find a valid dog image")

--- a/pkg/prow/plugins/help/help_test.go
+++ b/pkg/prow/plugins/help/help_test.go
@@ -176,12 +176,12 @@ func TestLabel(t *testing.T) {
 	for _, tc := range testcases {
 		sort.Strings(tc.expectedNewLabels)
 		fakeScmClient, fakeClient := fake.NewDefault()
-		fakeGHClient := gitprovider.ToTestClient(fakeScmClient)
+		fakeSCMProviderClient := gitprovider.ToTestClient(fakeScmClient)
 		fakeClient.RepoLabelsExisting = []string{labels.Help, labels.GoodFirstIssue}
 
 		// Add initial labels
 		for _, label := range tc.issueLabels {
-			fakeGHClient.AddLabel("org", "repo", 1, label, false)
+			fakeSCMProviderClient.AddLabel("org", "repo", 1, label, false)
 		}
 
 		if len(tc.issueState) == 0 {
@@ -200,7 +200,7 @@ func TestLabel(t *testing.T) {
 			Repo:       scm.Repository{Namespace: "org", Name: "repo"},
 			Author:     scm.User{Login: "Alice"},
 		}
-		err := handle(fakeGHClient, logrus.WithField("plugin", pluginName), &fakePruner{}, e)
+		err := handle(fakeSCMProviderClient, logrus.WithField("plugin", pluginName), &fakePruner{}, e)
 		if err != nil {
 			t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
 			continue

--- a/pkg/prow/plugins/lgtm/lgtm_test.go
+++ b/pkg/prow/plugins/lgtm/lgtm_test.go
@@ -54,14 +54,14 @@ type fakeRepoOwners struct {
 }
 
 type fakePruner struct {
-	GitHubClient        *fake.Data
+	SCMProviderClient   *fake.Data
 	PullRequestComments []*scm.Comment
 }
 
 func (fp *fakePruner) PruneComments(pr bool, shouldPrune func(*scm.Comment) bool) {
 	for _, comment := range fp.PullRequestComments {
 		if shouldPrune(comment) {
-			fp.GitHubClient.PullRequestCommentsDeleted = append(fp.GitHubClient.PullRequestCommentsDeleted, comment.Body)
+			fp.SCMProviderClient.PullRequestCommentsDeleted = append(fp.SCMProviderClient.PullRequestCommentsDeleted, comment.Body)
 		}
 	}
 }
@@ -301,7 +301,7 @@ func TestLGTMComment(t *testing.T) {
 			StoreTreeHash: true,
 		})
 		fp := &fakePruner{
-			GitHubClient:        fc,
+			SCMProviderClient:   fc,
 			PullRequestComments: fc.PullRequestComments[5],
 		}
 		if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -455,7 +455,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
 		pc := &plugins.Configuration{}
 		fp := &fakePruner{
-			GitHubClient:        fc,
+			SCMProviderClient:   fc,
 			PullRequestComments: fc.PullRequestComments[5],
 		}
 		if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -652,7 +652,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 			StoreTreeHash: tc.storeTreeHash,
 		})
 		fp := &fakePruner{
-			GitHubClient:        fc,
+			SCMProviderClient:   fc,
 			PullRequestComments: fc.PullRequestComments[5],
 		}
 		if err := handlePullRequestReview(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
@@ -1103,7 +1103,7 @@ func TestRemoveTreeHashComment(t *testing.T) {
 
 	fc.PullRequestLabelsAdded = []string{"kubernetes/kubernetes#101:" + LGTMLabel}
 	fp := &fakePruner{
-		GitHubClient:        fc,
+		SCMProviderClient:   fc,
 		PullRequestComments: fc.PullRequestComments[101],
 	}
 	handle(false, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", PluginName), fp)

--- a/pkg/prow/plugins/lifecycle/lifecycle.go
+++ b/pkg/prow/plugins/lifecycle/lifecycle.go
@@ -72,7 +72,7 @@ type lifecycleClient interface {
 }
 
 func lifecycleHandleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
-	gc := pc.GitHubClient
+	gc := pc.SCMProviderClient
 	log := pc.Logger
 	if err := handleReopen(gc, log, &e); err != nil {
 		return err

--- a/pkg/prow/plugins/owners-label/owners-label_test.go
+++ b/pkg/prow/plugins/owners-label/owners-label_test.go
@@ -176,12 +176,12 @@ func TestHandle(t *testing.T) {
 		for _, name := range tc.filesChanged {
 			changes = append(changes, &scm.Change{Path: name})
 		}
-		fakeScmClient, fghc := fake.NewDefault()
+		fakeScmClient, fspc := fake.NewDefault()
 		fakeClient := gitprovider.ToTestClient(fakeScmClient)
 
-		fghc.PullRequests[basicPR.Number] = &basicPR
-		fghc.PullRequestChanges[basicPR.Number] = changes
-		fghc.RepoLabelsExisting = tc.repoLabels
+		fspc.PullRequests[basicPR.Number] = &basicPR
+		fspc.PullRequestChanges[basicPR.Number] = changes
+		fspc.RepoLabelsExisting = tc.repoLabels
 
 		// Add initial labels
 		for _, label := range tc.prLabels {
@@ -205,9 +205,9 @@ func TestHandle(t *testing.T) {
 			expectLabels = []string{}
 		}
 		sort.Strings(expectLabels)
-		sort.Strings(fghc.PullRequestLabelsAdded)
-		if !reflect.DeepEqual(expectLabels, fghc.PullRequestLabelsAdded) {
-			t.Errorf("expected the labels %q to be added, but %q were added.", expectLabels, fghc.PullRequestLabelsAdded)
+		sort.Strings(fspc.PullRequestLabelsAdded)
+		if !reflect.DeepEqual(expectLabels, fspc.PullRequestLabelsAdded) {
+			t.Errorf("expected the labels %q to be added, but %q were added.", expectLabels, fspc.PullRequestLabelsAdded)
 		}
 
 	}

--- a/pkg/prow/plugins/shrug/shrug.go
+++ b/pkg/prow/plugins/shrug/shrug.go
@@ -67,7 +67,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-type githubClient interface {
+type scmProviderClient interface {
 	AddLabel(owner, repo string, number int, label string, pr bool) error
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 	RemoveLabel(owner, repo string, number int, label string, pr bool) error
@@ -75,10 +75,10 @@ type githubClient interface {
 }
 
 func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, &e)
+	return handle(pc.SCMProviderClient, pc.Logger, &e)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
+func handle(spc scmProviderClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {
 	if e.Action != scm.ActionCreate {
 		return nil
 	}
@@ -97,7 +97,7 @@ func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEve
 
 	// Only add the label if it doesn't have it yet.
 	hasShrug := false
-	issueLabels, err := gc.GetIssueLabels(org, repo, e.Number, e.IsPR)
+	issueLabels, err := spc.GetIssueLabels(org, repo, e.Number, e.IsPR)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get the labels on %s/%s#%d.", org, repo, e.Number)
 	}
@@ -111,13 +111,13 @@ func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEve
 		log.Info("Removing Shrug label.")
 		resp := "¯\\\\\\_(ツ)\\_/¯"
 		log.Infof("Commenting with \"%s\".", resp)
-		if err := gc.CreateComment(org, repo, e.Number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp)); err != nil {
+		if err := spc.CreateComment(org, repo, e.Number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp)); err != nil {
 			return fmt.Errorf("failed to comment on %s/%s#%d: %v", org, repo, e.Number, err)
 		}
-		return gc.RemoveLabel(org, repo, e.Number, labels.Shrug, e.IsPR)
+		return spc.RemoveLabel(org, repo, e.Number, labels.Shrug, e.IsPR)
 	} else if !hasShrug && wantShrug {
 		log.Info("Adding Shrug label.")
-		return gc.AddLabel(org, repo, e.Number, labels.Shrug, e.IsPR)
+		return spc.AddLabel(org, repo, e.Number, labels.Shrug, e.IsPR)
 	}
 	return nil
 }

--- a/pkg/prow/plugins/size/size_test.go
+++ b/pkg/prow/plugins/size/size_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/prow/plugins"
 )
 
-type ghc struct {
+type spc struct {
 	*testing.T
 	labels    map[scm.Label]bool
 	files     map[string][]byte
@@ -35,14 +35,14 @@ type ghc struct {
 	getFileErr, getPullRequestChangesErr error
 }
 
-func (c *ghc) AddLabel(_, _ string, _ int, label string, _ bool) error {
+func (c *spc) AddLabel(_, _ string, _ int, label string, _ bool) error {
 	c.T.Logf("AddLabel: %s", label)
 	c.labels[scm.Label{Name: label}] = true
 
 	return c.addLabelErr
 }
 
-func (c *ghc) RemoveLabel(_, _ string, _ int, label string, _ bool) error {
+func (c *spc) RemoveLabel(_, _ string, _ int, label string, _ bool) error {
 	c.T.Logf("RemoveLabel: %s", label)
 	for k := range c.labels {
 		if k.Name == label {
@@ -53,7 +53,7 @@ func (c *ghc) RemoveLabel(_, _ string, _ int, label string, _ bool) error {
 	return c.removeLabelErr
 }
 
-func (c *ghc) GetIssueLabels(_, _ string, _ int, _ bool) (ls []*scm.Label, err error) {
+func (c *spc) GetIssueLabels(_, _ string, _ int, _ bool) (ls []*scm.Label, err error) {
 	c.T.Log("GetIssueLabels")
 	for k, ok := range c.labels {
 		if ok {
@@ -66,12 +66,12 @@ func (c *ghc) GetIssueLabels(_, _ string, _ int, _ bool) (ls []*scm.Label, err e
 	return
 }
 
-func (c *ghc) GetFile(_, _, path, _ string) ([]byte, error) {
+func (c *spc) GetFile(_, _, path, _ string) ([]byte, error) {
 	c.T.Logf("GetFile: %s", path)
 	return c.files[path], c.getFileErr
 }
 
-func (c *ghc) GetPullRequestChanges(_, _ string, _ int) ([]*scm.Change, error) {
+func (c *spc) GetPullRequestChanges(_, _ string, _ int) ([]*scm.Change, error) {
 	c.T.Log("GetPullRequestChanges")
 	return c.prChanges, c.getPullRequestChangesErr
 }
@@ -115,7 +115,7 @@ func TestSizesOrDefault(t *testing.T) {
 func TestHandlePR(t *testing.T) {
 	cases := []struct {
 		name        string
-		client      *ghc
+		client      *spc
 		event       scm.PullRequestHook
 		err         error
 		sizes       plugins.Size
@@ -123,7 +123,7 @@ func TestHandlePR(t *testing.T) {
 	}{
 		{
 			name: "simple size/S, no .generated_files",
-			client: &ghc{
+			client: &spc{
 				labels:     map[scm.Label]bool{},
 				getFileErr: scm.ErrNotFound,
 				prChanges: []*scm.Change{
@@ -163,7 +163,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "simple size/M, with .generated_files",
-			client: &ghc{
+			client: &spc{
 				labels: map[scm.Label]bool{},
 				files: map[string][]byte{
 					".generated_files": []byte(`
@@ -223,7 +223,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "simple size/M, with .gitattributes",
-			client: &ghc{
+			client: &spc{
 				labels: map[scm.Label]bool{},
 				files: map[string][]byte{
 					".gitattributes": []byte(`
@@ -283,7 +283,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "simple size/XS, with .generated_files and paths-from-repo",
-			client: &ghc{
+			client: &spc{
 				labels: map[scm.Label]bool{},
 				files: map[string][]byte{
 					".generated_files": []byte(`
@@ -369,7 +369,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name:   "pr closed event",
-			client: &ghc{},
+			client: &spc{},
 			event: scm.PullRequestHook{
 				Action: scm.ActionClose,
 			},
@@ -378,7 +378,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "XS -> S transition",
-			client: &ghc{
+			client: &spc{
 				labels: map[scm.Label]bool{
 					{Name: "irrelevant"}: true,
 					{Name: "size/XS"}:    true,
@@ -468,7 +468,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "pull request reopened",
-			client: &ghc{
+			client: &spc{
 				labels:     map[scm.Label]bool{},
 				getFileErr: scm.ErrNotFound,
 				prChanges: []*scm.Change{
@@ -508,7 +508,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "pull request edited",
-			client: &ghc{
+			client: &spc{
 				labels:     map[scm.Label]bool{},
 				getFileErr: scm.ErrNotFound,
 				prChanges: []*scm.Change{
@@ -541,7 +541,7 @@ func TestHandlePR(t *testing.T) {
 		},
 		{
 			name: "different label constraints",
-			client: &ghc{
+			client: &spc{
 				labels:     map[scm.Label]bool{},
 				getFileErr: scm.ErrNotFound,
 				prChanges: []*scm.Change{

--- a/pkg/prow/plugins/skip/skip_test.go
+++ b/pkg/prow/plugins/skip/skip_test.go
@@ -297,7 +297,7 @@ func TestSkipStatus(t *testing.T) {
 			t.Fatalf("%s: could not set presubmit regexes: %v", test.name, err)
 		}
 
-		fghc := &fakegitprovider.FakeClient{
+		fspc := &fakegitprovider.FakeClient{
 			IssueComments: make(map[int][]*scm.Comment),
 			PullRequests: map[int]*scm.PullRequest{
 				test.event.Number: {
@@ -319,13 +319,13 @@ func TestSkipStatus(t *testing.T) {
 		}
 		l := logrus.WithField("plugin", pluginName)
 
-		if err := handle(fghc, l, test.event, test.presubmits, true); err != nil {
+		if err := handle(fspc, l, test.event, test.presubmits, true); err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 			continue
 		}
 
 		// Check that the correct statuses have been updated.
-		created := fghc.CreatedStatuses[test.sha]
+		created := fspc.CreatedStatuses[test.sha]
 		if len(test.expected) != len(created) {
 			t.Errorf("%s: status mismatch: expected:\n%+v\ngot:\n%+v", test.name, test.expected, created)
 			continue

--- a/pkg/prow/plugins/stage/stage.go
+++ b/pkg/prow/plugins/stage/stage.go
@@ -63,7 +63,7 @@ type stageClient interface {
 }
 
 func stageHandleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, &e)
+	return handle(pc.SCMProviderClient, pc.Logger, &e)
 }
 
 func handle(gc stageClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent) error {

--- a/pkg/prow/plugins/trigger/generic-comment_test.go
+++ b/pkg/prow/plugins/trigger/generic-comment_test.go
@@ -819,10 +819,10 @@ func TestHandleGenericComment(t *testing.T) {
 		fakeConfig := &config.Config{ProwConfig: config.ProwConfig{PlumberJobNamespace: "plumberJobs"}}
 		fakePlumberClient := fake.NewPlumber()
 		c := Client{
-			GitHubClient:  g,
-			PlumberClient: fakePlumberClient,
-			Config:        fakeConfig,
-			Logger:        logrus.WithField("plugin", PluginName),
+			SCMProviderClient: g,
+			PlumberClient:     fakePlumberClient,
+			Config:            fakeConfig,
+			Logger:            logrus.WithField("plugin", PluginName),
 		}
 		presubmits := tc.Presubmits
 		if presubmits == nil {

--- a/pkg/prow/plugins/trigger/pull-request_test.go
+++ b/pkg/prow/plugins/trigger/pull-request_test.go
@@ -278,10 +278,10 @@ func TestHandlePullRequest(t *testing.T) {
 		}
 		fakePlumberClient := fake.NewPlumber()
 		c := Client{
-			GitHubClient:  g,
-			PlumberClient: fakePlumberClient,
-			Config:        &config.Config{},
-			Logger:        logrus.WithField("plugin", PluginName),
+			SCMProviderClient: g,
+			PlumberClient:     fakePlumberClient,
+			Config:            &config.Config{},
+			Logger:            logrus.WithField("plugin", PluginName),
 		}
 
 		presubmits := map[string][]config.Presubmit{

--- a/pkg/prow/plugins/trigger/push_test.go
+++ b/pkg/prow/plugins/trigger/push_test.go
@@ -135,10 +135,10 @@ func TestHandlePE(t *testing.T) {
 		g := &fakegitprovider.FakeClient{}
 		fakePlumberClient := fake.NewPlumber()
 		c := Client{
-			GitHubClient:  g,
-			PlumberClient: fakePlumberClient,
-			Config:        &config.Config{ProwConfig: config.ProwConfig{PlumberJobNamespace: "plumberJobs"}},
-			Logger:        logrus.WithField("plugin", PluginName),
+			SCMProviderClient: g,
+			PlumberClient:     fakePlumberClient,
+			Config:            &config.Config{ProwConfig: config.ProwConfig{PlumberJobNamespace: "plumberJobs"}},
+			Logger:            logrus.WithField("plugin", PluginName),
 		}
 		postsubmits := map[string][]config.Postsubmit{
 			"org/repo": {

--- a/pkg/prow/plugins/trigger/trigger_test.go
+++ b/pkg/prow/plugins/trigger/trigger_test.go
@@ -328,14 +328,14 @@ func TestRunAndSkipJobs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			fakeGitHubClient := fakegitprovider.FakeClient{}
+			fakeSCMClient := fakegitprovider.FakeClient{}
 			fakePlumberClient := fake.NewPlumber()
 			fakePlumberClient.FailJobs = testCase.jobCreationErrs
 
 			client := Client{
-				GitHubClient:  &fakeGitHubClient,
-				PlumberClient: fakePlumberClient,
-				Logger:        logrus.WithField("testcase", testCase.name),
+				SCMProviderClient: &fakeSCMClient,
+				PlumberClient:     fakePlumberClient,
+				Logger:            logrus.WithField("testcase", testCase.name),
 			}
 
 			err := RunAndSkipJobs(client, pr, testCase.requestedJobs, testCase.skippedJobs, "event-guid", testCase.elideSkippedContexts)
@@ -346,7 +346,7 @@ func TestRunAndSkipJobs(t *testing.T) {
 				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 			}
 
-			if actual, expected := fakeGitHubClient.CreatedStatuses[pr.Head.Ref], testCase.expectedStatuses; !reflect.DeepEqual(actual, expected) {
+			if actual, expected := fakeSCMClient.CreatedStatuses[pr.Head.Ref], testCase.expectedStatuses; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: created incorrect statuses: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 
@@ -428,14 +428,14 @@ func TestRunRequested(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			fakeGitHubClient := fakegitprovider.FakeClient{}
+			fakeSCMClient := fakegitprovider.FakeClient{}
 			fakePlumberClient := fake.NewPlumber()
 			fakePlumberClient.FailJobs = testCase.jobCreationErrs
 
 			client := Client{
-				GitHubClient:  &fakeGitHubClient,
-				PlumberClient: fakePlumberClient,
-				Logger:        logrus.WithField("testcase", testCase.name),
+				SCMProviderClient: &fakeSCMClient,
+				PlumberClient:     fakePlumberClient,
+				Logger:            logrus.WithField("testcase", testCase.name),
 			}
 
 			err := runRequested(client, pr, testCase.requestedJobs, "event-guid")

--- a/pkg/prow/plugins/welcome/welcome.go
+++ b/pkg/prow/plugins/welcome/welcome.go
@@ -72,20 +72,20 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		nil
 }
 
-type githubClient interface {
+type scmProviderClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 	FindIssues(query, sort string, asc bool) ([]scm.Issue, error)
 }
 
 type client struct {
-	GitHubClient githubClient
-	Logger       *logrus.Entry
+	SCMProviderClient scmProviderClient
+	Logger            *logrus.Entry
 }
 
 func getClient(pc plugins.Agent) client {
 	return client{
-		GitHubClient: pc.GitHubClient,
-		Logger:       pc.Logger,
+		SCMProviderClient: pc.SCMProviderClient,
+		Logger:            pc.Logger,
 	}
 }
 
@@ -104,7 +104,7 @@ func handlePR(c client, pre scm.PullRequestHook, welcomeTemplate string) error {
 	repo := pre.PullRequest.Base.Repo.Name
 	user := pre.PullRequest.Author.Login
 	query := fmt.Sprintf("is:pr repo:%s/%s author:%s", org, repo, user)
-	issues, err := c.GitHubClient.FindIssues(query, "", false)
+	issues, err := c.SCMProviderClient.FindIssues(query, "", false)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func handlePR(c client, pre scm.PullRequestHook, welcomeTemplate string) error {
 		}
 
 		// actually post the comment
-		return c.GitHubClient.CreateComment(org, repo, pre.PullRequest.Number, true, msgBuffer.String())
+		return c.SCMProviderClient.CreateComment(org, repo, pre.PullRequest.Number, true, msgBuffer.String())
 	}
 
 	return nil

--- a/pkg/prow/plugins/welcome/welcome_test.go
+++ b/pkg/prow/plugins/welcome/welcome_test.go
@@ -191,8 +191,8 @@ func TestHandlePR(t *testing.T) {
 	}
 
 	c := client{
-		GitHubClient: fc,
-		Logger:       &logrus.Entry{},
+		SCMProviderClient: fc,
+		Logger:            &logrus.Entry{},
 	}
 	for _, tc := range testCases {
 		// clear out comments from the last test case

--- a/pkg/prow/plugins/yuks/yuks.go
+++ b/pkg/prow/plugins/yuks/yuks.go
@@ -61,7 +61,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	return pluginHelp, nil
 }
 
-type githubClient interface {
+type scmProviderClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
 }
 
@@ -99,10 +99,10 @@ func (url realJoke) readJoke() (string, error) {
 }
 
 func handleGenericComment(pc plugins.Agent, e gitprovider.GenericCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, &e, jokeURL)
+	return handle(pc.SCMProviderClient, pc.Logger, &e, jokeURL)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, j joker) error {
+func handle(spc scmProviderClient, log *logrus.Entry, e *gitprovider.GenericCommentEvent, j joker) error {
 	// Only consider new comments.
 	if e.Action != scm.ActionCreate {
 		return nil
@@ -123,7 +123,7 @@ func handle(gc githubClient, log *logrus.Entry, e *gitprovider.GenericCommentEve
 		}
 		if simple.MatchString(resp) {
 			log.Infof("Commenting with \"%s\".", resp)
-			return gc.CreateComment(org, repo, number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp))
+			return spc.CreateComment(org, repo, number, e.IsPR, plugins.FormatResponseRaw(e.Body, e.Link, e.Author.Login, resp))
 		}
 
 		log.Errorf("joke contains invalid characters: %v", resp)

--- a/pkg/prow/repoowners/repoowners_test.go
+++ b/pkg/prow/repoowners/repoowners_test.go
@@ -146,7 +146,7 @@ func getTestClient(
 
 	return &Client{
 			git:    git,
-			ghc:    &fakegitprovider.FakeClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}},
+			spc:    &fakegitprovider.FakeClient{Collaborators: []string{"cjwagner", "k8s-ci-robot", "alice", "bob", "carl", "mml", "maggie"}},
 			logger: logrus.WithField("client", "repoowners"),
 			cache:  make(map[string]cacheEntry),
 

--- a/pkg/tide/status_test.go
+++ b/pkg/tide/status_test.go
@@ -390,7 +390,7 @@ func TestSetStatuses(t *testing.T) {
 			t.Fatalf("Failed to get log output before testing: %v", err)
 		}
 
-		sc := &statusController{ghc: fc, config: ca.Config, logger: log}
+		sc := &statusController{spc: fc, config: ca.Config, logger: log}
 		sc.setStatuses([]PullRequest{pr}, pool, blockers.Blockers{})
 		if str, err := log.String(); err != nil {
 			t.Fatalf("For case %s: failed to get log output: %v", tc.name, err)

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -54,7 +54,7 @@ import (
 // For mocking out sleep during unit tests.
 var sleep = time.Sleep
 
-type prowJobClient interface {
+type plumberClient interface {
 	Create(*plumber.PipelineOptions, metapipeline.Client, scm.Repository) (*plumber.PipelineOptions, error)
 	List(opts metav1.ListOptions) (*plumber.PipelineOptionsList, error)
 }
@@ -81,7 +81,7 @@ type DefaultController struct {
 	logger        *logrus.Entry
 	config        config.Getter
 	spc           scmProviderClient
-	prowJobClient prowJobClient
+	plumberClient plumberClient
 	gc            git.Client
 	mpClient      metapipeline.Client
 	tektonClient  tektonclient.Interface
@@ -206,7 +206,7 @@ func init() {
 }
 
 // NewController makes a DefaultController out of the given clients.
-func NewController(spcSync, spcStatus *gitprovider.Client, prowJobClient prowJobClient, mpClient metapipeline.Client, tektonClient tektonclient.Interface, ns string, cfg config.Getter, gc git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*DefaultController, error) {
+func NewController(spcSync, spcStatus *gitprovider.Client, plumberClient plumberClient, mpClient metapipeline.Client, tektonClient tektonclient.Interface, ns string, cfg config.Getter, gc git.Client, maxRecordsPerPool int, opener io.Opener, historyURI, statusURI string, logger *logrus.Entry) (*DefaultController, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}
@@ -227,7 +227,7 @@ func NewController(spcSync, spcStatus *gitprovider.Client, prowJobClient prowJob
 	return &DefaultController{
 		logger:        logger.WithField("controller", "sync"),
 		spc:           spcSync,
-		prowJobClient: prowJobClient,
+		plumberClient: plumberClient,
 		mpClient:      mpClient,
 		tektonClient:  tektonClient,
 		ns:            ns,
@@ -325,12 +325,12 @@ func (c *DefaultController) Sync() error {
 	var err error
 	if len(prs) > 0 {
 		start := time.Now()
-		pjList, err := c.prowJobClient.List(metav1.ListOptions{})
+		pjList, err := c.plumberClient.List(metav1.ListOptions{})
 		if err != nil {
-			c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to list ProwJobs from the cluster.")
+			c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to list PipelineActivitys from the cluster.")
 			return err
 		}
-		c.logger.WithField("duration", time.Since(start).String()).Debug("Listed ProwJobs from the cluster.")
+		c.logger.WithField("duration", time.Since(start).String()).Debug("Listed PipelineActivitys from the cluster.")
 		pjs = pjList.Items
 
 		if label := c.config().Tide.BlockerLabel; label != "" {
@@ -481,7 +481,7 @@ func (c *DefaultController) initSubpoolData(sp *subpool) error {
 	var err error
 	sp.presubmits, err = c.presubmitsByPull(sp)
 	if err != nil {
-		return fmt.Errorf("error determining required presubmit prowjobs: %v", err)
+		return fmt.Errorf("error determining required presubmit PipelineActivitys: %v", err)
 	}
 	sp.cc, err = c.config().GetTideContextPolicy(sp.org, sp.repo, sp.branch)
 	if err != nil {
@@ -513,8 +513,8 @@ func filterSubpool(spc scmProviderClient, sp *subpool) *subpool {
 // - Have known merge conflicts.
 // - Have failing or missing status contexts.
 // - Have pending required status contexts that are not associated with a
-//   ProwJob. (This ensures that the 'tide' context indicates that the pending
-//   status is preventing merge. Required ProwJob statuses are allowed to be
+//   PipelineActivity. (This ensures that the 'tide' context indicates that the pending
+//   status is preventing merge. Required PipelineActivity statuses are allowed to be
 //   'pending' because this prevents kicking PRs from the pool when Tide is
 //   retesting them.)
 func filterPR(spc scmProviderClient, sp *subpool, pr *PullRequest) bool {
@@ -525,7 +525,7 @@ func filterPR(spc scmProviderClient, sp *subpool, pr *PullRequest) bool {
 		return true
 	}
 	// Filter out PRs with unsuccessful contexts unless the only unsuccessful
-	// contexts are pending required prowjobs.
+	// contexts are pending required PipelineActivitys.
 	contexts, err := headContexts(log, spc, pr)
 	if err != nil {
 		log.WithError(err).Error("Getting head contexts.")
@@ -783,7 +783,7 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 			log.WithError(err).Error("Error getting head contexts, solely using PJs for status")
 		}
 		// Accumulate the best result for each job (Passing > Pending > Failing/Unknown)
-		// We can ignore the baseSHA here because the subPool only contains ProwJobs with the correct baseSHA
+		// We can ignore the baseSHA here because the subPool only contains PipelineActivitys with the correct baseSHA
 		psStates := make(map[string]simpleState)
 		for _, pj := range pjs {
 			if pj.Spec.Type != plumber.PresubmitJob {
@@ -1147,9 +1147,9 @@ func (c *DefaultController) trigger(sp subpool, presubmits map[int][]config.Pres
 				Branch:    string(pr.BaseRef.Name),
 				Clone:     cloneURL,
 			}
-			if _, err := c.prowJobClient.Create(&pj, c.mpClient, repo); err != nil {
-				c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to create ProwJob on the cluster.")
-				return fmt.Errorf("failed to create a ProwJob for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
+			if _, err := c.plumberClient.Create(&pj, c.mpClient, repo); err != nil {
+				c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to create pipeline on the cluster.")
+				return fmt.Errorf("failed to create a pipeline for job: %q, PRs: %v: %v", spec.Job, prNumbers(prs), err)
 			}
 			sha := refs.BaseSHA
 			if len(refs.Pulls) > 0 {
@@ -1165,7 +1165,7 @@ func (c *DefaultController) trigger(sp subpool, presubmits map[int][]config.Pres
 				c.logger.WithField("duration", time.Since(start).String()).Debug("Failed to set pending status on triggered context.")
 				return errors.Wrapf(err, "Cannot update PR status on org %s repo %s sha %s for context %s", refs.Org, refs.Repo, sha, statusInput.Label)
 			}
-			c.logger.WithField("duration", time.Since(start).String()).Debug("Created ProwJob on the cluster.")
+			c.logger.WithField("duration", time.Since(start).String()).Debug("Created pipeline on the cluster.")
 		}
 	}
 	return nil
@@ -1406,7 +1406,7 @@ type subpool struct {
 	// sha is the baseSHA for this subpool
 	sha string
 
-	// pjs contains all ProwJobs of type Presubmit or Batch
+	// pjs contains all PipelineActivitys of type Presubmit or Batch
 	// that have the same baseSHA as the subpool
 	pjs []plumber.PipelineOptions
 	prs []PullRequest
@@ -1422,7 +1422,7 @@ func poolKey(org, repo, branch string) string {
 }
 
 // dividePool splits up the list of pull requests and prow jobs into a group
-// per repo and branch. It only keeps ProwJobs that match the latest branch.
+// per repo and branch. It only keeps PipelineActivitys that match the latest branch.
 func (c *DefaultController) dividePool(pool map[string]PullRequest, pjs []plumber.PipelineOptions) (map[string]*subpool, error) {
 	sps := make(map[string]*subpool)
 	for _, pr := range pool {

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -716,7 +716,7 @@ func TestDividePool(t *testing.T) {
 		refs: map[string]string{"k/t-i heads/master": "123"},
 	}
 	c := &DefaultController{
-		ghc:    fc,
+		spc:    fc,
 		logger: logrus.WithField("component", "tide"),
 	}
 	pulls := make(map[string]PullRequest)
@@ -1368,7 +1368,7 @@ func TestTakeAction(t *testing.T) {
 				logger:        logrus.WithField("controller", "tide"),
 				gc:            gc,
 				config:        ca.Config,
-				ghc:           &fgc,
+				spc:           &fgc,
 				prowJobClient: fakePlumberClient,
 			}
 			var batchPending []PullRequest
@@ -1660,7 +1660,7 @@ func TestSync(t *testing.T) {
 		}
 		sc := &statusController{
 			logger:         logrus.WithField("controller", "status-update"),
-			ghc:            fgc,
+			spc:            fgc,
 			config:         ca.Config,
 			newPoolPending: make(chan bool, 1),
 			shutDown:       make(chan bool),
@@ -1669,14 +1669,14 @@ func TestSync(t *testing.T) {
 		defer sc.shutdown()
 		c := &DefaultController{
 			config:        ca.Config,
-			ghc:           fgc,
+			spc:           fgc,
 			prowJobClient: fakePlumberClient,
 			tektonClient:  fakeTektonClient,
 			ns:            "jx",
 			logger:        logrus.WithField("controller", "sync"),
 			sc:            sc,
 			changedFiles: &changedFilesAgent{
-				ghc:             fgc,
+				spc:             fgc,
 				nextChangeCache: make(map[changeCacheKey][]string),
 			},
 			History: hist,
@@ -2381,9 +2381,9 @@ func TestPresubmitsByPull(t *testing.T) {
 		}
 		c := &DefaultController{
 			config: cfgAgent.Config,
-			ghc:    &fgc{},
+			spc:    &fgc{},
 			changedFiles: &changedFilesAgent{
-				ghc:             &fgc{},
+				spc:             &fgc{},
 				changeCache:     tc.initialChangeCache,
 				nextChangeCache: make(map[changeCacheKey][]string),
 			},
@@ -2495,7 +2495,7 @@ func TestPrepareMergeDetails(t *testing.T) {
 		cfgAgent.Set(cfg)
 		c := &DefaultController{
 			config: cfgAgent.Config,
-			ghc:    &fgc{},
+			spc:    &fgc{},
 			logger: logrus.WithField("component", "tide"),
 		}
 

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -81,7 +81,7 @@ func TestAccumulateBatch(t *testing.T) {
 		number int
 		sha    string
 	}
-	type prowjob struct {
+	type activity struct {
 		prs   []pull
 		job   string
 		state plumber.PipelineState
@@ -90,7 +90,7 @@ func TestAccumulateBatch(t *testing.T) {
 		name             string
 		presubmits       map[int][]config.Presubmit
 		pulls            []pull
-		prowJobs         []prowjob
+		activities       []activity
 		combinedContexts map[string]map[string]commitStatus
 
 		merges  []int
@@ -105,21 +105,21 @@ func TestAccumulateBatch(t *testing.T) {
 				1: {{Reporter: config.Reporter{Context: "foo"}}},
 				2: {{Reporter: config.Reporter{Context: "foo"}}},
 			},
-			pulls:    []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}}},
-			pending:  true,
+			pulls:      []pull{{1, "a"}, {2, "b"}},
+			activities: []activity{{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}}},
+			pending:    true,
 		},
 		{
 			name:       "pending batch missing presubmits is ignored",
 			presubmits: map[int][]config.Presubmit{1: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs:   []prowjob{{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}}},
+			activities: []activity{{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}}},
 		},
 		{
 			name:       "batch pending, successful previous run",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}}},
@@ -134,7 +134,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "successful run",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{2, "b"}}},
@@ -145,7 +145,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "successful run, multiple PRs",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -156,7 +156,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "failure in run but overridden, multiple PRs",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.FailureState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -175,7 +175,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "successful run, failures in past",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -189,7 +189,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "failures",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: jobSet},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.FailureState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.FailureState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -200,7 +200,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "missing job required by one PR",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -210,7 +210,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "successful run with PR that requires additional job",
 			presubmits: map[int][]config.Presubmit{1: jobSet, 2: append(jobSet, config.Presubmit{Reporter: config.Reporter{Context: "boo"}})},
 			pulls:      []pull{{1, "a"}, {2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: plumber.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
@@ -227,7 +227,7 @@ func TestAccumulateBatch(t *testing.T) {
 			name:       "pending batch with PR that left pool, successful previous run",
 			presubmits: map[int][]config.Presubmit{2: jobSet},
 			pulls:      []pull{{2, "b"}},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{job: "foo", state: plumber.PendingState, prs: []pull{{1, "a"}}},
 				{job: "foo", state: plumber.SuccessState, prs: []pull{{2, "b"}}},
 				{job: "bar", state: plumber.SuccessState, prs: []pull{{2, "b"}}},
@@ -249,7 +249,7 @@ func TestAccumulateBatch(t *testing.T) {
 				pulls = append(pulls, pr)
 			}
 			var pjs []plumber.PipelineOptions
-			for _, pj := range test.prowJobs {
+			for _, pj := range test.activities {
 				npj := plumber.PipelineOptions{
 					Spec: plumber.PipelineOptionsSpec{
 						Job:     pj.job,
@@ -289,7 +289,7 @@ func TestAccumulate(t *testing.T) {
 			},
 		},
 	}
-	type prowjob struct {
+	type activity struct {
 		prNumber int
 		job      string
 		state    plumber.PipelineState
@@ -299,7 +299,7 @@ func TestAccumulate(t *testing.T) {
 		name             string
 		presubmits       map[int][]config.Presubmit
 		pullRequests     map[int]string
-		prowJobs         []prowjob
+		activities       []activity
 		combinedContexts map[string]map[string]commitStatus
 
 		successes []int
@@ -318,7 +318,7 @@ func TestAccumulate(t *testing.T) {
 				6: jobSet,
 				7: jobSet,
 			},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{2, "job1", plumber.PendingState, "sha2"},
 				{2, "job2", plumber.FailureState, "sha2"},
 				{3, "job1", plumber.PendingState, "sha3"},
@@ -358,7 +358,7 @@ func TestAccumulate(t *testing.T) {
 					{Reporter: config.Reporter{Context: "job4"}},
 				},
 			},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{7, "job1", plumber.SuccessState, ""},
 				{7, "job2", plumber.FailureState, ""},
 				{7, "job3", plumber.FailureState, ""},
@@ -385,7 +385,7 @@ func TestAccumulate(t *testing.T) {
 					{Reporter: config.Reporter{Context: "job4"}},
 				},
 			},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{7, "job1", plumber.FailureState, ""},
 				{7, "job2", plumber.FailureState, ""},
 				{7, "job3", plumber.FailureState, ""},
@@ -412,7 +412,7 @@ func TestAccumulate(t *testing.T) {
 					{Reporter: config.Reporter{Context: "job4"}},
 				},
 			},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{7, "job1", plumber.SuccessState, ""},
 				{7, "job2", plumber.FailureState, ""},
 				{7, "job3", plumber.FailureState, ""},
@@ -440,7 +440,7 @@ func TestAccumulate(t *testing.T) {
 					{Reporter: config.Reporter{Context: "job4"}},
 				},
 			},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{7, "job1", plumber.SuccessState, ""},
 				{7, "job2", plumber.FailureState, ""},
 				{7, "job3", plumber.FailureState, ""},
@@ -465,7 +465,7 @@ func TestAccumulate(t *testing.T) {
 				},
 			},
 			pullRequests: map[int]string{7: "new", 8: "new"},
-			prowJobs: []prowjob{
+			activities: []activity{
 				{7, "job1", plumber.SuccessState, "old"},
 				{7, "job1", plumber.FailureState, "new"},
 				{8, "job1", plumber.FailureState, "old"},
@@ -479,7 +479,7 @@ func TestAccumulate(t *testing.T) {
 		{
 			name:         "two PRs, no jobs, all success",
 			pullRequests: map[int]string{7: "new", 8: "new"},
-			prowJobs:     []prowjob{},
+			activities:   []activity{},
 
 			successes: []int{8, 7},
 			pendings:  []int{},
@@ -498,7 +498,7 @@ func TestAccumulate(t *testing.T) {
 				)
 			}
 			var pjs []plumber.PipelineOptions
-			for _, pj := range test.prowJobs {
+			for _, pj := range test.activities {
 				pjs = append(pjs, plumber.PipelineOptions{
 					Spec: plumber.PipelineOptionsSpec{
 						Job:     pj.job,
@@ -1369,7 +1369,7 @@ func TestTakeAction(t *testing.T) {
 				gc:            gc,
 				config:        ca.Config,
 				spc:           &fgc,
-				prowJobClient: fakePlumberClient,
+				plumberClient: fakePlumberClient,
 			}
 			var batchPending []PullRequest
 			if tc.batchPending {
@@ -1386,15 +1386,15 @@ func TestTakeAction(t *testing.T) {
 
 			numCreated := 0
 			var batchJobs []*plumber.PipelineOptions
-			for _, prowJob := range fakePlumberClient.Pipelines {
-				pjSha := prowJob.Spec.Refs.Pulls[0].SHA
-				if scm.StatePending.String() != fgc.combinedStatus[pjSha][prowJob.Spec.Context].status {
-					t.Errorf("Status not set to %s for context %s, is %s instead", scm.StatePending.String(), prowJob.Spec.Context,
-						fgc.combinedStatus[pjSha][prowJob.Spec.Context].status)
+			for _, activity := range fakePlumberClient.Pipelines {
+				pjSha := activity.Spec.Refs.Pulls[0].SHA
+				if scm.StatePending.String() != fgc.combinedStatus[pjSha][activity.Spec.Context].status {
+					t.Errorf("Status not set to %s for context %s, is %s instead", scm.StatePending.String(), activity.Spec.Context,
+						fgc.combinedStatus[pjSha][activity.Spec.Context].status)
 				}
 				numCreated++
-				if prowJob.Spec.Type == plumber.BatchJob {
-					batchJobs = append(batchJobs, prowJob)
+				if activity.Spec.Type == plumber.BatchJob {
+					batchJobs = append(batchJobs, activity)
 				}
 			}
 			if tc.triggered != numCreated {
@@ -1670,7 +1670,7 @@ func TestSync(t *testing.T) {
 		c := &DefaultController{
 			config:        ca.Config,
 			spc:           fgc,
-			prowJobClient: fakePlumberClient,
+			plumberClient: fakePlumberClient,
 			tektonClient:  fakeTektonClient,
 			ns:            "jx",
 			logger:        logrus.WithField("controller", "sync"),

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -214,10 +214,10 @@ func (o *Options) handleWebHookRequests(w http.ResponseWriter, r *http.Request) 
 	})
 
 	o.server.ClientAgent = &plugins.ClientAgent{
-		BotName:          o.GetBotName(),
-		GitHubClient:     scmClient,
-		KubernetesClient: kubeClient,
-		GitClient:        gitClient,
+		BotName:           o.GetBotName(),
+		SCMProviderClient: scmClient,
+		KubernetesClient:  kubeClient,
+		GitClient:         gitClient,
 	}
 	l, output, err := o.ProcessWebHook(logrus.WithField("Webhook", webhook.Kind()), webhook)
 	if err != nil {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -92,10 +92,10 @@ func (suite *WebhookTestSuite) SetupSuite() {
 			ConfigAgent: configAgent,
 			Plugins:     pluginAgent,
 			ClientAgent: &plugins.ClientAgent{
-				BotName:          options.GetBotName(),
-				GitHubClient:     scmClient,
-				KubernetesClient: kubeClient,
-				GitClient:        gitClient,
+				BotName:           options.GetBotName(),
+				SCMProviderClient: scmClient,
+				KubernetesClient:  kubeClient,
+				GitClient:         gitClient,
 			},
 		},
 	}


### PR DESCRIPTION
It just gets confusing, since what we've been calling the "github client" is actually the "scm provider client", and what gets referred to in Tide as the "prowjob client" is also called the "plumber client" in some places, and is definitely not a prowjob client. So let's make things a bit clearer and rename `GitHubClient` to `SCMProviderClient`, `githubClient` to `scmProviderClient`, `prowJobClient` to `plumberClient`, and variables/parameters like `ghc githubClient` to `spc scmProviderClient`, etc.

This doesn't really matter, per se, but it helps with the understandability a bit.