### PR TITLE
feat(tekton): Set a default 24 hour timeout for created PipelineRuns

### DIFF
--- a/pkg/engines/tekton/controller.go
+++ b/pkg/engines/tekton/controller.go
@@ -491,6 +491,10 @@ func (c *Controller) makePipelineRun(lj v1alpha1.LighthouseJob) (*tektonv1beta1.
 		},
 		Spec: *specCopy,
 	}
+	// Set a default timeout of 1 day if no timeout is specified
+	if p.Spec.Timeout == nil {
+		p.Spec.Timeout = &metav1.Duration{Duration: 24 * time.Hour}
+	}
 	p.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion: lighthouse.GroupAndVersion,
 		Kind:       "LighthouseJob",

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
@@ -28,7 +28,6 @@ spec:
     podTemplate:
       schedulerName: ""
     serviceAccountName: tekton-bot
-    timeout: 240h0m0s
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
@@ -55,5 +55,5 @@ spec:
   podTemplate:
     schedulerName: ""
   serviceAccountName: tekton-bot
-  timeout: 240h0m0s
+  timeout: 24h0m0s
 status: {}

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
@@ -26,7 +26,6 @@ spec:
     podTemplate:
       schedulerName: ""
     serviceAccountName: tekton-bot
-    timeout: 240h0m0s
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master


### PR DESCRIPTION
fixes #880

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>