### PR TITLE
fix: Keeper needs permissions to create lighthouse jobs

### DIFF
--- a/charts/lighthouse/templates/keeper-role.yaml
+++ b/charts/lighthouse/templates/keeper-role.yaml
@@ -48,14 +48,22 @@ rules:
     resources:
       - lighthousejobs
     verbs:
-      - get
+      - create
+      - delete
       - list
+      - update
+      - get
       - watch
+      - patch
   - apiGroups:
       - lighthouse.jenkins.io
     resources:
       - lighthousejobs/status
     verbs:
-      - get
+      - create
+      - delete
       - list
+      - update
+      - get
       - watch
+      - patch


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>