### PR TITLE
WIP: feat: Add ability to autoincrement build numbers

### DIFF
--- a/Dockerfile.buildnumbers
+++ b/Dockerfile.buildnumbers
@@ -1,0 +1,4 @@
+FROM alpine:3.10
+RUN apk add --update --no-cache ca-certificates git
+COPY ./bin/buildnumbers  /buildnumbers
+ENTRYPOINT ["/buildnumbers"]

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ KEEPER_EXECUTABLE := keeper
 FOGHORN_EXECUTABLE := foghorn
 GCJOBS_EXECUTABLE := gc-jobs
 TEKTONCONTROLLER_EXECUTABLE := lighthouse-tekton-controller
+BUILDNUMBERS_EXECUTABLE := buildnumbers
 
 WEBHOOKS_MAIN_SRC_FILE=cmd/webhooks/main.go
 KEEPER_MAIN_SRC_FILE=cmd/keeper/main.go
 FOGHORN_MAIN_SRC_FILE=cmd/foghorn/main.go
 GCJOBS_MAIN_SRC_FILE=cmd/gc/main.go
 TEKTONCONTROLLER_MAIN_SRC_FILE=cmd/tektoncontroller/main.go
+BUILDNUMBERS_MAIN_SRC_FILE=cmd/buildnumbers/main.go
 
 DOCKER_REGISTRY := jenkinsxio
 DOCKER_IMAGE_NAME := lighthouse
@@ -76,7 +78,7 @@ clean:
 	rm -rf bin build release
 
 .PHONY: build
-build: webhooks keeper foghorn tekton-controller gc-jobs
+build: webhooks keeper foghorn tekton-controller buildnumbers gc-jobs
 
 .PHONY: webhooks
 webhooks:
@@ -93,6 +95,10 @@ foghorn:
 .PHONY: gc-jobs
 gc-jobs:
 	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(GCJOBS_EXECUTABLE) $(GCJOBS_MAIN_SRC_FILE)
+
+.PHONY: buildnumbers
+buildnumbers:
+	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(BUILDNUMBERS_EXECUTABLE) $(BUILDNUMBERS_MAIN_SRC_FILE)
 
 .PHONY: tekton-controller
 tekton-controller:
@@ -112,7 +118,7 @@ mod: build
 	$(GO) mod tidy
 
 .PHONY: build-linux
-build-linux: build-webhooks-linux build-foghorn-linux build-gc-jobs-linux build-keeper-linux build-tekton-controller-linux
+build-linux: build-webhooks-linux build-foghorn-linux build-gc-jobs-linux build-keeper-linux build-buildnumbers-linux build-tekton-controller-linux
 
 .PHONY: build-webhooks-linux
 build-webhooks-linux:
@@ -125,6 +131,10 @@ build-keeper-linux:
 .PHONY: build-foghorn-linux
 build-foghorn-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(FOGHORN_EXECUTABLE) $(FOGHORN_MAIN_SRC_FILE)
+
+.PHONY: build-buildnumbers-linux
+build-buildnumbers-linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(BUILDNUMBERS_EXECUTABLE) $(BUILDNUMBERS_MAIN_SRC_FILE)
 
 .PHONY: build-gc-jobs-linux
 build-gc-jobs-linux:

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -48,6 +48,29 @@ Current chart version is `0.1.0-SNAPSHOT`
 
 | Key | Type | Description | Default |
 |-----|------|-------------|---------|
