### PR TITLE
docs: Add yuks plugin docs

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -30,7 +30,7 @@
 | updateconfig          | `config_updater`          | TODO |
 | welcome               | `welcome`                 | TODO |
 | wip                   |                           | TODO |
-| yuks                  |                           | TODO |
+| yuks                  |                           | [docs](./plugins/yuks.md) |
 
 ## Plugins configuration file (plugins.yaml)
 

--- a/docs/plugins/yuks.md
+++ b/docs/plugins/yuks.md
@@ -1,0 +1,28 @@
+# yuks
+
+`yuks` plugin documentation:
+- [Description](#description)
+- [Commands](#commands)
+- [Configuration](#configuration)
+- [Compatibility matrix](#compatibility-matrix)
+
+## Description
+
+The yuks plugin comments with jokes.
+
+## Commands
+
+### /joke
+
+Posts comments with jokes in response to the `/joke` command.
+
+## Configuration
+
+This plugin has no configuration option.
+
+## Compatibility matrix
+
+|               | GitHub | GitHub Enterprise | BitBucket Server | GitLab |
+| ------------- | ------ | ----------------- | ---------------- | ------ |
+| Pull requests | Yes    | Yes               | Yes              | Yes    |
+| Commits       | Yes    | Yes               | Yes              | Yes    |


### PR DESCRIPTION
This PR adds yuks plugin docs.

I propose the following structure for plugin docs:
- Description
- Commands
- Configuration
- Compatibility matrix

I feel like those 4 sections will address most documentation aspects and having the same structure for all plugin docs helps improve docs quality.

I'm thinking about adding compatibility matrix to code also, it could be useful for porting plugins that are not compatible with all scm providers.