### PR TITLE
fix: Use Lighthouse-specific HMAC token secret name

### DIFF
--- a/charts/lighthouse/templates/hmacsecret.yaml
+++ b/charts/lighthouse/templates/hmacsecret.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: hmac-token
+  name: lighthouse-hmac-token
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 type: Opaque
 data:  
   hmac: {{ default "" .Values.hmacToken | b64enc | quote }}

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: "HMAC_TOKEN"
             valueFrom:
               secretKeyRef:
-                name: "hmac-token"
+                name: "lighthouse-hmac-token"
                 key: hmac
           - name: "JX_LOG_FORMAT"
             value: "{{ .Values.logFormat }}"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/gorilla/sessions v1.1.3
-	github.com/jenkins-x/go-scm v1.5.116
+	github.com/jenkins-x/go-scm v1.5.117
 	github.com/jenkins-x/jx v0.0.0-20200508065626-f2777de9ed7a
 	github.com/knative/build v0.7.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,6 @@ github.com/jenkins-x/go-scm v1.5.117 h1:D7d1sDWUU+xocCNLQVoYKpMjVKnQvsPva+hPzruc
 github.com/jenkins-x/go-scm v1.5.117/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314 h1:kyBMx/ucSV92S+umX/V6DDaPNynlFFOM9MGJWApltoU=
 github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314/go.mod h1:C6j5HgwlHGjRU27W4XCs6jXksqYFo8OdBu+p44jqQeM=
-github.com/jenkins-x/jx v0.0.0-20200506212314-f6c0570661bd h1:zka/F2arruAkI+7aBp+LpcfzLHdxwnhILJQrlSSWogA=
-github.com/jenkins-x/jx v0.0.0-20200506212314-f6c0570661bd/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/jx v0.0.0-20200507095921-7d7b43305a4e h1:89QAH0281mtUvcjJrojSff042ybyaU7cjiSDb6RUlp4=
 github.com/jenkins-x/jx v0.0.0-20200507095921-7d7b43305a4e/go.mod h1:AJ/IR1nGGbDLePNIxD0X9yiGGmlIJDB7+OuiBcT+KHo=
 github.com/jenkins-x/jx v0.0.0-20200507114739-db0ae9c1d21c h1:cCkyT+bgeXnSvbtjolAbET5HzV+6tLoq8FVtbXyhIo0=


### PR DESCRIPTION
This will fail until https://github.com/jenkins-x/jx/pull/7160 is merged and in the version stream.

fixes https://github.com/jenkins-x/jx/issues/7154

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>