### PR TITLE
fix: Get rid of Deck link

### DIFF
--- a/pkg/keeper/status.go
+++ b/pkg/keeper/status.go
@@ -326,7 +326,6 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 					Context:     GetStatusContextLabel(),
 					State:       wantState,
 					Description: wantDesc,
-					TargetURL:   targetURL(sc.config, pr, log),
 				}); err != nil {
 				log.WithError(err).Errorf(
 					"Failed to set status context from %q to %q.",


### PR DESCRIPTION
It doesn't go anywhere, so let's get rid of it. I'm leaving the `targetUrl` logic in here in case we end up wanting to revisit it in the future.

fixes #695

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>