### PR TITLE
chore: Add makefile and (potentially) OWNERS to helmignore

### DIFF
--- a/charts/lighthouse/.helmignore
+++ b/charts/lighthouse/.helmignore
@@ -19,3 +19,6 @@
 .project
 .idea/
 *.tmproj
+# Project files
+Makefile
+OWNERS


### PR DESCRIPTION
This PR adds makefile and (potentially) OWNERS to helmignore.

There should be no point in adding the Makefile in helm package.
I added OWNERS too as it is common to have an OWNERS files.