### PR TITLE
chore: Remove app lifecycle tests

### DIFF
--- a/bdd/ghe/ci.sh
+++ b/bdd/ghe/ci.sh
@@ -85,10 +85,8 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-quickstart-golang-http \
-    --tests test-lighthouse \
-    --tests test-app-lifecycle
-
+    --tests test-create-spring \
+    --tests test-lighthouse
 
 bdd_result=$?
 if [[ $bdd_result != 0 ]]; then

--- a/bdd/github/ci.sh
+++ b/bdd/github/ci.sh
@@ -85,8 +85,7 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests test-create-spring \
-    --tests test-lighthouse \
-    --tests test-app-lifecycle
+    --tests test-lighthouse
 
 bdd_result=$?
 if [[ $bdd_result != 0 ]]; then


### PR DESCRIPTION
These are actually redundant now that we have `test-lighthouse`. And
let's use `test-create-spring` because we want to get the merge all
the way to prod.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>