### PR TITLE
fix: Don't recreate the metapipeline client for each GHA tide sync

### DIFF
--- a/pkg/tide/githubapp/factory.go
+++ b/pkg/tide/githubapp/factory.go
@@ -17,9 +17,14 @@ import (
 // NewTideController creates a new controller; either regular or a GitHub App flavour
 // depending on the $GITHUB_APP_SECRET_DIR environment variable
 func NewTideController(configAgent *config.Agent, botName string, gitKind string, gitToken string, serverURL string, maxRecordsPerPool int, opener io.Opener, historyURI string, statusURI string) (tide.Controller, error) {
+	clientFactory := jxfactory.NewFactory()
+	mpClient, err := plumber.NewMetaPipelineClient(clientFactory)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting Kubernetes client.")
+	}
 	githubAppSecretDir := util.GetGitHubAppSecretDir()
 	if githubAppSecretDir != "" {
-		return NewGitHubAppTideController(githubAppSecretDir, configAgent, botName, gitKind, maxRecordsPerPool, opener, historyURI, statusURI)
+		return NewGitHubAppTideController(githubAppSecretDir, configAgent, mpClient, botName, gitKind, maxRecordsPerPool, opener, historyURI, statusURI)
 	}
 
 	scmClient, err := factory.NewClient(gitKind, serverURL, "")
@@ -43,11 +48,6 @@ func NewTideController(configAgent *config.Agent, botName string, gitKind string
 	plumberClient, err := plumber.NewPlumber(jxClient, ns)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting Plumber client.")
-	}
-	clientFactory := jxfactory.NewFactory()
-	mpClient, err := plumber.NewMetaPipelineClient(clientFactory)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error getting Kubernetes client.")
 	}
 	c, err := tide.NewController(gitproviderClient, gitproviderClient, plumberClient, mpClient, tektonClient, ns, configAgent.Config, gitClient, maxRecordsPerPool, opener, historyURI, statusURI, nil)
 	return c, err


### PR DESCRIPTION
This ends up leaving a tmp directory with a clone of the version stream around for each Tide sync, which eventually overwhelms things and causes git operations to fail. There's no reason not to just create it once and reuse it.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>