### PR TITLE
fix: Lower-case owner/org in Foghorn job lookup

### DIFF
--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -366,7 +366,7 @@ func createLabelSelectorFromActivity(activity *record.ActivityRecord) (labels.Se
 	var selectors []string
 
 	if activity.Owner != "" {
-		selectors = append(selectors, fmt.Sprintf("%s=%s", util.OrgLabel, activity.Owner))
+		selectors = append(selectors, fmt.Sprintf("%s=%s", util.OrgLabel, strings.ToLower(activity.Owner)))
 	}
 	if activity.Repo != "" {
 		selectors = append(selectors, fmt.Sprintf("%s=%s", util.RepoLabel, activity.Repo))


### PR DESCRIPTION
We had been comparing the owner label on the `PipelineActivity`, which is always lower case, but now we're comparing the `record.Owner`, which is coming from the `PipelineActivity.Spec.GitOwner`, which isn't forced to lowercase, so let's handle that properly.

fixes #832

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>