### PR TITLE
fix: Use $() instead of ${} in pipeline params

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,7 @@ github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b h1:oGq
 github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b/go.mod h1:Wtl/v6YdQxv397EREtzwgd9+Ud7Q5D8XMbi3Zazgkrs=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v32 v32.0.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-licenses v0.0.0-20191112164736-212ea350c932/go.mod h1:16wa6pRqNDUIhOtwF0GcROVqMeXHZJ7H6eGDFUh5Pfk=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -753,6 +754,7 @@ github.com/jenkins-x/jx-logging v0.0.10 h1:K1+2NaWOOk2pP9dJlErjlOvYbA24oQ9D9ItJI
 github.com/jenkins-x/jx-logging v0.0.10/go.mod h1:mjEejiArk2Mk+J+72/YcSKGo9bZlJ/LwKYjMgAiv+G4=
 github.com/jenkins-x/jx/v2 v2.1.98 h1:Lxq+EqQKjZeHWekmxvDg/gCwg7FCLaUNGPNRtt+geLA=
 github.com/jenkins-x/jx/v2 v2.1.98/go.mod h1:gszLGbo65HRFg3m9UUxUgnRda6RrCDqvDjDFlelliMA=
+github.com/jenkins-x/jx/v2 v2.1.101/go.mod h1:is2IOY+26ubdmd6txOz0J+V5miDOkePTJRcRHBMgdSA=
 github.com/jenkins-x/lighthouse-config v0.0.6 h1:s73GxzEaqsqn/9w+VnkPKLx4lSs450PMgk4rpCioOm0=
 github.com/jenkins-x/lighthouse-config v0.0.6/go.mod h1:5ax5UF79SGM+Xc3HrWR/9LsPQBWDxE+TEJMwPAikst8=
 github.com/jenkins-x/lighthouse-config v0.0.7 h1:v2yBD4Jup9XUmFi2dXfmPrkjXTNPuLZBj+rZlxi05fQ=

--- a/jenkins-x-bbs.yml
+++ b/jenkins-x-bbs.yml
@@ -94,7 +94,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.webhooks
-                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
 
@@ -103,30 +103,30 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.keeper
-                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-foghorn
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.foghorn
-                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.gcJobs
-                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - command: bdd/bbs/ci.sh
                 name: runci

--- a/jenkins-x-ghe.yml
+++ b/jenkins-x-ghe.yml
@@ -94,7 +94,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.webhooks
-                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
 
@@ -103,30 +103,30 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.keeper
-                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-foghorn
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.foghorn
-                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.gcJobs
-                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - command: bdd/ghe/ci.sh
                 name: runci

--- a/jenkins-x-github.yml
+++ b/jenkins-x-github.yml
@@ -94,7 +94,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.webhooks
-                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
 
@@ -103,30 +103,30 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.keeper
-                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-foghorn
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.foghorn
-                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.gcJobs
-                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - command: bdd/github/ci.sh
                 name: runci

--- a/jenkins-x-gitlab.yml
+++ b/jenkins-x-gitlab.yml
@@ -94,7 +94,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.webhooks
-                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
 
@@ -103,30 +103,30 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.keeper
-                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-keeper:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-foghorn
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.foghorn
-                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.gcJobs
-                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - command: bdd/gitlab/ci.sh
                 name: runci

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -149,7 +149,7 @@ pipelineConfig:
                 command: /kaniko/executor
                 args: 
                 - --dockerfile=/workspace/source/Dockerfile.webhooks
-                - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:${inputs.params.version}
+                - --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$(inputs.params.version)
                 - --context=/workspace/source
                 - --cache-dir=/workspace
 
@@ -158,30 +158,30 @@ pipelineConfig:
                 command: /kaniko/executor
                 args:
                 - --dockerfile=/workspace/source/Dockerfile.keeper
-                - --destination=gcr.io/jenkinsxio/lighthouse-keeper:${inputs.params.version}
+                - --destination=gcr.io/jenkinsxio/lighthouse-keeper:$(inputs.params.version)
                 - --context=/workspace/source
                 - --cache-dir=/workspace
-                - --build-arg=VERSION=${inputs.params.version}
+                - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-foghorn
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.foghorn
-                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor
                 args:
                   - --dockerfile=/workspace/source/Dockerfile.gcJobs
-                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:${inputs.params.version}
+                  - --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$(inputs.params.version)
                   - --context=/workspace/source
                   - --cache-dir=/workspace
-                  - --build-arg=VERSION=${inputs.params.version}
+                  - --build-arg=VERSION=$(inputs.params.version)
 
               - name: release
                 image: gcr.io/jenkinsxio/builder-go


### PR DESCRIPTION
Tekton 0.11 needs this change.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>