### PR TITLE
fix: Get rid of whitelist/blacklist terminology

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,9 +106,12 @@ type ProwConfig struct {
 	// PushGateway is a prometheus push gateway.
 	PushGateway PushGateway `json:"push_gateway,omitempty"`
 
-	// OwnersDirBlacklist is used to configure which directories to ignore when
+	// OwnersDirExcludes is used to configure which directories to ignore when
 	// searching for OWNERS{,_ALIAS} files in a repo.
-	OwnersDirBlacklist OwnersDirBlacklist `json:"owners_dir_blacklist,omitempty"`
+	OwnersDirExcludes *OwnersDirExcludes `json:"owners_dir_excludes,omitempty"`
+
+	// OwnersDirExcludes is DEPRECATED in favor of OwnersDirExcludes
+	OwnersDirBlacklist *OwnersDirExcludes `json:"owners_dir_blacklist,omitempty"`
 
 	// Pub/Sub Subscriptions that we want to listen to
 	PubSubSubscriptions PubsubSubscriptions `json:"pubsub_subscriptions,omitempty"`
@@ -131,9 +134,9 @@ type ProviderConfig struct {
 	BotUser string `json:"botUser,omitempty"`
 }
 
-// OwnersDirBlacklist is used to configure which directories to ignore when
+// OwnersDirExcludes is used to configure which directories to ignore when
 // searching for OWNERS{,_ALIAS} files in a repo.
-type OwnersDirBlacklist struct {
+type OwnersDirExcludes struct {
 	// Repos configures a directory blacklist per repo (or org)
 	Repos map[string][]string `json:"repos"`
 	// Default configures a default blacklist for repos (or orgs) not
@@ -637,6 +640,10 @@ func (c *Config) finalizeJobConfig() error {
 		if err := resolvePresets(v.Name, v.Labels, v.Spec, c.Presets); err != nil {
 			return err
 		}
+	}
+
+	if c.OwnersDirExcludes == nil {
+		c.OwnersDirExcludes = c.OwnersDirBlacklist
 	}
 
 	return nil

--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -231,7 +231,7 @@ func (br Brancher) GetRE() *regexp.Regexp {
 	return br.re
 }
 
-// ShouldRun returns true if the input branch matches, given the whitelist/blacklist.
+// ShouldRun returns true if the input branch matches, given the includes/excludes.
 func (br Brancher) ShouldRun(branch string) bool {
 	if br.RunsAgainstAllBranch() {
 		return true

--- a/pkg/keeper/status.go
+++ b/pkg/keeper/status.go
@@ -126,22 +126,22 @@ func requirementDiff(pr *PullRequest, q *config.KeeperQuery, cc contextChecker) 
 
 	// Weight incorrect branches with very high diff so that we select the query
 	// for the correct branch.
-	targetBranchBlacklisted := false
+	targetBranchExcluded := false
 	for _, excludedBranch := range q.ExcludedBranches {
 		if string(pr.BaseRef.Name) == excludedBranch {
-			targetBranchBlacklisted = true
+			targetBranchExcluded = true
 			break
 		}
 	}
-	// if no whitelist is configured, the target is OK by default
-	targetBranchWhitelisted := len(q.IncludedBranches) == 0
+	// if no inclusion list is configured, the target is OK by default
+	targetBranchIncluded := len(q.IncludedBranches) == 0
 	for _, includedBranch := range q.IncludedBranches {
 		if string(pr.BaseRef.Name) == includedBranch {
-			targetBranchWhitelisted = true
+			targetBranchIncluded = true
 			break
 		}
 	}
-	if targetBranchBlacklisted || !targetBranchWhitelisted {
+	if targetBranchExcluded || !targetBranchIncluded {
 		diff += 1000
 		if desc == "" {
 			desc = fmt.Sprintf(" Merging to branch %s is forbidden.", pr.BaseRef.Name)

--- a/pkg/keeper/status_test.go
+++ b/pkg/keeper/status_test.go
@@ -36,15 +36,15 @@ func TestExpectedStatus(t *testing.T) {
 	testcases := []struct {
 		name string
 
-		baseref         string
-		branchWhitelist []string
-		branchBlacklist []string
-		sameBranchReqs  bool
-		labels          []string
-		milestone       string
-		contexts        []Context
-		inPool          bool
-		blocks          []int
+		baseref           string
+		branchIncludeList []string
+		branchExcludeList []string
+		sameBranchReqs    bool
+		labels            []string
+		milestone         string
+		contexts          []Context
+		inPool            bool
+		blocks            []int
 
 		state string
 		desc  string
@@ -101,34 +101,34 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Needs need-1 label."),
 		},
 		{
-			name:            "against excluded branch",
-			baseref:         "bad",
-			branchBlacklist: []string{"bad"},
-			sameBranchReqs:  true,
-			labels:          neededLabels,
-			inPool:          false,
+			name:              "against excluded branch",
+			baseref:           "bad",
+			branchExcludeList: []string{"bad"},
+			sameBranchReqs:    true,
+			labels:            neededLabels,
+			inPool:            false,
 
 			state: scmprovider.StatusPending,
 			desc:  fmt.Sprintf(statusNotInPool, " Merging to branch bad is forbidden."),
 		},
 		{
-			name:            "not against included branch",
-			baseref:         "bad",
-			branchWhitelist: []string{"good"},
-			sameBranchReqs:  true,
-			labels:          neededLabels,
-			inPool:          false,
+			name:              "not against included branch",
+			baseref:           "bad",
+			branchIncludeList: []string{"good"},
+			sameBranchReqs:    true,
+			labels:            neededLabels,
+			inPool:            false,
 
 			state: scmprovider.StatusPending,
 			desc:  fmt.Sprintf(statusNotInPool, " Merging to branch bad is forbidden."),
 		},
 		{
-			name:            "choose query for correct branch",
-			baseref:         "bad",
-			branchWhitelist: []string{"good"},
-			milestone:       "v1.0",
-			labels:          neededLabels,
-			inPool:          false,
+			name:              "choose query for correct branch",
+			baseref:           "bad",
+			branchIncludeList: []string{"good"},
+			milestone:         "v1.0",
+			labels:            neededLabels,
+			inPool:            false,
 
 			state: scmprovider.StatusPending,
 			desc:  fmt.Sprintf(statusNotInPool, " Needs 1, 2, 3, 4, 5, 6, 7 labels."),
@@ -215,14 +215,14 @@ func TestExpectedStatus(t *testing.T) {
 			Milestone: "v1.0",
 		}
 		if tc.sameBranchReqs {
-			secondQuery.ExcludedBranches = tc.branchBlacklist
-			secondQuery.IncludedBranches = tc.branchWhitelist
+			secondQuery.ExcludedBranches = tc.branchExcludeList
+			secondQuery.IncludedBranches = tc.branchIncludeList
 		}
 		queriesByRepo := config.KeeperQueries{
 			config.KeeperQuery{
 				Orgs:             []string{""},
-				ExcludedBranches: tc.branchBlacklist,
-				IncludedBranches: tc.branchWhitelist,
+				ExcludedBranches: tc.branchExcludeList,
+				IncludedBranches: tc.branchIncludeList,
 				Labels:           neededLabels,
 				MissingLabels:    forbiddenLabels,
 				Milestone:        "v1.0",

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -143,9 +143,12 @@ type Owners struct {
 	// control in the provided repos.
 	SkipCollaborators []string `json:"skip_collaborators,omitempty"`
 
-	// LabelsBlackList holds a list of labels that should not be present in any
+	// LabelsExcludeList holds a list of labels that should not be present in any
 	// OWNERS file, preventing their automatic addition by the owners-label plugin.
 	// This check is performed by the verify-owners plugin.
+	LabelsExcludeList []string `json:"labels_excludes,omitempty"`
+
+	// LabelsBlackList is DEPRECATED in favor of LabelsExcludeList
 	LabelsBlackList []string `json:"labels_blacklist,omitempty"`
 }
 
@@ -438,16 +441,20 @@ type ConfigUpdater struct {
 
 // MergeWarning is a config for the slackevents plugin's manual merge warnings.
 // If a PR is pushed to any of the repos listed in the config then send messages
-// to the all the slack channels listed if pusher is NOT in the whitelist.
+// to the all the slack channels listed if pusher is NOT in the includes.
 type MergeWarning struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`
 	// List of channels on which a event is published.
 	Channels []string `json:"channels,omitempty"`
-	// A slack event is published if the user is not part of the WhiteList.
-	WhiteList []string `json:"whitelist,omitempty"`
-	// A slack event is published if the user is not on the branch whitelist
-	BranchWhiteList map[string][]string `json:"branch_whitelist,omitempty"`
+	// A slack event is published if the user is not part of the includes.
+	Includes []string `json:"includes,omitempty"`
+	// Deprecated in favor of Includes
+	Whitelist []string `json:"whitelist,omitempty"`
+	// A slack event is published if the user is not in the branch includes
+	BranchIncludes map[string][]string `json:"branch_includes,omitempty"`
+	// Deprecated in favor of BranchIncludes
+	BranchWhitelist map[string][]string `json:"branch_whitelist,omitempty"`
 }
 
 // Welcome is config for the welcome plugin.
@@ -689,8 +696,11 @@ func (c *Configuration) setDefaults() {
 	if c.SigMention.Regexp == "" {
 		c.SigMention.Regexp = `(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`
 	}
-	if c.Owners.LabelsBlackList == nil {
-		c.Owners.LabelsBlackList = []string{labels.Approved, labels.LGTM}
+	if c.Owners.LabelsExcludeList == nil {
+		c.Owners.LabelsExcludeList = c.Owners.LabelsBlackList
+	}
+	if c.Owners.LabelsExcludeList == nil {
+		c.Owners.LabelsExcludeList = []string{labels.Approved, labels.LGTM}
 	}
 	for _, milestone := range c.RepoMilestone {
 		if milestone.MaintainersFriendlyName == "" {

--- a/pkg/webhook/test_data/test_config.yaml
+++ b/pkg/webhook/test_data/test_config.yaml
@@ -68,7 +68,7 @@ branch-protection:
 deck:
   spyglass: {}
 gerrit: {}
-owners_dir_blacklist:
+owners_dir_excludes:
   default: null
   repos: null
 plank: {}

--- a/test/e2e/test_data/example-config.tmpl.yml
+++ b/test/e2e/test_data/example-config.tmpl.yml
@@ -12,7 +12,7 @@ deck:
 gerrit: {}
 github:
   LinkURL: null
-owners_dir_blacklist:
+owners_dir_excludes:
   default: null
   repos: null
 plank: {}


### PR DESCRIPTION
the `owners_dir_blacklist` field in the `config` `ConfigMap`, and the `labels_blacklist` field in the `plugins` `ConfigMap` should now change to `owners_dir_excludes` and `labels_excludes` respectively, but the existing fields will still function.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>