### PR TITLE
fix: Don't make tidy-deps on jx

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -206,7 +206,7 @@ pipelineConfig:
                   - --version
                   - $VERSION
                   - --build
-                  - "\"make build tidy-deps\""
+                  - "\"make mod\""
                   - --repo
                   - https://github.com/jenkins-x/jx.git
 


### PR DESCRIPTION
That can cause problems. There'll be a `make mod` soon (when https://github.com/jenkins-x/jx/pull/7487 merges), though, so let's use that.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>