### PR TITLE
feat: GitLab support in Keeper

### DIFF
--- a/bdd/gitlab/ci.sh
+++ b/bdd/gitlab/ci.sh
@@ -70,8 +70,7 @@ echo "Building lighthouse with version $VERSION"
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
 
-# TODO: Figure out why chatops doesn't work for gitlab!
-export BDD_ENABLE_TEST_CHATOPS_COMMANDS="false"
+export BDD_ENABLE_TEST_CHATOPS_COMMANDS="true"
 
 # Enable checking the commit status reporting URL
 export BDD_LIGHTHOUSE_BASE_REPORT_URL=https://example.com
@@ -90,7 +89,8 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-create-spring
+    --tests test-create-spring \
+    --tests test-lighthouse
 
 # Gitlab labels on pull requests aren't properly implemented yet on our side, so no quickstart tests - they depend on them.
 

--- a/bdd/gitlab/jx-requirements.yml
+++ b/bdd/gitlab/jx-requirements.yml
@@ -1,5 +1,7 @@
 cluster:
   clusterName: lh-bdd-gl
+  devEnvApprovers:
+    - jenkins-x-bot-1
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.113
+	github.com/jenkins-x/go-scm v1.5.116
 	github.com/jenkins-x/jx v0.0.0-20200506212314-f6c0570661bd
 	github.com/knative/build v0.7.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -410,12 +410,10 @@ github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c h1:jqLMOnuwp+ac6nI
 github.com/jbrukh/bayesian v0.0.0-20161210175230-bf3f261f9a9c/go.mod h1:SELxwZQq/mPnfPCR2mchLmT4TQaPJvYtLcCtDWSM7vM=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135 h1:3zy/Nvdi9V95Jfu6+W4NAJrHDeypB58FSLyzI3XfO/4=
 github.com/jenkins-x/draft-repo v0.0.0-20180417100212-2f66cc518135/go.mod h1:K/L25ViEpDx196rOZyjn433tAM5zr2F/IouK+3g+DkE=
-github.com/jenkins-x/go-scm v1.5.115 h1:9v1GjDwJ8wE0cb5nxv4Cl+JPRmyE2Ibjs4zMdbUM3wc=
-github.com/jenkins-x/go-scm v1.5.115/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
+github.com/jenkins-x/go-scm v1.5.116 h1:tFuiKxeqRw8l4xWb6vSr2tvLxcs91BL++ThM69+tLCg=
+github.com/jenkins-x/go-scm v1.5.116/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
-github.com/jenkins-x/jx v0.0.0-20200505160558-a485178e7fa2 h1:yyQNbcVkP+CtkQUCgb4RhhqSU5uCBVft6cyWGJeuWZc=
-github.com/jenkins-x/jx v0.0.0-20200505160558-a485178e7fa2/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/jx v0.0.0-20200506212314-f6c0570661bd h1:zka/F2arruAkI+7aBp+LpcfzLHdxwnhILJQrlSSWogA=
 github.com/jenkins-x/jx v0.0.0-20200506212314-f6c0570661bd/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.1.1-0.20200408213659-1dcf20c371bb h1:woC0LbYpL9rgwZn13Z0KQBEGAmi9ugpWgWtQezHqsBM=

--- a/jenkins-x-gitlab.yml
+++ b/jenkins-x-gitlab.yml
@@ -47,6 +47,16 @@ pipelineConfig:
               secretKeyRef:
                 name: test-jenkins-user 
                 key: password
+          - name: BDD_APPROVER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: jx-pipeline-git-gitlab-gl-approver
+                key: username
+          - name: BDD_APPROVER_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: jx-pipeline-git-gitlab-gl-approver
+                key: password
         agent:
           image: gcr.io/jenkinsxio/builder-go-nodejs
         stages:

