### PR TITLE
feat: BitBucket Server support via comments emulating labels

### DIFF
--- a/bdd/bbs/ci.sh
+++ b/bdd/bbs/ci.sh
@@ -67,16 +67,13 @@ rm values.tmpl.yaml.tmp
 sed -e s/\$VERSION/${VERSION}/g ../bdd/helm-requirements.yaml.template > env/requirements.yaml
 
 # TODO: Disable chatops tests until issue creation and labeling on BBS is ready
-export BDD_ENABLE_TEST_CHATOPS_COMMANDS="false"
+export BDD_ENABLE_TEST_CHATOPS_COMMANDS="true"
 
 echo "Building lighthouse with version $VERSION"
 
 # TODO hack until we fix boot to do this too!
 helm init --client-only
 helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
-
-# TODO: Re-enable checking whether build controller has updated PipelineActivity once BBS is actually being worked on again.
-export BDD_DISABLE_PIPELINEACTIVITY_CHECK=true
 
 # Enable checking the commit status reporting URL
 export BDD_LIGHTHOUSE_BASE_REPORT_URL=https://example.com
@@ -95,9 +92,8 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-create-spring
-
-# Bitbucket doesn't have pull request labels, so...yeah. Can't do quickstart tests, to say the least.
+    --tests test-create-spring \
+    --tests test-lighthouse
 
 bdd_result=$?
 if [[ $bdd_result != 0 ]]; then

--- a/pkg/scmprovider/issues.go
+++ b/pkg/scmprovider/issues.go
@@ -106,6 +106,9 @@ func (c *Client) AddLabel(owner, repo string, number int, label string, pr bool)
 	ctx := context.Background()
 	fullName := c.repositoryName(owner, repo)
 	if pr {
+		if !c.SupportsPRLabels() {
+			return AddLabelToComment(c, owner, repo, number, label)
+		}
 		_, err := c.client.PullRequests.AddLabel(ctx, fullName, number, label)
 		return err
 	}
