### PR TITLE
fix: Only use GraphQL for GitHub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/hashicorp/go-multierror v1.1.0
-	github.com/jenkins-x/go-scm v1.5.154
+	github.com/jenkins-x/go-scm v1.5.155
 	github.com/mattn/go-zglob v0.0.1
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/U
 github.com/jenkins-x/go-scm v1.5.65/go.mod h1:MgGRkJScE/rJ30J/bXYqduN5sDPZqZFITJopsnZmTOw=
 github.com/jenkins-x/go-scm v1.5.79/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jenkins-x/go-scm v1.5.117/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
-github.com/jenkins-x/go-scm v1.5.154 h1:LD/Pdx4O8JFTPKhFF/rrvWrw40+LPSA1V0w9eOLvuNk=
-github.com/jenkins-x/go-scm v1.5.154/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
+github.com/jenkins-x/go-scm v1.5.155 h1:mTUssRLKfm0mv5eOzJZ510RfpoWI7DaWSInNpQXurEs=
+github.com/jenkins-x/go-scm v1.5.155/go.mod h1:Gt1dJz1rH47GbMlL47mWkibKHAM5+htwzOpsGmEbvfg=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.1.1-0.20200408213659-1dcf20c371bb h1:woC0LbYpL9rgwZn13Z0KQBEGAmi9ugpWgWtQezHqsBM=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.1.1-0.20200408213659-1dcf20c371bb/go.mod h1:Erk5rrGYkvFlFAoVbz/7obMDEIUFCEbhK1odoR0Msqo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/scmprovider/client.go
+++ b/pkg/scmprovider/client.go
@@ -149,8 +149,9 @@ func (c *Client) ServerURL() *url.URL {
 }
 
 // SupportsGraphQL returns true if the underlying provider supports our GraphQL queries
+// Currently, that means it has to be GitHub.
 func (c *Client) SupportsGraphQL() bool {
-	return c.client.GraphQL != nil
+	return c.client.Driver == scm.DriverGithub
 }
 
 // ProviderType returns the type of the underlying SCM provider


### PR DESCRIPTION
With go-scm 1.5.155, there's a GraphQL client for GitLab, but it won't actually work for our needs, so we need to change the check for when to use GraphQL to explicitly just be when we're on GitHub for now.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>