### PR TITLE
chore: replace clients.GetConfig with clientcmd.BuildConfigFromFlags

### DIFF
--- a/cmd/foghorn/main.go
+++ b/cmd/foghorn/main.go
@@ -5,11 +5,11 @@ import (
 	"os"
 
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
-	"github.com/jenkins-x/lighthouse/pkg/clients"
 	"github.com/jenkins-x/lighthouse/pkg/foghorn"
 	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -46,7 +46,7 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 
-	cfg, err := clients.GetConfig("", "")
+	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not create kubeconfig")
 	}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -9,10 +9,10 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	clientset "github.com/jenkins-x/lighthouse/pkg/client/clientset/versioned"
 	lhclient "github.com/jenkins-x/lighthouse/pkg/client/clientset/versioned/typed/lighthouse/v1alpha1"
-	"github.com/jenkins-x/lighthouse/pkg/clients"
 	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 
-	cfg, err := clients.GetConfig("", "")
+	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not create kubeconfig")
 	}

--- a/cmd/tektoncontroller/main.go
+++ b/cmd/tektoncontroller/main.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
-	"github.com/jenkins-x/lighthouse/pkg/clients"
 	tektonengine "github.com/jenkins-x/lighthouse/pkg/engines/tekton"
 	"github.com/jenkins-x/lighthouse/pkg/interrupts"
 	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
 	"github.com/sirupsen/logrus"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -52,7 +52,7 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 
-	cfg, err := clients.GetConfig("", "")
+	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not create kubeconfig")
 	}

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -1,11 +1,6 @@
 package clients
 
 import (
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
-
 	clientset "github.com/jenkins-x/lighthouse/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
@@ -20,7 +15,7 @@ import (
 
 // GetAPIClients returns the tekton, kube, and Lighthouse clients and the kubeconfig used to create them
 func GetAPIClients() (tektonclient.Interface, kubeclient.Interface, clientset.Interface, *rest.Config, error) {
-	kubeCfg, err := GetConfig("", "")
+	kubeCfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "unable to get kubeconfig")
 	}
@@ -41,32 +36,4 @@ func GetAPIClients() (tektonclient.Interface, kubeclient.Interface, clientset.In
 	}
 
 	return tektonClient, kubeClient, lhClient, kubeCfg, nil
-}
-
-// GetConfig returns a rest.Config to be used for kubernetes client creation.
-// It does so in the following order:
-//   1. Use the passed kubeconfig/masterURL.
-//   2. Fallback to the KUBECONFIG environment variable.
-//   3. Fallback to in-cluster config.
-//   4. Fallback to the ~/.kube/config.
-func GetConfig(masterURL, kubeconfig string) (*rest.Config, error) {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-	// If we have an explicit indication of where the kubernetes config lives, read that.
-	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
-	}
-	// If not, try the in-cluster config.
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-	// If no in-cluster config, try the default location in the user's home directory.
-	if usr, err := user.Current(); err == nil {
-		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not create a valid kubeconfig")
 }


### PR DESCRIPTION
This PR replaces `clients.GetConfig` with `clientcmd.BuildConfigFromFlags`.

Will require a change in the lighthouse-jx-controller too.

Closes #963 