+| `buildNumbers.enable` | bool |  | `false` |
+| `buildNumbers.image.pullPolicy` | string |  | `"{{ .Values.image.pullPolicy }}"` |
+| `buildNumbers.image.repository` | string |  | `"{{ .Values.image.parentRepository }}/lighthouse-build-numbers"` |
+| `buildNumbers.image.tag` | string |  | `"{{ .Values.image.tag }}"` |
+| `buildNumbers.livenessProbe.initialDelaySeconds` | int |  | `60` |
+| `buildNumbers.livenessProbe.periodSeconds` | int |  | `10` |
+| `buildNumbers.livenessProbe.successThreshold` | int |  | `1` |
+| `buildNumbers.livenessProbe.timeoutSeconds` | int |  | `1` |
+| `buildNumbers.probe.path` | string |  | `"/healthz"` |
+| `buildNumbers.probe.port` | int |  | `8081` |
+| `buildNumbers.readinessProbe.periodSeconds` | int |  | `10` |
+| `buildNumbers.readinessProbe.successThreshold` | int |  | `1` |
+| `buildNumbers.readinessProbe.timeoutSeconds` | int |  | `1` |
+| `buildNumbers.replicaCount` | int |  | `1` |
+| `buildNumbers.resources.limits.cpu` | string |  | `"100m"` |
+| `buildNumbers.resources.limits.memory` | string |  | `"256Mi"` |
+| `buildNumbers.resources.requests.cpu` | string |  | `"80m"` |
+| `buildNumbers.resources.requests.memory` | string |  | `"128Mi"` |
+| `buildNumbers.service.externalPort` | int |  | `80` |
+| `buildNumbers.service.internalPort` | int |  | `8080` |
+| `buildNumbers.service.name` | string |  | `"lighthouse-build-numbers"` |
+| `buildNumbers.service.type` | string |  | `"ClusterIP"` |
+| `buildNumbers.terminationGracePeriodSeconds` | int |  | `30` |
 | `cluster.crds.create` | bool |  | `true` |
 | `clusterName` | string |  | `""` |
 | `configMaps.config` | string |  | `nil` |
@@ -134,7 +157,8 @@ Current chart version is `0.1.0-SNAPSHOT`
 | `webhooks.livenessProbe.periodSeconds` | int |  | `10` |
 | `webhooks.livenessProbe.successThreshold` | int |  | `1` |
 | `webhooks.livenessProbe.timeoutSeconds` | int |  | `1` |
-| `webhooks.probe.path` | string |  | `"/"` |
+| `webhooks.probe.path` | string |  | `"/healthz"` |
+| `webhooks.probe.port` | int |  | `8081` |
 | `webhooks.readinessProbe.periodSeconds` | int |  | `10` |
 | `webhooks.readinessProbe.successThreshold` | int |  | `1` |
 | `webhooks.readinessProbe.timeoutSeconds` | int |  | `1` |

--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -35,3 +35,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "tekton-controller" .Values.tektoncontroller.nameOverride -}}
 {{- printf "%s-%s" .Chart.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "buildnumbers.name" -}}
+{{- $name := default "build-counter" .Values.buildNumbers.nameOverride -}}
+{{- printf "%s-%s" .Chart.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/lighthouse/templates/buildnumbers-deployment.yaml
+++ b/charts/lighthouse/templates/buildnumbers-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.buildNumbers.enable }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "buildnumbers.name" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "buildnumbers.name" . }}
+spec:
+  replicas: {{ .Values.buildNumbers.replicaCount }}
+  selector:
+    matchLabels:
+      draft: {{ default "draft-app" .Values.draft }}
+      app: {{ template "buildnumbers.name" . }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "buildnumbers.name" . }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "buildnumbers.name" . }}
+      containers:
+      - name: {{ template "buildnumbers.name" . }}
+        image: {{ tpl .Values.buildNumbers.image.repository . }}:{{ tpl .Values.buildNumbers.image.tag . }}
+        imagePullPolicy: {{ tpl .Values.buildNumbers.image.pullPolicy . }}
+        args:
+          - "--namespace={{ .Release.Namespace }}"
+          - "--port={{ .Values.buildNumbers.service.internalPort }}"
+{{- if hasKey .Values "env" }}
+        env:
+{{- range $pkey, $pval := .Values.env }}
+          - name: {{ $pkey }}
+            value: {{ quote $pval }}
+{{- end }}
+{{- end }}
+        ports:
+        - containerPort: {{ .Values.buildNumbers.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.buildNumbers.probe.path }}
+            port: {{ .Values.buildNumbers.probe.port }}
+          initialDelaySeconds: {{ .Values.buildNumbers.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.buildNumbers.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.buildNumbers.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.buildNumbers.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.buildNumbers.probe.path }}/ready
+            port: {{ .Values.buildNumbers.probe.port }}
+          periodSeconds: {{ .Values.buildNumbers.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.buildNumbers.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.buildNumbers.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.buildNumbers.resources | indent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.buildNumbers.terminationGracePeriodSeconds }}
+{{- end }}

