### PR TITLE
fix: Fix helm chart missing argument in ne condition

### DIFF
--- a/charts/lighthouse/templates/plugins-cm.yaml
+++ b/charts/lighthouse/templates/plugins-cm.yaml
@@ -37,7 +37,7 @@ data:
     label:
       additional_labels: null
     owners: {}
-{{- if ne .Values.configMaps.configUpdater.orgAndRepo }}
+{{- if ne .Values.configMaps.configUpdater.orgAndRepo "" }}
     plugins:
       {{ .Values.configMaps.configUpdater.orgAndRepo }}:
       - config-updater


### PR DESCRIPTION
This PR fixes a missing argument in ne condition in the lighthouse helm chart 

Fixes #900 