### PR TITLE
fix: Update status immediately after creating pipeline

### DIFF
--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -110,13 +110,14 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldBuild: false,
 		},
 		{
-			name:        "accept /test from non-trusted member if PR author is trusted",
-			Author:      "untrusted-member",
-			PRAuthor:    "trusted-member",
-			Body:        "/test all",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
+			name:         "accept /test from non-trusted member if PR author is trusted",
+			Author:       "untrusted-member",
+			PRAuthor:     "trusted-member",
+			Body:         "/test all",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
 		},
 		{
 			name:        "reject /test from non-trusted member when PR author is untrusted",
@@ -130,12 +131,13 @@ func TestHandleGenericComment(t *testing.T) {
 		{
 			name: `Non-trusted member after "/ok-to-test".`,
 
-			Author:      "untrusted-member",
-			Body:        "/test all",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
-			IssueLabels: issueLabels(labels.OkToTest),
+			Author:       "untrusted-member",
+			Body:         "/test all",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
+			IssueLabels:  issueLabels(labels.OkToTest),
 		},
 		{
 			name: `Non-trusted member after "/ok-to-test", needs-ok-to-test label wasn't deleted.`,
@@ -145,6 +147,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:         "open",
 			IsPR:          true,
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			IssueLabels:   issueLabels(labels.NeedsOkToTest, labels.OkToTest),
 			RemovedLabels: issueLabels(labels.NeedsOkToTest),
 		},
@@ -161,22 +164,24 @@ func TestHandleGenericComment(t *testing.T) {
 		{
 			name: "Trusted member's ok to test",
 
-			Author:      "trusted-member",
-			Body:        "looks great, thanks!\n/ok-to-test",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
-			AddedLabels: issueLabels(labels.OkToTest),
+			Author:       "trusted-member",
+			Body:         "looks great, thanks!\n/ok-to-test",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
+			AddedLabels:  issueLabels(labels.OkToTest),
 		},
 		{
 			name: "Trusted member's ok to test, trailing space.",
 
-			Author:      "trusted-member",
-			Body:        "looks great, thanks!\n/ok-to-test \r",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
-			AddedLabels: issueLabels(labels.OkToTest),
+			Author:       "trusted-member",
+			Body:         "looks great, thanks!\n/ok-to-test \r",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
+			AddedLabels:  issueLabels(labels.OkToTest),
 		},
 		{
 			name: "Trusted member's not ok to test.",
@@ -190,11 +195,12 @@ func TestHandleGenericComment(t *testing.T) {
 		{
 			name: "Trusted member's test this.",
 
-			Author:      "trusted-member",
-			Body:        "/test all",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
+			Author:       "trusted-member",
+			Body:         "/test all",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
 		},
 		{
 			name: "Wrong branch.",
@@ -355,6 +361,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			StartsExactly: "pull-jab",
 		},
 		{
@@ -381,6 +388,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			StartsExactly: "pull-jib",
 		},
 		{
@@ -407,6 +415,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			StartsExactly: "pull-jub",
 		},
 		{
@@ -486,6 +495,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			StartsExactly: "pull-jab",
 			IssueLabels:   issueLabels(labels.NeedsOkToTest),
 			AddedLabels:   issueLabels(labels.OkToTest),
@@ -702,6 +712,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
+			ShouldReport:  true,
 			StartsExactly: "pull-jub",
 		},
 		{
@@ -756,13 +767,14 @@ func TestHandleGenericComment(t *testing.T) {
 			ShouldReport:         false,
 		},
 		{
-			name:        "accept /test all from trusted user",
-			Author:      "trusted-member",
-			PRAuthor:    "trusted-member",
-			Body:        "/test all",
-			State:       "open",
-			IsPR:        true,
-			ShouldBuild: true,
+			name:         "accept /test all from trusted user",
+			Author:       "trusted-member",
+			PRAuthor:     "trusted-member",
+			Body:         "/test all",
+			State:        "open",
+			IsPR:         true,
+			ShouldBuild:  true,
+			ShouldReport: true,
 		},
 		{
 			name:        `Non-trusted member after "/lgtm" and "/approve"`,
@@ -776,119 +788,121 @@ func TestHandleGenericComment(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		if tc.Branch == "" {
-			tc.Branch = "master"
-		}
-		g := &fake2.SCMClient{
-			CreatedStatuses:     map[string][]*scm.StatusInput{},
-			IssueComments:       map[int][]*scm.Comment{},
-			PullRequestComments: map[int][]*scm.Comment{},
-			OrgMembers:          map[string][]string{"org": {"trusted-member"}},
-			PullRequests: map[int]*scm.PullRequest{
-				0: {
-					Author: scm.User{Login: tc.PRAuthor},
-					Number: 0,
-					Head: scm.PullRequestBranch{
-						Sha: "cafe",
-					},
-					Base: scm.PullRequestBranch{
-						Ref: tc.Branch,
-						Repo: scm.Repository{
-							Namespace: "org",
-							Name:      "repo",
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.Branch == "" {
+				tc.Branch = "master"
+			}
+			g := &fake2.SCMClient{
+				CreatedStatuses:     map[string][]*scm.StatusInput{},
+				IssueComments:       map[int][]*scm.Comment{},
+				PullRequestComments: map[int][]*scm.Comment{},
+				OrgMembers:          map[string][]string{"org": {"trusted-member"}},
+				PullRequests: map[int]*scm.PullRequest{
+					0: {
+						Author: scm.User{Login: tc.PRAuthor},
+						Number: 0,
+						Head: scm.PullRequestBranch{
+							Sha: "cafe",
+						},
+						Base: scm.PullRequestBranch{
+							Ref: tc.Branch,
+							Repo: scm.Repository{
+								Namespace: "org",
+								Name:      "repo",
+							},
 						},
 					},
 				},
-			},
-			PullRequestChanges: map[int][]*scm.Change{0: {{Path: "CHANGED"}}},
-			CombinedStatuses: map[string]*scm.CombinedStatus{
-				"cafe": {
-					Statuses: []*scm.Status{
-						{State: scm.StatePending, Label: "pull-job"},
-						{State: scm.StateFailure, Label: "pull-jib"},
-						{State: scm.StateSuccess, Label: "pull-jub"},
-					},
-				},
-			},
-		}
-		if tc.IsPR {
-			g.PullRequestLabelsExisting = tc.IssueLabels
-		} else {
-			g.IssueLabelsExisting = tc.IssueLabels
-		}
-		fakeConfig := &config.Config{ProwConfig: config.ProwConfig{LighthouseJobNamespace: "lighthouseJobs"}}
-		fakeLauncher := fake.NewLauncher()
-		c := Client{
-			SCMProviderClient: g,
-			LauncherClient:    fakeLauncher,
-			Config:            fakeConfig,
-			Logger:            logrus.WithField("plugin", PluginName),
-		}
-		presubmits := tc.Presubmits
-		if presubmits == nil {
-			presubmits = map[string][]config.Presubmit{
-				"org/repo": {
-					{
-						JobBase: config.JobBase{
-							Name: "job",
+				PullRequestChanges: map[int][]*scm.Change{0: {{Path: "CHANGED"}}},
+				CombinedStatuses: map[string]*scm.CombinedStatus{
+					"cafe": {
+						Statuses: []*scm.Status{
+							{State: scm.StatePending, Label: "pull-job"},
+							{State: scm.StateFailure, Label: "pull-jib"},
+							{State: scm.StateSuccess, Label: "pull-jub"},
 						},
-						AlwaysRun: true,
-						Reporter: config.Reporter{
-							Context: "pull-job",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
-						RerunCommand: `/test job`,
-						Brancher:     config.Brancher{Branches: []string{"master"}},
-					},
-					{
-						JobBase: config.JobBase{
-							Name: "jib",
-						},
-						AlwaysRun: false,
-						Reporter: config.Reporter{
-							Context: "pull-jib",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
-						RerunCommand: `/test jib`,
 					},
 				},
 			}
-		}
-		if err := c.Config.SetPresubmits(presubmits); err != nil {
-			t.Fatalf("%s: failed to set presubmits: %v", tc.name, err)
-		}
+			if tc.IsPR {
+				g.PullRequestLabelsExisting = tc.IssueLabels
+			} else {
+				g.IssueLabelsExisting = tc.IssueLabels
+			}
+			fakeConfig := &config.Config{ProwConfig: config.ProwConfig{LighthouseJobNamespace: "lighthouseJobs"}}
+			fakeLauncher := fake.NewLauncher()
+			c := Client{
+				SCMProviderClient: g,
+				LauncherClient:    fakeLauncher,
+				Config:            fakeConfig,
+				Logger:            logrus.WithField("plugin", PluginName),
+			}
+			presubmits := tc.Presubmits
+			if presubmits == nil {
+				presubmits = map[string][]config.Presubmit{
+					"org/repo": {
+						{
+							JobBase: config.JobBase{
+								Name: "job",
+							},
+							AlwaysRun: true,
+							Reporter: config.Reporter{
+								Context: "pull-job",
+							},
+							Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
+							RerunCommand: `/test job`,
+							Brancher:     config.Brancher{Branches: []string{"master"}},
+						},
+						{
+							JobBase: config.JobBase{
+								Name: "jib",
+							},
+							AlwaysRun: false,
+							Reporter: config.Reporter{
+								Context: "pull-jib",
+							},
+							Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+							RerunCommand: `/test jib`,
+						},
+					},
+				}
+			}
+			if err := c.Config.SetPresubmits(presubmits); err != nil {
+				t.Fatalf("%s: failed to set presubmits: %v", tc.name, err)
+			}
 
-		event := scmprovider.GenericCommentEvent{
-			Action: scm.ActionCreate,
-			Repo: scm.Repository{
-				Namespace: "org",
-				Name:      "repo",
-				FullName:  "org/repo",
-			},
-			Body:        tc.Body,
-			Author:      scm.User{Login: tc.Author},
-			IssueAuthor: scm.User{Login: tc.PRAuthor},
-			IssueState:  tc.State,
-			IsPR:        tc.IsPR,
-		}
+			event := scmprovider.GenericCommentEvent{
+				Action: scm.ActionCreate,
+				Repo: scm.Repository{
+					Namespace: "org",
+					Name:      "repo",
+					FullName:  "org/repo",
+				},
+				Body:        tc.Body,
+				Author:      scm.User{Login: tc.Author},
+				IssueAuthor: scm.User{Login: tc.PRAuthor},
+				IssueState:  tc.State,
+				IsPR:        tc.IsPR,
+			}
 
-		trigger := &plugins.Trigger{
-			IgnoreOkToTest:       tc.IgnoreOkToTest,
-			ElideSkippedContexts: tc.ElideSkippedContexts,
-		}
+			trigger := &plugins.Trigger{
+				IgnoreOkToTest:       tc.IgnoreOkToTest,
+				ElideSkippedContexts: tc.ElideSkippedContexts,
+			}
 
-		log.Printf("running case %s", tc.name)
-		// In some cases handleGenericComment can be called twice for the same event.
-		// For instance on Issue/PR creation and modification.
-		// Let's call it twice to ensure idempotency.
-		if err := handleGenericComment(c, trigger, event); err != nil {
-			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
-		}
-		validate(tc.name, fakeLauncher, g, tc, t)
-		if err := handleGenericComment(c, trigger, event); err != nil {
-			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
-		}
-		validate(tc.name, fakeLauncher, g, tc, t)
+			log.Printf("running case %s", tc.name)
+			// In some cases handleGenericComment can be called twice for the same event.
+			// For instance on Issue/PR creation and modification.
+			// Let's call it twice to ensure idempotency.
+			if err := handleGenericComment(c, trigger, event); err != nil {
+				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
+			}
+			validate(tc.name, fakeLauncher, g, tc, t)
+			if err := handleGenericComment(c, trigger, event); err != nil {
+				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
+			}
+			validate(tc.name, fakeLauncher, g, tc, t)
+		})
 	}
 }
 


### PR DESCRIPTION
The delay between `/retest` and the previous bad status being replaced is annoyingly long, so let's do that quicker.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>