### PR TITLE
fix: Stop using in-cluster chartmuseum in BDD requirements

### DIFF
--- a/bdd/helm-requirements.yaml.template
+++ b/bdd/helm-requirements.yaml.template
@@ -11,7 +11,7 @@ dependencies:
   - alias: lighthouse
     condition: lighthouse.enabled
     name: lighthouse
-    repository: https://chartmuseum-jx.jenkins-x.live
+    repository: https://chartmuseum.jenkins-x.io
     version: $VERSION
   - alias: lighthouse-jx
     condition: lighthouse.enabled


### PR DESCRIPTION
The internal chartmuseum tends to explode lately for reasons I don't understand, but its contents are mirrored promptly enough to the public-facing one that we might as well just use that and avoid the pain.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>