### PR TITLE
fix: allow the default jx image to be configured via helm

### DIFF
--- a/bdd/values.yaml.template
+++ b/bdd/values.yaml.template
@@ -11,6 +11,9 @@ tide:
     tag: $VERSION
     pullPolicy: IfNotPresent
 
+env:
+  JX_DEFAULT_IMAGE: ""
+
 vault:
 {{- if eq .Requirements.secretStorage "vault" }}
   enabled: true

--- a/charts/lighthouse/templates/deployment.yaml
+++ b/charts/lighthouse/templates/deployment.yaml
@@ -55,8 +55,8 @@ spec:
         - name: "JX_LOG_FORMAT"
           value: "json"
 {{- range $pkey, $pval := .Values.env }}
-        - name: {{ $pkey }}
-          value: {{ quote $pval }}
+          - name: {{ $pkey }}
+            value: {{ quote $pval }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/charts/lighthouse/templates/deployment.yaml
+++ b/charts/lighthouse/templates/deployment.yaml
@@ -54,9 +54,11 @@ spec:
               key: hmac
         - name: "JX_LOG_FORMAT"
           value: "json"
+{{- if hasKey .Values "env"}}
 {{- range $pkey, $pval := .Values.env }}
-          - name: {{ $pkey }}
-            value: {{ quote $pval }}
+        - name: {{ $pkey }}
+          value: {{ quote $pval }}
+{{- end }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -21,6 +21,7 @@ image:
 
 # define environment variables here as a map of key: value
 env:
+  JX_DEFAULT_IMAGE: ""
 
 # enable this flag to use knative serve to deploy the app
 knativeDeploy: false

--- a/pkg/plumber/plumber.go
+++ b/pkg/plumber/plumber.go
@@ -85,7 +85,7 @@ func (b *PipelineBuilder) Create(request *PipelineOptions, metapipelineClient me
 		// Also not finding an equivalent to labels from the PipelineRunRequest
 		ServiceAccount: sa,
 		// I believe we can use an empty string default image?
-		DefaultImage: "",
+		DefaultImage: os.Getenv("JX_DEFAULT_IMAGE"),
 		EnvVariables: spec.GetEnvVars(),
 	}
 


### PR DESCRIPTION
when using istio with helm 3 and lighthouse we need a way to use a different default image in meta pipeline client (as we need an image with helm 3 etc) so lets add a simple way to override the value via an environment variable.

this PR also fixes a bug in the indentation of allowing additional environment variables to be passed into the lighthouse `Deployment`