--- a/charts/lighthouse/templates/buildnumbers-rb.yaml
+++ b/charts/lighthouse/templates/buildnumbers-rb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.buildNumbers.enable }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "buildnumbers.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "buildnumbers.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "buildnumbers.name" . }}
+{{- end }}

--- a/charts/lighthouse/templates/buildnumbers-role.yaml
+++ b/charts/lighthouse/templates/buildnumbers-role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.buildNumbers.enable }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "buildnumbers.name" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create
+  - list
+  - watch
+{{- end }}

--- a/charts/lighthouse/templates/buildnumbers-sa.yaml
+++ b/charts/lighthouse/templates/buildnumbers-sa.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.buildNumbers.enable }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "buildnumbers.name" . }}
+{{- end }}

--- a/charts/lighthouse/templates/buildnumbers-service.yaml
+++ b/charts/lighthouse/templates/buildnumbers-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.buildNumbers.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.buildNumbers.service.name }}
+  name: {{ .Values.buildNumbers.service.name }}
+{{- else }}
+  name: {{ template "buildnumbers.name" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.buildNumbers.service.annotations }}
+  annotations:
+{{ toYaml .Values.buildNumbers.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.buildNumbers.service.type }}
+  ports:
+  - port: {{ .Values.buildNumbers.service.externalPort }}
+    targetPort: {{ .Values.buildNumbers.service.internalPort }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "buildnumbers.name" . }}
+{{- end }}

--- a/charts/lighthouse/templates/lighthouse-build-numbers-cm.yaml
+++ b/charts/lighthouse/templates/lighthouse-build-numbers-cm.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Only create the "lighthouse-build-numbers" ConfigMap on install, so that we don't overwrite it on upgrade.
+*/ -}}
+{{- if and .Values.buildNumbers.enable (or (not .Release.IsUpgrade) .Values.configMaps.config) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lighthouse-build-numbers
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+data:
+  buildNums.json: |
+    {
+      Number: {}
+    }
+{{- end }}

--- a/charts/lighthouse/templates/tekton-controller-deployment.yaml
+++ b/charts/lighthouse/templates/tekton-controller-deployment.yaml
@@ -33,6 +33,9 @@ spec:
 {{- if ne .Values.tektoncontroller.dashboardURL "" }}
           - "--dashboard-url={{ .Values.tektoncontroller.dashboardURL}}"
 {{- end }}
+{{- if .Values.buildNumbers.enable }}
+          - "--build-num-url=http://{{ .Values.buildNumbers.service.name }}/"
+{{- end }}
         ports:
           - name: metrics
             containerPort: 8080

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -68,15 +68,15 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.webhooks.probe.path }}
-            port: {{ .Values.webhooks.service.internalPort }}
+            port: {{ .Values.webhooks.probe.port }}
           initialDelaySeconds: {{ .Values.webhooks.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webhooks.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.webhooks.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.webhooks.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.webhooks.probe.path }}
