### PR TITLE
fix: Check if OwnersDirExcludes is non-nil before using it

### DIFF
--- a/pkg/repoowners/repoowners.go
+++ b/pkg/repoowners/repoowners.go
@@ -233,12 +233,15 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 
 		excludeConfig := c.config.OwnersDirExcludes
 
-		dirExcludes := defaultDirExcludes.Union(sets.NewString(excludeConfig.Default...))
-		if bl, ok := excludeConfig.Repos[org]; ok {
-			dirExcludes.Insert(bl...)
-		}
-		if bl, ok := excludeConfig.Repos[org+"/"+repo]; ok {
-			dirExcludes.Insert(bl...)
+		dirExcludes := sets.NewString()
+		if excludeConfig != nil {
+			dirExcludes = defaultDirExcludes.Union(sets.NewString(excludeConfig.Default...))
+			if bl, ok := excludeConfig.Repos[org]; ok {
+				dirExcludes.Insert(bl...)
+			}
+			if bl, ok := excludeConfig.Repos[org+"/"+repo]; ok {
+				dirExcludes.Insert(bl...)
+			}
 		}
 		entry.owners, err = loadOwnersFrom(gitRepo.Dir, mdYaml, entry.aliases, dirExcludes, log)
 		if err != nil {


### PR DESCRIPTION
fixes #891

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>