### PR TITLE
fix: Change default keeper status label and allow overriding

### DIFF
--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -75,6 +75,8 @@ spec:
 {{- end }}
         - name: "JX_LOG_FORMAT"
           value: "{{ .Values.logFormat }}"
+        - name: "LIGHTHOUSE_KEEPER_STATUS_CONTEXT_LABEL"
+          value: "{{ .Values.keeper.statusContextLabel}}"
 {{- if hasKey .Values "env" }}
 {{- range $pkey, $pval := .Values.keeper.env }}
         - name: {{ $pkey }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -81,6 +81,7 @@ foghorn:
   reportURLBase: ""
 
 keeper:
+  statusContextLabel: "Lighthouse Merge Status"
   replicaCount: 1
   livenessProbe:
     initialDelaySeconds: 120

--- a/pkg/keeper/keeper.go
+++ b/pkg/keeper/keeper.go
@@ -614,7 +614,7 @@ func isPassingTests(log *logrus.Entry, spc scmProviderClient, pr PullRequest, cc
 func unsuccessfulContexts(contexts []Context, cc contextChecker, log *logrus.Entry) []Context {
 	var failed []Context
 	for _, ctx := range contexts {
-		if string(ctx.Context) == statusContext {
+		if string(ctx.Context) == GetStatusContextLabel() {
 			continue
 		}
 		if cc.IsOptional(string(ctx.Context)) {

--- a/pkg/keeper/status_test.go
+++ b/pkg/keeper/status_test.go
@@ -137,7 +137,7 @@ func TestExpectedStatus(t *testing.T) {
 			name:      "only failed keeper context",
 			labels:    neededLabels,
 			milestone: "v1.0",
-			contexts:  []Context{{Context: githubql.String(statusContext), State: githubql.StatusStateError}},
+			contexts:  []Context{{Context: githubql.String(GetStatusContextLabel()), State: githubql.StatusStateError}},
 			inPool:    false,
 
 			state: scmprovider.StatusPending,
@@ -369,7 +369,7 @@ func TestSetStatuses(t *testing.T) {
 		if tc.hasContext {
 			pr.Commits.Nodes[0].Commit.Status.Contexts = []Context{
 				{
-					Context:     githubql.String(statusContext),
+					Context:     githubql.String(GetStatusContextLabel()),
 					State:       tc.state,
 					Description: githubql.String(tc.desc),
 				},


### PR DESCRIPTION
If the new `LIGHTHOUSE_KEEPER_STATUS_CONTEXT_LABEL` env var isn't set, it'll still be `keeper`, but if that is set, it'll be used instead. We'll now default it to `Lighthouse Merge Status` in the chart, but it can be overriden via the `keeper.statusContextLabel` value.

fixes #656