-            port: {{ .Values.webhooks.service.internalPort }}
+            path: {{ .Values.webhooks.probe.path }}/ready
+            port: {{ .Values.webhooks.probe.port }}
           periodSeconds: {{ .Values.webhooks.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.webhooks.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.webhooks.readinessProbe.timeoutSeconds }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -54,7 +54,8 @@ webhooks:
       cpu: 80m
       memory: 128Mi
   probe:
-    path: /
+    port: 8081
+    path: /healthz
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 10
@@ -172,3 +173,36 @@ configMaps:
   # configUpdater:
   #   orgAndRepo: foo/bar
   #   path: a/b/c
+
+buildNumbers:
+  enable: false
+  replicaCount: 1
+  image:
+    repository: "{{ .Values.image.parentRepository }}/lighthouse-build-numbers"
+    tag: "{{ .Values.image.tag }}"
+    pullPolicy: "{{ .Values.image.pullPolicy }}"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 80m
+      memory: 128Mi
+  probe:
+    port: 8081
+    path: /healthz
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  terminationGracePeriodSeconds: 30
+  service:
+    name: lighthouse-build-numbers
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8080

--- a/cmd/buildnumbers/main.go
+++ b/cmd/buildnumbers/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/jenkins-x/lighthouse/pkg/clients"
+	"github.com/jenkins-x/lighthouse/pkg/interrupts"
+	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
+	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	configMapName = "lighthouse-build-numbers"
+	configMapKey  = "buildNums.json"
+)
+
+type options struct {
+	port      int
+	namespace string
+}
+
+func gatherOptions() options {
+	o := options{}
+	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	flag.StringVar(&o.namespace, "namespace", "", "The namespace to find the configmap in")
+
+	flag.Parse()
+	return o
+}
+
+func (o *options) Validate() error {
+	return nil
+}
+
+type store struct {
+	Number          map[string]int // job name -> last vended build number
+	mutex           sync.Mutex
+	configMapClient corev1.ConfigMapInterface
+}
+
+func newStore(configMapClient corev1.ConfigMapInterface) (*store, error) {
+	s := &store{
+		Number:          make(map[string]int),
+		configMapClient: configMapClient,
+	}
+	cfgMap, err := configMapClient.Get(configMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch current state of configmap: %v", err)
+	}
+	value := cfgMap.Data[configMapKey]
+
+	err = json.Unmarshal([]byte(value), s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *store) save() error {
+	buf, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	cfgMap, err := s.configMapClient.Get(configMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch current state of configmap: %v", err)
+	}
+
+	cfgMap.Data[configMapKey] = string(buf)
+	_, err = s.configMapClient.Update(cfgMap)
+	return err
+}
+
+func (s *store) vend(jobName string) int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	n, ok := s.Number[jobName]
+	if !ok {
+		n = 0
+	}
+	n++
+
+	s.Number[jobName] = n
+
+	err := s.save()
+	if err != nil {
+		logrus.Error(err)
+	}
+
+	return n
+}
+
+func (s *store) peek(jobName string) int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.Number[jobName]
+}
+
+func (s *store) set(jobName string, n int) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.Number[jobName] = n
+
+	err := s.save()
+	if err != nil {
+		logrus.Error(err)
+	}
+}
+
+func (s *store) handle(w http.ResponseWriter, r *http.Request) {
+	jobName := r.URL.Path[len("/vend/"):]
+	switch r.Method {
+	case "GET":
+		n := s.vend(jobName)
+		logrus.Infof("Vending %s number %d to %s.", jobName, n, r.RemoteAddr)
+		fmt.Fprintf(w, "%d", n)
+	case "HEAD":
+		n := s.peek(jobName)
+		logrus.Infof("Peeking %s number %d to %s.", jobName, n, r.RemoteAddr)
+		fmt.Fprintf(w, "%d", n)
+	case "POST":
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			logrus.WithError(err).Error("Unable to read body.")
+			return
+		}
+		n, err := strconv.Atoi(string(body))
+		if err != nil {
+			logrus.WithError(err).Error("Unable to parse number.")
+			return
+		}
+		logrus.Infof("Setting %s to %d from %s.", jobName, n, r.RemoteAddr)
+		s.set(jobName, n)
+	}
+}
+
+func main() {
+	logrusutil.ComponentInit("lighthouse-build-numbers")
+
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	defer interrupts.WaitForGracefulShutdown()
+
+	kubeCfg, err := clients.GetConfig("", "")
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not create kubeconfig")
+	}
+
+	kubeClient, err := kubeclient.NewForConfig(kubeCfg)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not create kubeclient")
+	}
+
+	health := util.NewHealth()
+
+	s, err := newStore(kubeClient.CoreV1().ConfigMaps(o.namespace))
+	if err != nil {
+		logrus.WithError(err).Fatal("newStore failed")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vend/", s.handle)
+	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
+	health.ServeReady()
+	interrupts.ListenAndServe(server, 5*time.Second)
+}

