### PR TITLE
feat: make CRD creation optional

### DIFF
--- a/charts/lighthouse/templates/lighthousejobs-crd.yaml
+++ b/charts/lighthouse/templates/lighthousejobs-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -125,3 +125,7 @@ clusterName: ""
 user: ""
 
 logFormat: "json"
+
+cluster:
+  crds:
+    create: true


### PR DESCRIPTION
Like with Tekton, we need to make CRD creation optional to make it work with Openshift.