--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -384,7 +384,7 @@ func (c *Controller) reportStatus(ns string, activity *jxv1.PipelineActivity, jo
 	repo := activity.Spec.GitRepository
 	gitURL := activity.Spec.GitURL
 	activityStatus := activity.Spec.Status
-	statusInfo := toScmStatusDescriptionRunningStages(activity)
+	statusInfo := toScmStatusDescriptionRunningStages(activity, c.gitKind())
 
 	fields := map[string]interface{}{
 		"name":        activity.Name,
@@ -539,7 +539,7 @@ type reportStatusInfo struct {
 	runningStages string
 }
 
-func toScmStatusDescriptionRunningStages(activity *jxv1.PipelineActivity) reportStatusInfo {
+func toScmStatusDescriptionRunningStages(activity *jxv1.PipelineActivity, gitKind string) reportStatusInfo {
 	info := reportStatusInfo{
 		description:   "",
 		runningStages: "",
@@ -567,7 +567,9 @@ func toScmStatusDescriptionRunningStages(activity *jxv1.PipelineActivity) report
 	}
 	stagesByStatus := activity.StagesByStatus()
 
-	if len(stagesByStatus[jxv1.ActivityStatusTypeRunning]) > 0 {
+	// GitLab does not currently support updating description without changing state, so we need simple descriptions there.
+	// TODO: link to GitLab issue (apb)
+	if len(stagesByStatus[jxv1.ActivityStatusTypeRunning]) > 0 && gitKind != "gitlab" {
 		info.runningStages = strings.Join(stagesByStatus[jxv1.ActivityStatusTypeRunning], ",")
 		info.description = fmt.Sprintf("Pipeline running stage(s): %s", strings.Join(stagesByStatus[jxv1.ActivityStatusTypeRunning], ", "))
 		if len(info.description) > 63 {

--- a/pkg/jobutil/filter.go
+++ b/pkg/jobutil/filter.go
@@ -26,13 +26,13 @@ import (
 )
 
 // TestAllRe provides the regex for `/test all`
-var TestAllRe = regexp.MustCompile(`(?m)^/test all,?($|\s.*)`)
+var TestAllRe = regexp.MustCompile(`(?m)^/(?:lh-)?test all,?($|\s.*)`)
 
 // RetestRe provides the regex for `/retest`
-var RetestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
+var RetestRe = regexp.MustCompile(`(?m)^/(?:lh-)?retest\s*$`)
 
 // OkToTestRe provies the regex for `/ok-to-test`
-var OkToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
+var OkToTestRe = regexp.MustCompile(`(?m)^/(?:lh-)?ok-to-test\s*$`)
 
 // Filter digests a presubmit config to determine if:
 //  - we the presubmit matched the filter

--- a/pkg/keeper/search.go
+++ b/pkg/keeper/search.go
@@ -39,7 +39,7 @@ func floor(t time.Time) time.Time {
 	return t
 }
 
-func search(query querier, log *logrus.Entry, q string, start, end time.Time) ([]PullRequest, error) {
+func graphQLSearch(query querier, log *logrus.Entry, q string, start, end time.Time) ([]PullRequest, error) {
 	start = floor(start)
 	end = floor(end)
 	log = log.WithFields(logrus.Fields{
@@ -82,7 +82,7 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time) ([
 	return ret, nil
 }
 
-// dateToken generates a GitHub search query token for the specified date range.
+// dateToken generates a GitHub graphQLSearch query token for the specified date range.
 // See: https://help.github.com/articles/understanding-the-search-syntax/#query-for-dates
 func dateToken(start, end time.Time) string {
 	// GitHub's GraphQL API silently fails if you provide it with an invalid time

--- a/pkg/keeper/search_test.go
+++ b/pkg/keeper/search_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestSearch(t *testing.T) {
-	const q = "random search string"
+	const q = "random graphQLSearch string"
 	now := time.Now()
 	earlier := now.Add(-5 * time.Hour)
 	makePRs := func(numbers ...int) []PullRequest {
@@ -155,7 +155,7 @@ func TestSearch(t *testing.T) {
 				*ret = sq
 				return nil
 			}
-			prs, err := search(querier, logrus.WithField("test", tc.name), q, tc.start, tc.end)
+			prs, err := graphQLSearch(querier, logrus.WithField("test", tc.name), q, tc.start, tc.end)
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/pkg/keeper/status_test.go
+++ b/pkg/keeper/status_test.go
@@ -274,7 +274,7 @@ func TestExpectedStatus(t *testing.T) {
 		}
 		blocks.Repo[blockers.OrgRepo{Org: "", Repo: ""}] = items
 
-		state, desc := expectedStatus(queriesByRepo, &pr, pool, &config.KeeperContextPolicy{}, blocks)
+		state, desc := expectedStatus(queriesByRepo, &pr, pool, &config.KeeperContextPolicy{}, blocks, "fake")
 		if state != tc.state {
 			t.Errorf("Expected status state %q, but got %q.", string(tc.state), string(state))
 		}
@@ -437,14 +437,9 @@ func TestTargetUrl(t *testing.T) {
 				Author: struct {
 					Login githubql.String
 				}{Login: githubql.String("author")},
-				Repository: struct {
-					Name          githubql.String
-					NameWithOwner githubql.String
-					URL           githubql.String
-					Owner         struct {
-						Login githubql.String
-					}
-				}{NameWithOwner: githubql.String("org/repo")},
+				Repository: Repository{
+					NameWithOwner: githubql.String("org/repo"),
+				},
 				HeadRefName: "head",
 			},
 			config:      config.Keeper{PRStatusBaseURL: "pr.status.com"},

--- a/pkg/plugins/approve/approvers/approvers_test.go
+++ b/pkg/plugins/approve/approvers/approvers_test.go
@@ -725,7 +725,48 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "dev"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "dev", false); got == nil {
+		t.Error("GetMessage() failed")
+	} else if *got != want {
+		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+	}
+}
+
+func TestGetMessageWithPrefix(t *testing.T) {
+	ap := NewApprovers(
+		Owners{
+			filenames: []string{"a/a.go", "b/b.go"},
+			repo: createFakeRepo(map[string]sets.String{
+				"a": sets.NewString("Alice"),
+				"b": sets.NewString("Bill"),
+			}),
+			log: logrus.WithField("plugin", "some_plugin"),
+		},
+	)
+	ap.RequireIssue = true
+	ap.AddApprover("Bill", "REFERENCE", false)
+
+	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
+
+This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Bill</a>*
+To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**
+You can assign the PR to them by writing ` + "`/lh-assign @alice`" + ` in a comment when ready.
+
+*No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/lh-approve no-issue`" + `
+
+The full list of commands accepted by this bot can be found [here](https://go.k8s.io/bot-commands?repo=org%2Frepo).
+
+<details open>
+Needs approval from an approver in each of these files:
+
+- **[a/OWNERS](https://github.com/org/repo/blob/dev/a/OWNERS)**
+- ~~[b/OWNERS](https://github.com/org/repo/blob/dev/b/OWNERS)~~ [Bill]
+
+Approvers can indicate their approval by writing ` + "`/lh-approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/lh-approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":["alice"]} -->`
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "dev", true); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -767,7 +808,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -807,7 +848,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","bill"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -851,7 +892,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -894,7 +935,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":[]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -935,7 +976,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
@@ -976,7 +1017,7 @@ Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comme
 Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["alice","doctor"]} -->`
-	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "org", "repo", "master"); got == nil {
+	if got := GetMessage(ap, &url.URL{Scheme: "https", Host: "github.mycorp.com"}, "org", "repo", "master", false); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
 		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)

--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -32,9 +32,9 @@ import (
 const pluginName = "assign"
 
 var (
-	assignRe = regexp.MustCompile(`(?mi)^/(un)?assign(( @?[-\w]+?)*)\s*$`)
+	assignRe = regexp.MustCompile(`(?mi)^/(?:lh-)?(un)?assign(( @?[-\w]+?)*)\s*$`)
 	// CCRegexp parses and validates /cc commands, also used by blunderbuss
-	CCRegexp = regexp.MustCompile(`(?mi)^/(un)?cc(( +@?[-/\w]+?)*)\s*$`)
+	CCRegexp = regexp.MustCompile(`(?mi)^/(?:lh-)?(un)?cc(( +@?[-/\w]+?)*)\s*$`)
 )
 
 func init() {
@@ -51,14 +51,14 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Assigns an assignee to the PR",
 		Featured:    true,
 		WhoCanUse:   "Anyone can use the command, but the target user must be an org member, a repo collaborator, or should have previously commented on the issue or PR.",
-		Examples:    []string{"/assign", "/unassign", "/assign @k8s-ci-robot"},
+		Examples:    []string{"/assign", "/unassign", "/assign @k8s-ci-robot", "/lh-assign"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[un]cc [[@]<username>...]",
 		Description: "Requests a review from the user(s).",
 		Featured:    true,
 		WhoCanUse:   "Anyone can use the command, but the target user must be a member of the org that owns the repository.",
-		Examples:    []string{"/cc", "/uncc", "/cc @k8s-ci-robot"},
+		Examples:    []string{"/cc", "/uncc", "/cc @k8s-ci-robot", "/lh-cc"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/assign/assign_test.go
+++ b/pkg/plugins/assign/assign_test.go
@@ -388,68 +388,77 @@ func TestAssignAndReview(t *testing.T) {
 			commenter:   "rando",
 			unrequested: []string{"kubernetes/sig-testing-misc"},
 		},
+		{
+			name:        "multi command types with prefix",
+			body:        "/lh-assign @fejta\n/lh-unassign @spxtr @cjwagner\n/lh-uncc @merlin \n/lh-cc @cjwagner",
+			commenter:   "rando",
+			assigned:    []string{"fejta"},
+			unassigned:  []string{"spxtr", "cjwagner"},
+			requested:   []string{"cjwagner"},
+			unrequested: []string{"merlin"},
+		},
 	}
 	for _, tc := range testcases {
-		fc := newFakeClient([]string{"hello-world", "allow_underscore", "cjwagner", "merlin", "kubernetes/sig-testing-misc"})
-		e := scmprovider.GenericCommentEvent{
-			Body:   tc.body,
-			Author: scm.User{Login: tc.commenter},
-			Repo:   scm.Repository{Name: "repo", Namespace: "org"},
-			Number: 5,
-		}
-		if err := handle(newAssignHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
-			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
-			continue
-		}
-		if err := handle(newReviewHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
-			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
-			continue
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeClient([]string{"hello-world", "allow_underscore", "cjwagner", "merlin", "kubernetes/sig-testing-misc"})
+			e := scmprovider.GenericCommentEvent{
+				Body:   tc.body,
+				Author: scm.User{Login: tc.commenter},
+				Repo:   scm.Repository{Name: "repo", Namespace: "org"},
+				Number: 5,
+			}
+			if err := handle(newAssignHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
+				t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
+			}
+			if err := handle(newReviewHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
+				t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
+			}
 
-		if tc.commented != fc.commented {
-			t.Errorf("For case %s, expect commented: %v, got commented %v", tc.name, tc.commented, fc.commented)
-		}
+			if tc.commented != fc.commented {
+				t.Errorf("For case %s, expect commented: %v, got commented %v", tc.name, tc.commented, fc.commented)
+			}
 
-		if len(fc.assigned) != len(tc.assigned) {
-			t.Errorf("For case %s, assigned actual %v != expected %s", tc.name, fc.assigned, tc.assigned)
-		} else {
-			for _, who := range tc.assigned {
-				if n, ok := fc.assigned[who]; !ok || n < 1 {
-					t.Errorf("For case %s, assigned actual %v != expected %s", tc.name, fc.assigned, tc.assigned)
-					break
+			if len(fc.assigned) != len(tc.assigned) {
+				t.Errorf("For case %s, assigned actual %v != expected %s", tc.name, fc.assigned, tc.assigned)
+			} else {
+				for _, who := range tc.assigned {
+					if n, ok := fc.assigned[who]; !ok || n < 1 {
+						t.Errorf("For case %s, assigned actual %v != expected %s", tc.name, fc.assigned, tc.assigned)
+						break
+					}
 				}
 			}
-		}
-		if len(fc.unassigned) != len(tc.unassigned) {
-			t.Errorf("For case %s, unassigned %v != %s", tc.name, fc.unassigned, tc.unassigned)
-		} else {
-			for _, who := range tc.unassigned {
-				if n, ok := fc.unassigned[who]; !ok || n < 1 {
-					t.Errorf("For case %s, unassigned %v != %s", tc.name, fc.unassigned, tc.unassigned)
-					break
+			if len(fc.unassigned) != len(tc.unassigned) {
+				t.Errorf("For case %s, unassigned %v != %s", tc.name, fc.unassigned, tc.unassigned)
+			} else {
+				for _, who := range tc.unassigned {
+					if n, ok := fc.unassigned[who]; !ok || n < 1 {
+						t.Errorf("For case %s, unassigned %v != %s", tc.name, fc.unassigned, tc.unassigned)
+						break
+					}
 				}
 			}
-		}
 
-		if len(fc.requested) != len(tc.requested) {
-			t.Errorf("For case %s, requested actual %v != expected %s", tc.name, fc.requested, tc.requested)
-		} else {
-			for _, who := range tc.requested {
-				if n, ok := fc.requested[who]; !ok || n < 1 {
-					t.Errorf("For case %s, requested actual %v != expected %s", tc.name, fc.requested, tc.requested)
-					break
+			if len(fc.requested) != len(tc.requested) {
+				t.Errorf("For case %s, requested actual %v != expected %s", tc.name, fc.requested, tc.requested)
+			} else {
+				for _, who := range tc.requested {
+					if n, ok := fc.requested[who]; !ok || n < 1 {
+						t.Errorf("For case %s, requested actual %v != expected %s", tc.name, fc.requested, tc.requested)
+						break
+					}
 				}
 			}
-		}
-		if len(fc.unrequested) != len(tc.unrequested) {
-			t.Errorf("For case %s, unrequested %v != %s", tc.name, fc.unrequested, tc.unrequested)
-		} else {
-			for _, who := range tc.unrequested {
-				if n, ok := fc.unrequested[who]; !ok || n < 1 {
-					t.Errorf("For case %s, unrequested %v != %s", tc.name, fc.unrequested, tc.unrequested)
-					break
+			if len(fc.unrequested) != len(tc.unrequested) {
+				t.Errorf("For case %s, unrequested %v != %s", tc.name, fc.unrequested, tc.unrequested)
+			} else {
+				for _, who := range tc.unrequested {
+					if n, ok := fc.unrequested[who]; !ok || n < 1 {
+						t.Errorf("For case %s, unrequested %v != %s", tc.name, fc.unrequested, tc.unrequested)
+						break
+					}
 				}
 			}
-		}
+		})
 	}
 }

--- a/pkg/plugins/cat/cat.go
+++ b/pkg/plugins/cat/cat.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	match          = regexp.MustCompile(`(?mi)^/meow(vie)?(?: (.+))?\s*$`)
+	match          = regexp.MustCompile(`(?mi)^/(?:lh-)?meow(vie)?(?: (.+))?\s*$`)
 	grumpyKeywords = regexp.MustCompile(`(?mi)^(no|grumpy)\s*$`)
 	meow           = &realClowder{
 		url: "https://api.thecatapi.com/v1/images/search?format=json&results_per_page=1",
@@ -66,7 +66,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Add a cat image to the issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
-		Examples:    []string{"/meow", "/meow caturday", "/meowvie clothes"},
+		Examples:    []string{"/meow", "/meow caturday", "/meowvie clothes", "/lh-meow"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/dog/dog.go
+++ b/pkg/plugins/dog/dog.go
@@ -34,10 +34,10 @@ import (
 )
 
 var (
-	match           = regexp.MustCompile(`(?mi)^/(woof|bark)\s*$`)
-	fineRegex       = regexp.MustCompile(`(?mi)^/this-is-fine\s*$`)
-	notFineRegex    = regexp.MustCompile(`(?mi)^/this-is-not-fine\s*$`)
-	unbearableRegex = regexp.MustCompile(`(?mi)^/this-is-unbearable\s*$`)
+	match           = regexp.MustCompile(`(?mi)^/(?:lh-)?(woof|bark)\s*$`)
+	fineRegex       = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-fine\s*$`)
+	notFineRegex    = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-not-fine\s*$`)
+	unbearableRegex = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-unbearable\s*$`)
 	filetypes       = regexp.MustCompile(`(?i)\.(jpg|gif|png)$`)
 )
 
@@ -59,7 +59,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/(woof|bark|this-is-{fine|not-fine|unbearable})",
+		Usage:       "/(lh-)?(woof|bark|this-is-{fine|not-fine|unbearable})",
 		Description: "Add a dog image to the issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Anyone",

--- a/pkg/plugins/dog/dog_test.go
+++ b/pkg/plugins/dog/dog_test.go
@@ -268,6 +268,14 @@ func TestDogs(t *testing.T) {
 			shouldComment: true,
 		},
 		{
+			name:          "leave dog on pr with prefix",
+			state:         "open",
+			action:        scm.ActionCreate,
+			body:          "/lh-woof",
+			pr:            true,
+			shouldComment: true,
+		},
+		{
 			name:          "leave dog on issue",
 			state:         "open",
 			action:        scm.ActionCreate,
@@ -304,6 +312,14 @@ func TestDogs(t *testing.T) {
 			shouldComment: true,
 		},
 		{
+			name:          "leave this-is-fine on pr with prefix",
+			state:         "open",
+			action:        scm.ActionCreate,
+			body:          "/lh-this-is-fine",
+			pr:            true,
+			shouldComment: true,
+		},
+		{
 			name:          "leave this-is-not-fine on pr",
 			state:         "open",
 			action:        scm.ActionCreate,
@@ -321,30 +337,32 @@ func TestDogs(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		fakeScmClient, fc := fake.NewDefault()
-		fakeClient := scmprovider.ToTestClient(fakeScmClient)
+		t.Run(tc.name, func(t *testing.T) {
+			fakeScmClient, fc := fake.NewDefault()
+			fakeClient := scmprovider.ToTestClient(fakeScmClient)
 
-		e := &scmprovider.GenericCommentEvent{
-			Action:     tc.action,
-			Body:       tc.body,
-			Number:     5,
-			IssueState: tc.state,
-			IsPR:       tc.pr,
-		}
-		err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakePack("doge"))
-		if err != nil {
-			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
-		}
-		var comments map[int][]*scm.Comment
-		if tc.pr {
-			comments = fc.PullRequestComments
-		} else {
-			comments = fc.IssueComments
-		}
-		if tc.shouldComment && len(comments[5]) != 1 {
-			t.Errorf("For case %s, should have commented.", tc.name)
-		} else if !tc.shouldComment && len(comments[5]) != 0 {
-			t.Errorf("For case %s, should not have commented.", tc.name)
-		}
+			e := &scmprovider.GenericCommentEvent{
+				Action:     tc.action,
+				Body:       tc.body,
+				Number:     5,
+				IssueState: tc.state,
+				IsPR:       tc.pr,
+			}
+			err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakePack("doge"))
+			if err != nil {
+				t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
+			}
+			var comments map[int][]*scm.Comment
+			if tc.pr {
+				comments = fc.PullRequestComments
+			} else {
+				comments = fc.IssueComments
+			}
+			if tc.shouldComment && len(comments[5]) != 1 {
+				t.Errorf("For case %s, should have commented.", tc.name)
+			} else if !tc.shouldComment && len(comments[5]) != 0 {
+				t.Errorf("For case %s, should not have commented.", tc.name)
+			}
+		})
 	}
 }

--- a/pkg/plugins/help/help.go
+++ b/pkg/plugins/help/help.go
@@ -31,10 +31,10 @@ import (
 const pluginName = "help"
 
 var (
-	helpRe                     = regexp.MustCompile(`(?mi)^/help\s*$`)
-	helpRemoveRe               = regexp.MustCompile(`(?mi)^/remove-help\s*$`)
-	helpGoodFirstIssueRe       = regexp.MustCompile(`(?mi)^/good-first-issue\s*$`)
-	helpGoodFirstIssueRemoveRe = regexp.MustCompile(`(?mi)^/remove-good-first-issue\s*$`)
+	helpRe                     = regexp.MustCompile(`(?mi)^/(?:lh-)?help\s*$`)
+	helpRemoveRe               = regexp.MustCompile(`(?mi)^/(?:lh-)?remove-help\s*$`)
+	helpGoodFirstIssueRe       = regexp.MustCompile(`(?mi)^/(?:lh-)?good-first-issue\s*$`)
+	helpGoodFirstIssueRemoveRe = regexp.MustCompile(`(?mi)^/(?:lh-)?remove-good-first-issue\s*$`)
 	helpGuidelinesURL          = "https://git.k8s.io/community/contributors/guide/help-wanted.md"
 	helpMsgPruneMatch          = "This request has been marked as needing help from a contributor."
 	helpMsg                    = `

--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -39,8 +39,8 @@ const (
 )
 
 var (
-	labelRe       = regexp.MustCompile(`(?mi)^/hold\s*$`)
-	labelCancelRe = regexp.MustCompile(`(?mi)^/hold cancel\s*$`)
+	labelRe       = regexp.MustCompile(`(?mi)^/(?:lh-)?hold\s*$`)
+	labelCancelRe = regexp.MustCompile(`(?mi)^/(?:lh-)?hold cancel\s*$`)
 )
 
 type hasLabelFunc func(label string, issueLabels []*scm.Label) bool

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -33,10 +33,10 @@ const pluginName = "label"
 
 var (
 	defaultLabels           = []string{"kind", "priority", "area"}
-	labelRegex              = regexp.MustCompile(`(?m)^/(area|committee|kind|language|priority|sig|triage|wg)\s*(.*)$`)
-	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|committee|kind|language|priority|sig|triage|wg)\s*(.*)$`)
-	customLabelRegex        = regexp.MustCompile(`(?m)^/label\s*(.*)$`)
-	customRemoveLabelRegex  = regexp.MustCompile(`(?m)^/remove-label\s*(.*)$`)
+	labelRegex              = regexp.MustCompile(`(?m)^/(?:lh-)?(area|committee|kind|language|priority|sig|triage|wg)\s*(.*)$`)
+	removeLabelRegex        = regexp.MustCompile(`(?m)^/(?:lh-)?remove-(area|committee|kind|language|priority|sig|triage|wg)\s*(.*)$`)
+	customLabelRegex        = regexp.MustCompile(`(?m)^/(?:lh-)?label\s*(.*)$`)
+	customRemoveLabelRegex  = regexp.MustCompile(`(?m)^/(?:lh-)?remove-label\s*(.*)$`)
 	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
 )
 
@@ -104,7 +104,7 @@ func getLabelsFromGenericMatches(matches [][]string, additionalLabels []string) 
 	var labels []string
 	for _, match := range matches {
 		parts := strings.Split(match[0], " ")
-		if ((parts[0] != "/label") && (parts[0] != "/remove-label")) || len(parts) != 2 {
+		if ((parts[0] != "/label") && (parts[0] != "/remove-label") && (parts[0] != "/lh-label") && (parts[0] != "/lh-remove-label")) || len(parts) != 2 {
 			continue
 		}
 		for _, l := range additionalLabels {

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -45,8 +45,8 @@ var (
 	configInfoStoreTreeHash    = `Squashing commits does not remove LGTM.`
 	// LGTMLabel is the name of the lgtm label applied by the lgtm plugin
 	LGTMLabel           = labels.LGTM
-	lgtmRe              = regexp.MustCompile(`(?mi)^/lgtm(?: no-issue)?\s*$`)
-	lgtmCancelRe        = regexp.MustCompile(`(?mi)^/lgtm cancel\s*$`)
+	lgtmRe              = regexp.MustCompile(`(?mi)^/(?:lh-)?lgtm(?: no-issue)?\s*$`)
+	lgtmCancelRe        = regexp.MustCompile(`(?mi)^/(?:lh-)?lgtm cancel\s*$`)
 	removeLGTMLabelNoti = "New changes are detected. LGTM label has been removed."
 )
 

--- a/pkg/plugins/lifecycle/close.go
+++ b/pkg/plugins/lifecycle/close.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
-var closeRe = regexp.MustCompile(`(?mi)^/close\s*$`)
+var closeRe = regexp.MustCompile(`(?mi)^/(?:lh-)?close\s*$`)
 
 type closeClient interface {
 	IsCollaborator(owner, repo, login string) (bool, error)

--- a/pkg/plugins/lifecycle/close_test.go
+++ b/pkg/plugins/lifecycle/close_test.go
@@ -169,30 +169,40 @@ func TestCloseComment(t *testing.T) {
 			shouldClose:   false,
 			shouldComment: true,
 		},
+		{
+			name:          "close by author with prefix",
+			action:        scm.ActionCreate,
+			state:         "open",
+			body:          "/lh-close",
+			commenter:     "author",
+			shouldClose:   true,
+			shouldComment: true,
+		},
 	}
 	for _, tc := range testcases {
-		fc := &fakeClientClose{labels: tc.labels}
-		e := &scmprovider.GenericCommentEvent{
-			Action:      tc.action,
-			IssueState:  tc.state,
-			Body:        tc.body,
-			Author:      scm.User{Login: tc.commenter},
-			Number:      5,
-			IssueAuthor: scm.User{Login: "author"},
-		}
-		if err := handleClose(fc, logrus.WithField("plugin", "fake-close"), e); err != nil {
-			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
-			continue
-		}
-		if tc.shouldClose && !fc.closed {
-			t.Errorf("For case %s, should have closed but didn't.", tc.name)
-		} else if !tc.shouldClose && fc.closed {
-			t.Errorf("For case %s, should not have closed but did.", tc.name)
-		}
-		if tc.shouldComment && !fc.commented {
-			t.Errorf("For case %s, should have commented but didn't.", tc.name)
-		} else if !tc.shouldComment && fc.commented {
-			t.Errorf("For case %s, should not have commented but did.", tc.name)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClientClose{labels: tc.labels}
+			e := &scmprovider.GenericCommentEvent{
+				Action:      tc.action,
+				IssueState:  tc.state,
+				Body:        tc.body,
+				Author:      scm.User{Login: tc.commenter},
+				Number:      5,
+				IssueAuthor: scm.User{Login: "author"},
+			}
+			if err := handleClose(fc, logrus.WithField("plugin", "fake-close"), e); err != nil {
+				t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
+			}
+			if tc.shouldClose && !fc.closed {
+				t.Errorf("For case %s, should have closed but didn't.", tc.name)
+			} else if !tc.shouldClose && fc.closed {
+				t.Errorf("For case %s, should not have closed but did.", tc.name)
+			}
+			if tc.shouldComment && !fc.commented {
+				t.Errorf("For case %s, should have commented but didn't.", tc.name)
+			} else if !tc.shouldComment && fc.commented {
+				t.Errorf("For case %s, should not have commented but did.", tc.name)
+			}
+		})
 	}
 }

--- a/pkg/plugins/lifecycle/lifecycle.go
+++ b/pkg/plugins/lifecycle/lifecycle.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	lifecycleLabels = []string{labels.LifecycleActive, labels.LifecycleFrozen, labels.LifecycleStale, labels.LifecycleRotten}
-	lifecycleRe     = regexp.MustCompile(`(?mi)^/(remove-)?lifecycle (active|frozen|stale|rotten)\s*$`)
+	lifecycleRe     = regexp.MustCompile(`(?mi)^/(?:lh-)?(remove-)?lifecycle (active|frozen|stale|rotten)\s*$`)
 )
 
 func init() {
@@ -46,21 +46,21 @@ func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.Plu
 		Description: "Closes an issue or PR.",
 		Featured:    false,
 		WhoCanUse:   "Authors and collaborators on the repository can trigger this command.",
-		Examples:    []string{"/close"},
+		Examples:    []string{"/close", "/lh-close"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/reopen",
 		Description: "Reopens an issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Authors and collaborators on the repository can trigger this command.",
-		Examples:    []string{"/reopen"},
+		Examples:    []string{"/reopen", "/lh-reopen"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[remove-]lifecycle <frozen|stale|rotten>",
 		Description: "Flags an issue or PR as frozen/stale/rotten",
 		Featured:    false,
 		WhoCanUse:   "Anyone can trigger this command.",
-		Examples:    []string{"/lifecycle frozen", "/remove-lifecycle stale"},
+		Examples:    []string{"/lifecycle frozen", "/remove-lifecycle stale", "/lh-lifecyle rotten"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/lifecycle/reopen.go
+++ b/pkg/plugins/lifecycle/reopen.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
-var reopenRe = regexp.MustCompile(`(?mi)^/reopen\s*$`)
+var reopenRe = regexp.MustCompile(`(?mi)^/(?:lh-)?reopen\s*$`)
 
 type scmProviderClient interface {
 	IsCollaborator(owner, repo, login string) (bool, error)

--- a/pkg/plugins/lifecycle/reopen_test.go
+++ b/pkg/plugins/lifecycle/reopen_test.go
@@ -124,30 +124,40 @@ func TestReopenComment(t *testing.T) {
 			shouldReopen:  false,
 			shouldComment: true,
 		},
+		{
+			name:          "re-open by author with prefix",
+			action:        scm.ActionCreate,
+			state:         "closed",
+			body:          "/lh-reopen",
+			commenter:     "author",
+			shouldReopen:  true,
+			shouldComment: true,
+		},
 	}
 	for _, tc := range testcases {
-		fc := &fakeClientReopen{}
-		e := &scmprovider.GenericCommentEvent{
-			Action:      tc.action,
-			IssueState:  tc.state,
-			Body:        tc.body,
-			Author:      scm.User{Login: tc.commenter},
-			Number:      5,
-			IssueAuthor: scm.User{Login: "author"},
-		}
-		if err := handleReopen(fc, logrus.WithField("plugin", "fake-reopen"), e); err != nil {
-			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
-			continue
-		}
-		if tc.shouldReopen && !fc.open {
-			t.Errorf("For case %s, should have reopened but didn't.", tc.name)
-		} else if !tc.shouldReopen && fc.open {
-			t.Errorf("For case %s, should not have reopened but did.", tc.name)
-		}
-		if tc.shouldComment && !fc.commented {
-			t.Errorf("For case %s, should have commented but didn't.", tc.name)
-		} else if !tc.shouldComment && fc.commented {
-			t.Errorf("For case %s, should not have commented but did.", tc.name)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClientReopen{}
+			e := &scmprovider.GenericCommentEvent{
+				Action:      tc.action,
+				IssueState:  tc.state,
+				Body:        tc.body,
+				Author:      scm.User{Login: tc.commenter},
+				Number:      5,
+				IssueAuthor: scm.User{Login: "author"},
+			}
+			if err := handleReopen(fc, logrus.WithField("plugin", "fake-reopen"), e); err != nil {
+				t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
+			}
+			if tc.shouldReopen && !fc.open {
+				t.Errorf("For case %s, should have reopened but didn't.", tc.name)
+			} else if !tc.shouldReopen && fc.open {
+				t.Errorf("For case %s, should not have reopened but did.", tc.name)
+			}
+			if tc.shouldComment && !fc.commented {
+				t.Errorf("For case %s, should have commented but didn't.", tc.name)
+			} else if !tc.shouldComment && fc.commented {
+				t.Errorf("For case %s, should not have commented but did.", tc.name)
+			}
+		})
 	}
 }

--- a/pkg/plugins/milestone/milestone.go
+++ b/pkg/plugins/milestone/milestone.go
@@ -35,7 +35,7 @@ import (
 const pluginName = "milestone"
 
 var (
-	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
+	milestoneRegex   = regexp.MustCompile(`(?m)^/(?:lh-)?milestone\s+(.+?)\s*$`)
 	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q with ID: %d."
@@ -78,7 +78,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Updates the milestone for an issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Members of the milestone maintainers GitHub team can use the '/milestone' command.",
-		Examples:    []string{"/milestone v1.10", "/milestone v1.9", "/milestone clear"},
+		Examples:    []string{"/milestone v1.10", "/milestone v1.9", "/milestone clear", "/lh-milestone clear"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -34,7 +34,7 @@ import (
 const pluginName = "milestonestatus"
 
 var (
-	statusRegex      = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
+	statusRegex      = regexp.MustCompile(`(?m)^/(?:lh-)?status\s+(.+)$`)
 	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to add status labels. If you believe you should be able to issue the /status command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q with ID: %d."
 	statusMap        = map[string]string{
@@ -78,7 +78,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Applies the 'status/' label to a PR.",
 		Featured:    false,
 		WhoCanUse:   "Members of the milestone maintainers GitHub team can use the '/status' command. This team is specified in the config by providing the GitHub team's ID.",
-		Examples:    []string{"/status approved-for-milestone", "/status in-progress", "/status in-review"},
+		Examples:    []string{"/status approved-for-milestone", "/status in-progress", "/status in-review", "/lh-status in-review"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -42,7 +42,7 @@ import (
 const pluginName = "override"
 
 var (
-	overrideRe = regexp.MustCompile(`(?mi)^/override( (.+?)\s*)?$`)
+	overrideRe = regexp.MustCompile(`(?mi)^/(?:lh-)?override( (.+?)\s*)?$`)
 )
 
 type scmProviderClient interface {
@@ -121,7 +121,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Forces a github status context to green (one per line).",
 		Featured:    false,
 		WhoCanUse:   "Repo administrators",
-		Examples:    []string{"/override pull-repo-whatever", "/override ci/circleci", "/override deleted-job"},
+		Examples:    []string{"/override pull-repo-whatever", "/override ci/circleci", "/override deleted-job", "/lh-override some-job"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -230,6 +230,24 @@ func TestHandle(t *testing.T) {
 			checkComments: []string{"on behalf of " + adminUser},
 		},
 		{
+			name:    "successfully override failure with prefix",
+			comment: "/lh-override broken-test",
+			contexts: map[string]*scm.StatusInput{
+				"broken-test": {
+					Label: "broken-test",
+					State: scm.StateFailure,
+				},
+			},
+			expected: map[string]*scm.StatusInput{
+				"broken-test": {
+					Label: "broken-test",
+					Desc:  description(adminUser),
+					State: scm.StateSuccess,
+				},
+			},
+			checkComments: []string{"on behalf of " + adminUser},
+		},
+		{
 			name:    "successfully override pending",
 			comment: "/override hung-test",
 			contexts: map[string]*scm.StatusInput{

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -143,6 +144,7 @@ type Agent struct {
 	GitClient          git2.Client
 	KubernetesClient   kubernetes.Interface
 	LighthouseClient   lighthouseclient.LighthouseJobInterface
+	ServerURL          *url.URL
 	/*
 		SlackClient      *slack.Client
 	*/
@@ -162,7 +164,7 @@ type Agent struct {
 }
 
 // NewAgent bootstraps a new Agent struct from the passed dependencies.
-func NewAgent(clientFactory jxfactory.Factory, configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientAgent *ClientAgent, metapipelineClient metapipeline.Client, logger *logrus.Entry) Agent {
+func NewAgent(clientFactory jxfactory.Factory, configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientAgent *ClientAgent, metapipelineClient metapipeline.Client, serverURL *url.URL, logger *logrus.Entry) Agent {
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
 	scmClient := scmprovider.ToClient(clientAgent.SCMProviderClient, clientAgent.BotName)
@@ -173,6 +175,7 @@ func NewAgent(clientFactory jxfactory.Factory, configAgent *config.Agent, plugin
 		LauncherClient:     clientAgent.LauncherClient,
 		MetapipelineClient: metapipelineClient,
 		LighthouseClient:   clientAgent.LighthouseClient,
+		ServerURL:          serverURL,
 
 		/*
 			SlackClient:   clientAgent.SlackClient,

--- a/pkg/plugins/pony/pony.go
+++ b/pkg/plugins/pony/pony.go
@@ -52,7 +52,7 @@ const (
 )
 
 var (
-	match = regexp.MustCompile(`(?mi)^/(?:pony)(?: +(.+?))?\s*$`)
+	match = regexp.MustCompile(`(?mi)^/(?:lh-)?(?:pony)(?: +(.+?))?\s*$`)
 )
 
 func init() {
@@ -69,7 +69,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Add a little pony image to the issue or PR. A particular pony can optionally be named for a picture of that specific pony.",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
-		Examples:    []string{"/pony", "/pony Twilight Sparkle"},
+		Examples:    []string{"/pony", "/pony Twilight Sparkle", "/lh-pony"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/shrug/shrug.go
+++ b/pkg/plugins/shrug/shrug.go
@@ -32,8 +32,8 @@ import (
 const pluginName = "shrug"
 
 var (
-	shrugRe   = regexp.MustCompile(`(?mi)^/shrug\s*$`)
-	unshrugRe = regexp.MustCompile(`(?mi)^/unshrug\s*$`)
+	shrugRe   = regexp.MustCompile(`(?mi)^/(?:lh-)?shrug\s*$`)
+	unshrugRe = regexp.MustCompile(`(?mi)^/(?:lh-)?unshrug\s*$`)
 )
 
 type event struct {

--- a/pkg/plugins/size/size.go
+++ b/pkg/plugins/size/size.go
@@ -93,13 +93,8 @@ func handlePR(spc scmProviderClient, sizes plugins.Size, le *logrus.Entry, pe sc
 
 	gf, err := genfiles.NewGroup(spc, owner, repo, sha)
 	if err != nil {
-		switch err.(type) {
-		case *genfiles.ParseError:
-			// Continue on parse errors, but warn that something is wrong.
-			le.Warnf("error while parsing .generated_files: %v", err)
-		default:
-			return err
-		}
+		// Continue on parse errors, but warn that something is wrong.
+		le.Warnf("error while parsing .generated_files: %v", err)
 	}
 
 	ga, err := gitattributes.NewGroup(func() ([]byte, error) { return spc.GetFile(owner, repo, ".gitattributes", sha) })

--- a/pkg/plugins/skip/skip.go
+++ b/pkg/plugins/skip/skip.go
@@ -34,7 +34,7 @@ import (
 const pluginName = "skip"
 
 var (
-	skipRe = regexp.MustCompile(`(?mi)^/skip\s*$`)
+	skipRe = regexp.MustCompile(`(?mi)^/(?:lh-)?skip\s*$`)
 )
 
 type scmProviderClient interface {
@@ -58,7 +58,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Cleans up GitHub stale commit statuses for non-blocking jobs on a PR.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can trigger this command on a PR.",
-		Examples:    []string{"/skip"},
+		Examples:    []string{"/skip", "/lh-skip"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/stage/stage.go
+++ b/pkg/plugins/stage/stage.go
@@ -34,7 +34,7 @@ var (
 	stageBeta   = "stage/beta"
 	stageStable = "stage/stable"
 	stageLabels = []string{stageAlpha, stageBeta, stageStable}
-	stageRe     = regexp.MustCompile(`(?mi)^/(remove-)?stage (alpha|beta|stable)\s*$`)
+	stageRe     = regexp.MustCompile(`(?mi)^/(?:lh-)?(remove-)?stage (alpha|beta|stable)\s*$`)
 )
 
 func init() {

--- a/pkg/plugins/stage/stage_test.go
+++ b/pkg/plugins/stage/stage_test.go
@@ -127,6 +127,13 @@ func TestStageLabels(t *testing.T) {
 			labels:  []string{},
 		},
 		{
+			name:    "add alpha with prefix, don't have it -> alpha added",
+			body:    "/lh-stage alpha",
+			added:   []string{stageAlpha},
+			removed: []string{},
+			labels:  []string{},
+		},
+		{
 			name:    "add beta, don't have it -> beta added",
 			body:    "/stage beta",
 			added:   []string{stageBeta},
@@ -143,6 +150,13 @@ func TestStageLabels(t *testing.T) {
 		{
 			name:    "remove alpha, have it -> alpha removed",
 			body:    "/remove-stage alpha",
+			added:   []string{},
+			removed: []string{stageAlpha},
+			labels:  []string{stageAlpha},
+		},
+		{
+			name:    "remove alpha with prefix, have it -> alpha removed",
+			body:    "/lh-remove-stage alpha",
 			added:   []string{},
 			removed: []string{stageAlpha},
 			labels:  []string{stageAlpha},
@@ -198,23 +212,25 @@ func TestStageLabels(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		fc := &fakeClient{
-			labels:  tc.labels,
-			added:   []string{},
-			removed: []string{},
-		}
-		e := &scmprovider.GenericCommentEvent{
-			Body:   tc.body,
-			Action: scm.ActionCreate,
-		}
-		err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
-		switch {
-		case err != nil:
-			t.Errorf("%s: unexpected error: %v", tc.name, err)
-		case !reflect.DeepEqual(tc.added, fc.added):
-			t.Errorf("%s: added %v != actual %v", tc.name, tc.added, fc.added)
-		case !reflect.DeepEqual(tc.removed, fc.removed):
-			t.Errorf("%s: removed %v != actual %v", tc.name, tc.removed, fc.removed)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				labels:  tc.labels,
+				added:   []string{},
+				removed: []string{},
+			}
+			e := &scmprovider.GenericCommentEvent{
+				Body:   tc.body,
+				Action: scm.ActionCreate,
+			}
+			err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+			switch {
+			case err != nil:
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			case !reflect.DeepEqual(tc.added, fc.added):
+				t.Errorf("%s: added %v != actual %v", tc.name, tc.added, fc.added)
+			case !reflect.DeepEqual(tc.removed, fc.removed):
+				t.Errorf("%s: removed %v != actual %v", tc.name, tc.removed, fc.removed)
+			}
+		})
 	}
 }

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -74,21 +74,21 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Marks a PR as 'trusted' and starts tests.",
 		Featured:    false,
 		WhoCanUse:   "Members of the trusted organization for the repo.",
-		Examples:    []string{"/ok-to-test"},
+		Examples:    []string{"/ok-to-test", "/lh-ok-to-test"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/test (<job name>|all)",
 		Description: "Manually starts a/all test job(s).",
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
-		Examples:    []string{"/test all", "/test pull-bazel-test"},
+		Examples:    []string{"/test all", "/test pull-bazel-test", "/lh-test all"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/retest",
 		Description: "Rerun test jobs that have failed.",
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
-		Examples:    []string{"/retest"},
+		Examples:    []string{"/retest", "/lh-retest"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/plugins/yuks/yuks.go
+++ b/pkg/plugins/yuks/yuks.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	match  = regexp.MustCompile(`(?mi)^/joke\s*$`)
+	match  = regexp.MustCompile(`(?mi)^/(?:lh-)?joke\s*$`)
 	simple = regexp.MustCompile(`^[\w?'!., ]+$`)
 )
 
@@ -56,7 +56,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "Tells a joke.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can use the `/joke` command.",
-		Examples:    []string{"/joke"},
+		Examples:    []string{"/joke", "/lh-joke"},
 	})
 	return pluginHelp, nil
 }

--- a/pkg/scmprovider/client.go
+++ b/pkg/scmprovider/client.go
@@ -18,6 +18,8 @@ type SCMClient interface {
 	// Functions implemented in client.go
 	BotName() (string, error)
 	SetBotName(string)
+	SupportsGraphQL() bool
+	ProviderType() string
 
 	// Functions implemented in content.go
 	GetFile(string, string, string, string) ([]byte, error)
@@ -57,6 +59,7 @@ type SCMClient interface {
 	Merge(string, string, int, MergeDetails) error
 	ReopenPR(string, string, int) error
 	ClosePR(string, string, int) error
+	ListAllPullRequestsForFullNameRepo(string, scm.PullRequestListOptions) ([]*scm.PullRequest, error)
 
 	// Functions implemented in repositories.go
 	GetRepoLabels(string, string) ([]*scm.Label, error)
@@ -69,6 +72,7 @@ type SCMClient interface {
 	HasPermission(string, string, string, ...string) (bool, error)
 	GetUserPermission(string, string, string) (string, error)
 	IsMember(string, string) (bool, error)
+	GetRepositoryByFullName(string) (*scm.Repository, error)
 
 	// Functions implemented in reviews.go
 	ListReviews(string, string, int) ([]*scm.Review, error)
@@ -118,6 +122,16 @@ func (c *Client) BotName() (string, error) {
 // SetBotName sets the bot name
 func (c *Client) SetBotName(botName string) {
 	c.botName = botName
+}
+
+// SupportsGraphQL returns true if the underlying provider supports our GraphQL queries
+func (c *Client) SupportsGraphQL() bool {
+	return c.client.GraphQL != nil
+}
+
+// ProviderType returns the type of the underlying SCM provider
+func (c *Client) ProviderType() string {
+	return c.client.Driver.String()
 }
 
 func (c *Client) repositoryName(owner string, repo string) string {

--- a/pkg/scmprovider/fake/fake.go
+++ b/pkg/scmprovider/fake/fake.go
@@ -32,6 +32,8 @@ const (
 	Bot = botName
 	// TestRef is the ref returned when calling GetRef
 	TestRef = "abcde"
+	// providerType is the fake provider name
+	providerType = "fake"
 )
 
 // SCMClient is like client, but fake.
@@ -89,6 +91,16 @@ type SCMClient struct {
 
 	// A list of refs that got deleted via DeleteRef
 	RefsDeleted []struct{ Org, Repo, Ref string }
+}
+
+// ProviderType returns the provider type
+func (f *SCMClient) ProviderType() string {
+	return providerType
+}
+
+// SupportsGraphQL returns whether the provider supports GraphQL
+func (f *SCMClient) SupportsGraphQL() bool {
+	return false
 }
 
 // BotName returns authenticated login.

--- a/pkg/scmprovider/repositories.go
+++ b/pkg/scmprovider/repositories.go
@@ -6,6 +6,13 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 )
 
+// GetRepositoryByFullName returns the repository details
+func (c *Client) GetRepositoryByFullName(fullName string) (*scm.Repository, error) {
+	ctx := context.Background()
+	r, _, err := c.client.Repositories.Find(ctx, fullName)
+	return r, err
+}
+
 // GetRepoLabels returns the repository labels
 func (c *Client) GetRepoLabels(owner, repo string) ([]*scm.Label, error) {
 	ctx := context.Background()

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -96,4 +96,7 @@ const (
 	ProwConfigFilename = "config.yaml"
 	// ProwPluginsFilename plugins file name
 	ProwPluginsFilename = "plugins.yaml"
+
+	// LighthouseCommandPrefix is an optional prefix for commands to deal with things like GitLab hijacking /approve
+	LighthouseCommandPrefix = "lh-"
 )

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -524,12 +525,17 @@ func (o *Options) createHookServer() (*Server, error) {
 		return nil, errors.Wrap(err, "failed to create metapipeline client")
 	}
 
+	serverURL, err := url.Parse(o.gitServerURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse server URL %s", o.gitServerURL)
+	}
 	server := &Server{
 		ClientFactory:      clientFactory,
 		ConfigAgent:        configAgent,
 		Plugins:            pluginAgent,
 		Metrics:            promMetrics,
 		MetapipelineClient: metapipelineClient,
+		ServerURL:          serverURL,
 		//TokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
 	}
 	return server, nil


### PR DESCRIPTION
With this change, any SCM provider that implements the needed REST queries (and populates `scm.Repository` and `scm.PullRequest` properly) should work. The initial target for this is GitLab.

Due to GitLab quick actions hijacking `/approve` and `/assign` most notably (there are some other quick action commands that overlap), I've added the ability to invoke any Lighthouse command with `/lh-(whatever)` as well as `/whatever`.

fixes #688
