### PR TITLE
feat: Support passing config.yaml and plugins.yaml to helm chart

### DIFF
--- a/charts/lighthouse/templates/config-cm.yaml
+++ b/charts/lighthouse/templates/config-cm.yaml
@@ -1,7 +1,7 @@
 {{- /*
 Only create the "config" ConfigMap on install, so that we don't overwrite it on upgrade.
 */ -}}
-{{- if and .Values.configMaps.create (not .Release.IsUpgrade) }}
+{{- if and .Values.configMaps.create (or (not .Release.IsUpgrade) .Values.configMaps.config) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 data:
+{{- if .Values.configMaps.config }}
+  config.yaml: |
+{{ .Values.configMaps.config | indent 4 }}
+{{- else }}
   config.yaml: |
     branch-protection:
       orgs: {}
@@ -55,4 +59,5 @@ data:
         - needs-ok-to-test
         - needs-rebase
         repos: []
+{{- end }}
 {{- end }}

--- a/charts/lighthouse/templates/plugins-cm.yaml
+++ b/charts/lighthouse/templates/plugins-cm.yaml
@@ -1,7 +1,7 @@
 {{- /*
-Only create the "config" ConfigMap on install, so that we don't overwrite it on upgrade.
+Only create the "plugins" ConfigMap on install, so that we don't overwrite it on upgrade.
 */ -}}
-{{- if and .Values.configMaps.create (not .Release.IsUpgrade) }}
+{{- if and .Values.configMaps.create (or (not .Release.IsUpgrade) .Values.configMaps.plugins) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 data:
+{{- if .Values.configMaps.plugins }}
+  plugins.yaml: |
+{{ .Values.configMaps.plugins | indent 4 }}
+{{- else }}
   plugins.yaml: |
     approve:
     - lgtm_acts_as_approve: true
@@ -79,4 +83,5 @@ data:
     #   trusted_org: org
     welcome:
     - message_template: Welcome
+{{- end }}
 {{- end }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -161,6 +161,8 @@ hook:
 
 configMaps:
   create: false
+  config: null
+  plugins: null
   configUpdater:
     orgAndRepo: ""
     path: ""


### PR DESCRIPTION
This PR adds support for passing `config.yaml` and `plugins.yaml` directly to helm chart.

Two new parameters are added : `configMaps.config` and `configMaps.plugins`.

The chart can then be installed with:

```bash
helm install .... \
--set configMaps.create=true \
--set-file configMaps.config=./config.yaml \
--set-file configMaps.plugins=./plugins.yaml
```

/cc @abayer 

Closes #906 