### PR TITLE
fix: Switch SCM client panics to ErrNotSupported

### DIFF
--- a/pkg/scmprovider/client.go
+++ b/pkg/scmprovider/client.go
@@ -93,17 +93,17 @@ type Client struct {
 
 // ClearMilestone clears milestone
 func (c *Client) ClearMilestone(org, repo string, num int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }
 
 // SetMilestone sets milestone
 func (c *Client) SetMilestone(org, repo string, issueNum, milestoneNum int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }
 
 // ListMilestones list milestones
 func (c *Client) ListMilestones(org, repo string) ([]Milestone, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 // BotName returns the bot name

--- a/pkg/scmprovider/issues.go
+++ b/pkg/scmprovider/issues.go
@@ -286,15 +286,15 @@ func (c *Client) EditComment(owner, repo string, number int, id int, comment str
 
 // ReopenIssue reopen an issue
 func (c *Client) ReopenIssue(owner, repo string, number int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }
 
 // FindIssues find issues
 func (c *Client) FindIssues(query, sort string, asc bool) ([]scm.Issue, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 // CloseIssue close issue
 func (c *Client) CloseIssue(owner, repo string, number int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }

--- a/pkg/scmprovider/pull_requests.go
+++ b/pkg/scmprovider/pull_requests.go
@@ -156,10 +156,10 @@ func (e MergeCommitsForbiddenError) Error() string { return string(e) }
 
 // ReopenPR reopens a pull request
 func (c *Client) ReopenPR(owner, repo string, number int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }
 
 // ClosePR closes a pull request
 func (c *Client) ClosePR(owner, repo string, number int) error {
-	panic("implement me")
+	return scm.ErrNotSupported
 }


### PR DESCRIPTION
Because we shouldn't be panicking in production, thanks.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>