### PR TITLE
chore: externalize CRDs definitions from chart templates

### DIFF
--- a/charts/lighthouse/config/lighthousejobs.lighthouse.jenkins.io.yaml
+++ b/charts/lighthouse/config/lighthousejobs.lighthouse.jenkins.io.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: lighthousejobs.lighthouse.jenkins.io
+spec:
+  group: lighthouse.jenkins.io
+  names:
+    kind: LighthouseJob
+    singular: lighthousejob
+    plural: lighthousejobs
+    shortNames:
+      - lhjob
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/charts/lighthouse/templates/lighthousejobs-crd.yaml
+++ b/charts/lighthouse/templates/lighthousejobs-crd.yaml
@@ -1,18 +1,3 @@
 {{- if .Values.cluster.crds.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: lighthousejobs.lighthouse.jenkins.io
-spec:
-  group: lighthouse.jenkins.io
-  names:
-    kind: LighthouseJob
-    singular: lighthousejob
-    plural: lighthousejobs
-    shortNames:
-      - lhjob
-  scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha1
+{{ .Files.Get "config/lighthousejobs.lighthouse.jenkins.io.yaml" }}
 {{- end -}}


### PR DESCRIPTION
This PR externalizes CRDs definitions from chart templates.

This will be useful when we can generate the CRD manifests.