### PR TITLE
fix: Get rid of live-check of SCM status for override

### DIFF
--- a/pkg/keeper/keeper.go
+++ b/pkg/keeper/keeper.go
@@ -572,17 +572,6 @@ const (
 	successState simpleState = "success"
 )
 
-func githubqlStatusStateToSimpleState(gqlState githubql.StatusState) simpleState {
-	switch gqlState {
-	case githubql.StatusStateSuccess:
-		return successState
-	case githubql.StatusStateExpected, githubql.StatusStatePending:
-		return pendingState
-	default:
-		return failureState
-	}
-}
-
 func toSimpleState(s v1alpha1.PipelineState) simpleState {
 	if s == v1alpha1.TriggeredState || s == v1alpha1.PendingState || s == v1alpha1.RunningState {
 		return pendingState
@@ -658,7 +647,7 @@ func pickSmallestPassingNumber(log *logrus.Entry, spc scmProviderClient, prs []P
 // accumulateBatch returns a list of PRs that can be merged after passing batch
 // testing, if any exist. It also returns a list of PRs currently being batch
 // tested.
-func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []v1alpha1.LighthouseJob, spc scmProviderClient, log *logrus.Entry) ([]PullRequest, []PullRequest) {
+func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []v1alpha1.LighthouseJob, log *logrus.Entry) ([]PullRequest, []PullRequest) {
 	log.Debug("accumulating PRs for batch testing")
 	if len(presubmits) == 0 {
 		log.Debug("no presubmits configured, no batch can be triggered")
@@ -711,22 +700,6 @@ func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, p
 		context := pj.Spec.Context
 		jobState := toSimpleState(pj.Status.State)
 
-		// Check for possible override cases by looking for the PR with the PJ's lastCommitSHA and checking its statuses.
-		for _, pr := range states[ref].prs {
-			if prHeadIsInPJPulls(pr, pj) {
-				contextStatuses, err := headContexts(log, spc, &pr)
-				if err != nil {
-					log.WithError(err).Error("Error getting head contexts, solely using PJs for status")
-				}
-				// Iterate over contexts and reset the job state if the context matches and is overridden.
-				for _, contextInfo := range contextStatuses {
-					if string(contextInfo.Context) == context {
-						jobState = commitStatusOrPJStatusForContext(contextInfo, jobState)
-					}
-				}
-			}
-		}
-
 		// Store the best result for this ref+context.
 		if s, ok := states[ref].jobStates[context]; !ok || s == failureState || jobState == successState {
 			states[ref].jobStates[context] = jobState
@@ -765,27 +738,12 @@ func accumulateBatch(presubmits map[int][]config.Presubmit, prs []PullRequest, p
 	return successBatch, pendingBatch
 }
 
-// prHeadIsInPJPulls checks to see if the given pull request's head sha is one of the pull shas in the job.
-func prHeadIsInPJPulls(pr PullRequest, pj v1alpha1.LighthouseJob) bool {
-	for _, pull := range pj.Spec.Refs.Pulls {
-		if pull.SHA == string(pr.HeadRefOID) {
-			return true
-		}
-	}
-	return false
-}
-
 // accumulate returns the supplied PRs sorted into three buckets based on their
 // accumulated state across the presubmits.
-func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []v1alpha1.LighthouseJob, spc scmProviderClient, log *logrus.Entry) (successes, pendings, missings []PullRequest, missingTests map[int][]config.Presubmit) {
+func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []v1alpha1.LighthouseJob, log *logrus.Entry) (successes, pendings, missings []PullRequest, missingTests map[int][]config.Presubmit) {
 
 	missingTests = map[int][]config.Presubmit{}
 	for _, pr := range prs {
-		// Get the actual contexts for the HEAD of the PR as well, to deal with things like override.
-		contexts, err := headContexts(log, spc, &pr)
-		if err != nil {
-			log.WithError(err).Error("Error getting head contexts, solely using PJs for status")
-		}
 		// Accumulate the best result for each job (Passing > Pending > Failing/Unknown)
 		// We can ignore the baseSHA here because the subPool only contains PipelineActivitys with the correct baseSHA
 		psStates := make(map[string]simpleState)
@@ -807,13 +765,6 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 				psStates[name] = newState
 			} else if oldState == pendingState && newState == successState {
 				psStates[name] = successState
-			}
-		}
-		// Iterate over the commit status contexts
-		for _, contextInfo := range contexts {
-			// If there's already a state recorded, see if it needs to be updated due to override.
-			if existingState, ok := psStates[string(contextInfo.Context)]; ok {
-				psStates[string(contextInfo.Context)] = commitStatusOrPJStatusForContext(contextInfo, existingState)
 			}
 		}
 		// The overall result for the PR is the worst of the best of all its
@@ -846,17 +797,6 @@ func accumulate(presubmits map[int][]config.Presubmit, prs []PullRequest, pjs []
 		}
 	}
 	return
-}
-
-func commitStatusOrPJStatusForContext(contextInfo Context, existingStatus simpleState) simpleState {
-	// If the context status is success, the existing status is neither an empty string nor success, and the context
-	// status description starts with util.OverriddenByPrefix, let's overwrite the state for the context.
-	contextState := githubqlStatusStateToSimpleState(contextInfo.State)
-	if existingStatus != "" && contextState == successState && existingStatus != successState &&
-		strings.HasPrefix(string(contextInfo.Description), util.OverriddenByPrefix) {
-		return contextState
-	}
-	return existingStatus
 }
 
 func prNumbers(prs []PullRequest) []int {
@@ -1310,8 +1250,8 @@ func (c *DefaultController) presubmitsByPull(sp *subpool) (map[int][]config.Pres
 
 func (c *DefaultController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, error) {
 	sp.log.Infof("Syncing subpool: %d PRs, %d PJs.", len(sp.prs), len(sp.pjs))
-	successes, pendings, missings, missingSerialTests := accumulate(sp.presubmits, sp.prs, sp.pjs, c.spc, sp.log)
-	batchMerge, batchPending := accumulateBatch(sp.presubmits, sp.prs, sp.pjs, c.spc, sp.log)
+	successes, pendings, missings, missingSerialTests := accumulate(sp.presubmits, sp.prs, sp.pjs, sp.log)
+	batchMerge, batchPending := accumulateBatch(sp.presubmits, sp.prs, sp.pjs, sp.log)
 	sp.log.WithFields(logrus.Fields{
 		"prs-passing":   prNumbers(successes),
 		"prs-pending":   prNumbers(pendings),

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -69,7 +69,13 @@ type client struct {
 }
 
 func (c client) createOverrideJob(job *v1alpha1.LighthouseJob) (*v1alpha1.LighthouseJob, error) {
-	return c.lhClient.Create(job)
+	overrideStatus := job.Status
+	createdJob, err := c.lhClient.Create(job)
+	if err != nil {
+		return nil, err
+	}
+	createdJob.Status = overrideStatus
+	return c.lhClient.UpdateStatus(createdJob)
 }
 
 func (c client) CreateComment(owner, repo string, number int, pr bool, comment string) error {


### PR DESCRIPTION
We're now using `LighthouseJob` for overrides, so we shouldn't need this any more.

fixes #678

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>