@@ -118,6 +121,9 @@ func (c *Client) RemoveLabel(owner, repo string, number int, label string, pr bo
 	ctx := context.Background()
 	fullName := c.repositoryName(owner, repo)
 	if pr {
+		if !c.SupportsPRLabels() {
+			return DeleteLabelFromComment(c, owner, repo, number, label)
+		}
 		_, err := c.client.PullRequests.DeleteLabel(ctx, fullName, number, label)
 		return err
 	}
@@ -198,6 +204,9 @@ func (c *Client) GetIssueLabels(org, repo string, number int, pr bool) ([]*scm.L
 		Page: 1,
 	}
 	if pr {
+		if !c.SupportsPRLabels() {
+			return GetLabelsFromComment(c, org, repo, number)
+		}
 		for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
 			labels, resp, err = c.client.PullRequests.ListLabels(ctx, fullName, number, opts)
 			if err != nil {

--- a/pkg/scmprovider/labels.go
+++ b/pkg/scmprovider/labels.go
@@ -1,0 +1,144 @@
+package scmprovider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jenkins-x/go-scm/scm"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	labelTag = "<!-- label report -->"
+)
+
+// GetLabelsFromComment extracts the applied "labels" from a pull request from a comment
+func GetLabelsFromComment(spc SCMClient, org, repo string, number int) ([]*scm.Label, error) {
+	comment, err := GetLabelReportComment(spc, org, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []*scm.Label
+
+	for _, l := range parseLabelReportComment(comment).List() {
+		labels = append(labels, &scm.Label{
+			Name: l,
+		})
+	}
+
+	return labels, nil
+}
+
+// DeleteLabelFromComment removes a label from the tracking comment
+func DeleteLabelFromComment(spc SCMClient, org, repo string, number int, label string) error {
+	comment, err := GetLabelReportComment(spc, org, repo, number)
+	if err != nil {
+		return err
+	}
+	existingLabels := parseLabelReportComment(comment)
+
+	existingLabels.Delete(label)
+
+	if existingLabels.Len() == 0 {
+		if comment != nil {
+			return spc.DeleteComment(org, repo, number, comment.ID, true)
+		}
+		// If there isn't a comment and there are no labels, we've never really labeled in the first place so hey.
+		return nil
+	}
+	newCommentBody := CreateLabelComment(existingLabels.List())
+
+	if comment != nil && comment.Body != newCommentBody {
+		return spc.EditComment(org, repo, number, comment.ID, newCommentBody, true)
+	}
+	if comment == nil {
+		return spc.CreateComment(org, repo, number, true, newCommentBody)
+	}
+	return nil
+}
+
+// AddLabelToComment adds a label to the tracking comment
+func AddLabelToComment(spc SCMClient, org, repo string, number int, label string) error {
+	comment, err := GetLabelReportComment(spc, org, repo, number)
+	if err != nil {
+		return err
+	}
+	existingLabels := parseLabelReportComment(comment)
+
+	existingLabels.Insert(label)
+
+	newCommentBody := CreateLabelComment(existingLabels.List())
+
+	if comment == nil {
+		return spc.CreateComment(org, repo, number, true, newCommentBody)
+	}
+	if comment.Body != newCommentBody {
+		return spc.EditComment(org, repo, number, comment.ID, newCommentBody, true)
+	}
+	return nil
+}
+
+func parseLabelReportComment(comment *scm.Comment) sets.String {
+	labels := sets.NewString()
+	if comment == nil {
+		return labels
+	}
+	var tracking bool
+	for _, line := range strings.Split(comment.Body, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "|")
+		line = strings.TrimSuffix(line, "|")
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "---") {
+			tracking = true
+		} else if len(line) == 0 {
+			tracking = false
+		} else if tracking {
+			labels.Insert(line)
+		}
+	}
+	return labels
+}
+
+// GetLabelReportComment gets the scm.Comment, if present, containing the label report.
+func GetLabelReportComment(spc SCMClient, org, repo string, number int) (*scm.Comment, error) {
+	prcs, err := spc.ListPullRequestComments(org, repo, number)
+	if err != nil {
+		return nil, fmt.Errorf("error listing comments: %v", err)
+	}
+	botName, err := spc.BotName()
+	if err != nil {
+		return nil, fmt.Errorf("error getting bot name: %v", err)
+	}
+
+	for _, comment := range prcs {
+		if comment.Author.Login != botName {
+			continue
+		}
+		if !strings.Contains(comment.Body, labelTag) {
+			continue
+		}
+
+		return comment, nil
+	}
+	return nil, nil
+}
+
+// CreateLabelComment creates the appropriate comment structure for the relevant labels
+func CreateLabelComment(labels []string) string {
+	lines := []string{
+		"The following labels have been applied to this pull request:",
+		"",
+		"| Label name |",
+		"| --- |",
+	}
+	for _, l := range labels {
+		lines = append(lines, fmt.Sprintf("| %s |", l))
+	}
+	lines = append(lines, []string{
+		"",
+		labelTag,
+	}...)
+	return strings.Join(lines, "\n")
+}

--- a/pkg/scmprovider/test_helpers.go
+++ b/pkg/scmprovider/test_helpers.go
@@ -2,12 +2,63 @@ package scmprovider
 
 import (
 	"github.com/jenkins-x/go-scm/scm"
+	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/jenkins-x/lighthouse/pkg/labels"
+	"github.com/pkg/errors"
 )
 
 // TestBotName is the default bot name used in tests
-var TestBotName = "jenkins-x-bot"
+var TestBotName = "k8s-ci-robot"
+
+// TestClient uses the go-scm fake client behind the scenes and allows access to its test data
+type TestClient struct {
+	Client
+
+	Data *fake.Data
+}
 
 // ToTestClient converts the scm client to an API that the prow plugins expect
-func ToTestClient(client *scm.Client) *Client {
-	return &Client{client: client, botName: TestBotName}
+func ToTestClient(client *scm.Client) *TestClient {
+	return &TestClient{
+		Client: Client{client: client, botName: TestBotName},
+		Data:   nil,
+	}
+}
+
+// NewTestClientForLabelsInComments returns a test client specifically for testing the scenario of labels not being available
+func NewTestClientForLabelsInComments() *TestClient {
+	fakeScmClient, fc := fake.NewDefault()
+	fakeScmClient.Driver = scm.DriverCoding
+
+	return &TestClient{
+		Client: Client{
+			client:  fakeScmClient,
+			botName: TestBotName,
+		},
+		Data: fc,
+	}
+}
+
+// PopulateFakeLabelsFromComments checks if there's Data for this test client, and if it doesn't support PR labels. If so,
+// it populates the label-related fields in the data from the comments.
+func (t *TestClient) PopulateFakeLabelsFromComments(org, repo string, number int, fakeLabel string, shouldUnlabel bool) error {
+	if t.Data != nil && !t.SupportsPRLabels() {
+		prLabels, err := t.GetIssueLabels(org, repo, number, true)
+		if err != nil {
+			return errors.Wrapf(err, "Unexpected error getting label comments")
+		}
+		hasLabel := false
+		for _, c := range prLabels {
+			if c.Name == labels.WorkInProgress {
+				t.Data.PullRequestLabelsAdded = append(t.Data.PullRequestLabelsAdded, fakeLabel)
+				hasLabel = true
+			} else {
+				t.Data.PullRequestLabelsAdded = append(t.Data.PullRequestLabelsAdded, fakeLabel)
+			}
+		}
+		if !hasLabel && shouldUnlabel {
+			t.Data.PullRequestLabelsRemoved = append(t.Data.PullRequestLabelsRemoved, fakeLabel)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Very, very, very super-preliminary. I need to add a bunch of more tests of the workaround logic for the hook side of adding/removing labels, and to Keeper's behavior as well. And I need to update `bdd-jx` to deal with this too. But hey, it's a start.

fixes #727

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>