### PR TITLE
docs: Add lh-joke command to yuks plugin docs

### DIFF
--- a/docs/plugins/yuks.md
+++ b/docs/plugins/yuks.md
@@ -12,9 +12,9 @@ The yuks plugin comments with jokes.
 
 ## Commands
 
-### /joke
+### /joke or /lh-joke
 
-Posts comments with jokes in response to the `/joke` command.
+Posts comments with jokes in response to the `/joke` or `/lh-joke` commands.
 
 ## Configuration
 


### PR DESCRIPTION
This PR adds the `/lh-joke` command to the yuks plugin docs.