--- a/cmd/buildnumbers/main_test.go
+++ b/cmd/buildnumbers/main_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	ns = "test-namespace"
+)
+
+func expectEqual(t *testing.T, msg string, have interface{}, want interface{}) {
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("bad %s: got %v, wanted %v",
+			msg, have, want)
+	}
+}
+
+func makeStore(t *testing.T) *store {
+	startingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			configMapKey: "{ \"Number\": {} }",
+		},
+	}
+
+	fkc := fake.NewSimpleClientset(startingConfigMap)
+
+	cfgMapClient := fkc.CoreV1().ConfigMaps(ns)
+	store, err := newStore(cfgMapClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}
+
+func TestVend(t *testing.T) {
+	store := makeStore(t)
+
+	expectEqual(t, "empty vend", store.vend("a"), 1)
+	expectEqual(t, "second vend", store.vend("a"), 2)
+	expectEqual(t, "third vend", store.vend("a"), 3)
+	expectEqual(t, "second empty", store.vend("b"), 1)
+
+	store2, err := newStore(store.configMapClient)
+	assert.NoError(t, err)
+	expectEqual(t, "fourth vend, different instance", store2.vend("a"), 4)
+}
+
+func TestSet(t *testing.T) {
+	store := makeStore(t)
+
+	store.set("foo", 300)
+	expectEqual(t, "peek", store.peek("foo"), 300)
+	store.set("foo2", 300)
+	expectEqual(t, "vend", store.vend("foo2"), 301)
+	expectEqual(t, "vend", store.vend("foo2"), 302)
+}
+
+func expectResponse(t *testing.T, handler http.Handler, req *http.Request, msg, value string) {
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	expectEqual(t, "http status OK", rr.Code, 200)
+
+	expectEqual(t, msg, rr.Body.String(), value)
+}
+
+func TestHandler(t *testing.T) {
+	store := makeStore(t)
+
+	handler := http.HandlerFunc(store.handle)
+
+	req, err := http.NewRequest("GET", "/vend/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectResponse(t, handler, req, "http vend", "1")
+	expectResponse(t, handler, req, "http vend", "2")
+
+	req, err = http.NewRequest("HEAD", "/vend/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectResponse(t, handler, req, "http peek", "2")
+
+	req, err = http.NewRequest("POST", "/vend/bar", strings.NewReader("40"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectResponse(t, handler, req, "http post", "")
+
+	req, err = http.NewRequest("HEAD", "/vend/bar", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectResponse(t, handler, req, "http vend", "40")
+}

--- a/cmd/tektoncontroller/main.go
+++ b/cmd/tektoncontroller/main.go
@@ -18,6 +18,7 @@ import (
 type options struct {
 	namespace    string
 	dashboardURL string
+	buildNumURL  string
 }
 
 func (o *options) Validate() error {
@@ -28,6 +29,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	var o options
 	fs.StringVar(&o.namespace, "namespace", "", "The namespace to listen in")
 	fs.StringVar(&o.dashboardURL, "dashboard-url", "", "The base URL for the Tekton Dashboard to link to for build reports")
+	fs.StringVar(&o.buildNumURL, "build-num-url", "", "The URL to query for auto-incrementing build numbers (optional)")
 	err := fs.Parse(args)
 	if err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
@@ -62,7 +64,7 @@ func main() {
 		logrus.WithError(err).Fatal("Unable to start manager")
 	}
 
-	reconciler := tektonengine.NewLighthouseJobReconciler(mgr.GetClient(), mgr.GetScheme(), o.dashboardURL, o.namespace)
+	reconciler := tektonengine.NewLighthouseJobReconciler(mgr.GetClient(), mgr.GetScheme(), o.dashboardURL, o.buildNumURL, o.namespace)
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithError(err).Fatal("Unable to create controller")
 	}

--- a/jenkins-x-bbs.yml
+++ b/jenkins-x-bbs.yml
@@ -128,6 +128,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/jenkins-x-ghe.yml
+++ b/jenkins-x-ghe.yml
@@ -128,6 +128,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/jenkins-x-github.yml
+++ b/jenkins-x-github.yml
@@ -128,6 +128,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/jenkins-x-gitlab.yml
+++ b/jenkins-x-gitlab.yml
@@ -128,6 +128,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -137,6 +137,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -178,6 +178,16 @@ pipelineConfig:
                   - --cache-dir=/workspace
                   - --build-arg=VERSION=${inputs.params.version}
 
+              - name: build-and-push-buildnumbers
+                image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
+                command: /kaniko/executor
+                args:
+                  - --dockerfile=/workspace/source/Dockerfile.buildnumbers
+                  - --destination=gcr.io/jenkinsxio/lighthouse-build-numbers:$(inputs.params.version)
+                  - --context=/workspace/source
+                  - --cache-dir=/workspace
+                  - --build-arg=VERSION=$(inputs.params.version)
+
               - name: build-and-push-gc-jobs
                 image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
                 command: /kaniko/executor

--- a/pkg/engines/tekton/controller.go
+++ b/pkg/engines/tekton/controller.go
@@ -26,16 +26,18 @@ type LighthouseJobReconciler struct {
 	logger       *logrus.Entry
 	scheme       *runtime.Scheme
 	dashboardURL string
+	buildNumURL  string
 	namespace    string
 }
 
 // NewLighthouseJobReconciler creates a LighthouseJob reconciler
-func NewLighthouseJobReconciler(client client.Client, scheme *runtime.Scheme, dashboardURL string, namespace string) *LighthouseJobReconciler {
+func NewLighthouseJobReconciler(client client.Client, scheme *runtime.Scheme, dashboardURL string, buildNumURL string, namespace string) *LighthouseJobReconciler {
 	return &LighthouseJobReconciler{
 		client:       client,
 		logger:       logrus.NewEntry(logrus.StandardLogger()).WithField("controller", controllerName),
 		scheme:       scheme,
 		dashboardURL: dashboardURL,
+		buildNumURL:  buildNumURL,
 		namespace:    namespace,
 	}
 }
@@ -93,7 +95,7 @@ func (r *LighthouseJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	if len(pipelineRunList.Items) == 0 {
 		if job.Status.State == lighthousev1alpha1.TriggeredState {
 			// construct a pipeline run
-			pipelineRun, err := makePipelineRun(ctx, job, r.namespace, r.logger, r.client)
+			pipelineRun, err := makePipelineRun(ctx, job, r.buildNumURL, r.namespace, r.logger, r.client)
 			if err != nil {
 				r.logger.Errorf("Failed to make pipeline run: %s", err)
 				return ctrl.Result{}, err

--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -75,7 +75,7 @@ func TestReconcile(t *testing.T) {
 			err = pipelinev1beta1.AddToScheme(scheme)
 			assert.NoError(t, err)
 			c := fake.NewFakeClientWithScheme(scheme, state...)
-			reconciler := NewLighthouseJobReconciler(c, scheme, dashboardBaseURL, ns)
+			reconciler := NewLighthouseJobReconciler(c, scheme, dashboardBaseURL, "", ns)
 
 			// invoke reconcile
 			_, err = reconciler.Reconcile(ctrl.Request{

--- a/pkg/engines/utils.go
+++ b/pkg/engines/utils.go
@@ -1,0 +1,51 @@
+package engines
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+)
+
+var (
+	sleep = time.Sleep
+)
+
+// GetBuildID calls out to the build number URL in order to get a build number for the build.
+func GetBuildID(key, buildNumURL string) (string, error) {
+	if buildNumURL == "" {
+		return "", nil
+	}
+	var err error
+	parsedURL, err := url.Parse(buildNumURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid build number url: %v", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, "vend", key)
+	sleepDuration := 100 * time.Millisecond
+	for retries := 0; retries < 10; retries++ {
+		if retries > 0 {
+			sleep(sleepDuration)
+			sleepDuration = sleepDuration * 2
+		}
+		var resp *http.Response
+		resp, err = http.Get(parsedURL.String())
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			err = fmt.Errorf("got unexpected response from build number service: %v", resp.Status)
+			continue
+		}
+		var buf []byte
+		buf, err = ioutil.ReadAll(resp.Body)
+		if err == nil {
+			return string(buf), nil
+		}
+		return "", err
+	}
+	return "", err
+}

--- a/pkg/engines/utils_test.go
+++ b/pkg/engines/utils_test.go
@@ -1,0 +1,94 @@
+package engines
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type responseVendor struct {
+	codes []int
+	data  []string
+
+	position int
+}
+
+func (r *responseVendor) next() (int, string) {
+	code := r.codes[r.position]
+	datum := r.data[r.position]
+
+	r.position = r.position + 1
+	if r.position == len(r.codes) {
+		r.position = 0
+	}
+
+	return code, datum
+}
+
+func parrotServer(codes []int, data []string) *httptest.Server {
+	vendor := responseVendor{
+		codes: codes,
+		data:  data,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code, datum := vendor.next()
+		w.WriteHeader(code)
+		fmt.Fprint(w, datum)
+	}))
+}
+
+func TestGetBuildID(t *testing.T) {
+	oldSleep := sleep
+	sleep = func(time.Duration) { return }
+	defer func() { sleep = oldSleep }()
+
+	var testCases = []struct {
+		name        string
+		codes       []int
+		data        []string
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:        "all good",
+			codes:       []int{200},
+			data:        []string{"yay"},
+			expected:    "yay",
+			expectedErr: false,
+		},
+		{
+			name:        "fail then success",
+			codes:       []int{500, 200},
+			data:        []string{"boo", "yay"},
+			expected:    "yay",
+			expectedErr: false,
+		},
+		{
+			name:        "fail",
+			codes:       []int{500},
+			data:        []string{"boo"},
+			expected:    "boo",
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			buildNumSrv := parrotServer(testCase.codes, testCase.data)
+
+			actual, actualErr := GetBuildID("dummy", buildNumSrv.URL)
+			if testCase.expectedErr && actualErr == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			} else if !testCase.expectedErr && actualErr != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, actualErr)
+			} else if !testCase.expectedErr && actual != testCase.expected {
+				t.Errorf("%s: expected response %v but got: %v", testCase.name, testCase.expected, actual)
+			}
+
+			buildNumSrv.Close()
+		})
+	}
+}

--- a/pkg/util/health.go
+++ b/pkg/util/health.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jenkins-x/lighthouse/pkg/interrupts"
+)
+
+const healthPort = 8081
+
+// Health keeps a request multiplexer for health liveness and readiness endpoints
+type Health struct {
+	healthMux *http.ServeMux
+}
+
+// NewHealth creates a new health request multiplexer and starts serving the liveness endpoint
+// on the given port
+func NewHealth() *Health {
+	healthMux := http.NewServeMux()
+	healthMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "OK") })
+	server := &http.Server{Addr: ":" + strconv.Itoa(healthPort), Handler: healthMux}
+	interrupts.ListenAndServe(server, 5*time.Second)
+	return &Health{
+		healthMux: healthMux,
+	}
+}
+
+// ServeReady starts serving the readiness endpoint
+func (h *Health) ServeReady() {
+	h.healthMux.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "OK") })
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -77,22 +77,6 @@ func (o *WebhooksController) CleanupGitClientDir() {
 	}
 }
 
-// Health returns either HTTP 204 if the service is healthy, otherwise nothing ('cos it's dead).
-func (o *WebhooksController) Health(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("Health check")
-	w.WriteHeader(http.StatusNoContent)
-}
-
-// Ready returns either HTTP 204 if the service is Ready to serve requests, otherwise HTTP 503.
-func (o *WebhooksController) Ready(w http.ResponseWriter, r *http.Request) {
-	logrus.Debug("Ready check")
-	if o.isReady() {
-		w.WriteHeader(http.StatusNoContent)
-	} else {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}
-}
-
 // DefaultHandler responds to requests without a specific handler
 func (o *WebhooksController) DefaultHandler(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path


### PR DESCRIPTION
Currently available only for Tekton. It'll start at 1 for each combination of `(org)-(repo)-(branch or PR)-(context)`. The "history" is persisted in a configmap - there may be a better option/approach.

This is heavily derived from Prow's `tot` service.

Still needs to be worked into the e2e tests.

fixes #950

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>