### PR TITLE
fix: Wrap payload passed to pipeline_run_params

### DIFF
--- a/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-lhjob.yml
@@ -31,11 +31,11 @@ spec:
     serviceAccountName: tekton-bot
   pipeline_run_params:
     - name: batch-refs
-      value_template: '{{ range $i, $v := .Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}'
+      value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}'
     - name: branch-name
-      value_template: '{{ .BaseRef }}'
+      value_template: '{{ .Refs.BaseRef }}'
     - name: repo-url
-      value_template: '{{ .CloneURI }}'
+      value_template: '{{ .Refs.CloneURI }}'
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/observed-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/observed-lhjob.yml
@@ -28,11 +28,11 @@ spec:
     serviceAccountName: tekton-bot
   pipeline_run_params:
     - name: batch-refs
-      value_template: '{{ range $i, $v := .Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}'
+      value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}'
     - name: branch-name
-      value_template: '{{ .BaseRef }}'
+      value_template: '{{ .Refs.BaseRef }}'
     - name: repo-url
-      value_template: '{{ .CloneURI }}'
+      value_template: '{{ .Refs.CloneURI }}'
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
@@ -31,9 +31,9 @@ spec:
     serviceAccountName: tekton-bot
   pipeline_run_params:
     - name: branch-name
-      value_template: '{{ range $i, $v := .Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
+      value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
     - name: repo-url
-      value_template: '{{ .CloneURI }}'
+      value_template: '{{ .Refs.CloneURI }}'
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
@@ -28,9 +28,9 @@ spec:
     serviceAccountName: tekton-bot
   pipeline_run_params:
     - name: branch-name
-      value_template: '{{ range $i, $v := .Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
+      value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
     - name: repo-url
-      value_template: '{{ .CloneURI }}'
+      value_template: '{{ .Refs.CloneURI }}'
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/utils.go
+++ b/pkg/engines/tekton/utils.go
@@ -83,13 +83,16 @@ func makePipelineRun(ctx context.Context, lj v1alpha1.LighthouseJob, namespace s
 		env[v1alpha1.PullPullRefEnv] = strings.Join(batchedRefsVals, " ")
 	}
 	if len(lj.Spec.PipelineRunParams) > 0 {
+		payload := map[string]interface{}{
+			"Refs": lj.Spec.Refs,
+		}
 		for _, param := range lj.Spec.PipelineRunParams {
 			parsedTemplate, err := template.New(param.Name).Parse(param.ValueTemplate)
 			if err != nil {
 				return nil, err
 			}
 			var msgBuffer bytes.Buffer
-			err = parsedTemplate.Execute(&msgBuffer, lj.Spec.Refs)
+			err = parsedTemplate.Execute(&msgBuffer, payload)
 			if err != nil {
 				return nil, err
 			}

--- a/test/e2e/tekton_test.go
+++ b/test/e2e/tekton_test.go
@@ -114,15 +114,15 @@ func ChatOpsTests() bool {
 			cfg.Presubmits[repoFullName][0].PipelineRunParams = []config.PipelineRunParam{
 				{
 					Name:          "batch-refs",
-					ValueTemplate: "{{ range $i, $v := .Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}",
+					ValueTemplate: "{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.Ref }}{{ end }}",
 				},
 				{
 					Name:          "branch-name",
-					ValueTemplate: "{{ .BaseRef }}",
+					ValueTemplate: "{{ .Refs.BaseRef }}",
 				},
 				{
 					Name:          "repo-url",
-					ValueTemplate: "{{ .CloneURI }}",
+					ValueTemplate: "{{ .Refs.CloneURI }}",
 				},
 			}
 


### PR DESCRIPTION
This PR wraps the payload passed to the template when resolving params in `pipeline_run_params`.

Instead of passing directly `spec.Refs` of the underlying `LighthouseJob`, it changes the payload to wrap `spec.Refs` into a `Refs` property.

This way, if we want to pass other data to the template it will be easier, just add a new property to the payload for the new data to be passed.