### PR TITLE
chore: Switch Keeper to config map watcher

### DIFF
--- a/charts/lighthouse/templates/config-cm.yaml
+++ b/charts/lighthouse/templates/config-cm.yaml
@@ -46,15 +46,16 @@ data:
         required-if-present-contexts: []
         skip-unknown-contexts: false
       merge_method: {}
-      queries:
-      - labels:
-        - approved
-        missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - needs-ok-to-test
-        - needs-rebase
-        repos: []
+      queries: []
+      # Example configuration for a query
+      # - labels:
+      #   - approved
+      #   missingLabels:
+      #   - do-not-merge
+      #   - do-not-merge/hold
+      #   - do-not-merge/work-in-progress
+      #   - needs-ok-to-test
+      #   repos:
+      #   - org/repo
 {{- end }}
 {{- end }}

--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
 {{- if .Values.keeper.datadog.enabled }}
       annotations:
-        ad.datadoghq.com/keeper.logs: '[{"source":"prow","service":"tide"}]'
+        ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
 {{- end }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
@@ -85,20 +85,14 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.keeper.resources | indent 10 }}
-        volumeMounts:
-        - name: config
-          mountPath: /etc/config
-          readOnly: true
 {{- if .Values.githubApp.enabled }}
+        volumeMounts:
         - name: githubapp-tokens
           mountPath: /secrets/githubapp/tokens
           readOnly: true
 {{- end }}
-      volumes:
-      - name: config
-        configMap:
-          name: config
 {{- if .Values.githubApp.enabled }}
+      volumes:
       - name: githubapp-tokens
         secret:
           secretName: tide-githubapp-tokens

--- a/cmd/keeper/main.go
+++ b/cmd/keeper/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
 	"github.com/jenkins-x/lighthouse/pkg/metrics"
 	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/jenkins-x/lighthouse/pkg/watcher"
 	"github.com/sirupsen/logrus"
 )
 
@@ -102,11 +103,12 @@ func main() {
 	}
 
 	configAgent := &config.Agent{}
-	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
-		logrus.WithError(err).Fatal("Error starting config agent.")
+	cfgMapWatcher, err := watcher.SetupConfigMapWatchers(o.namespace, configAgent, nil)
+	if err != nil {
+		logrus.WithError(err).Fatal("error starting config map watcher")
 	}
+	defer cfgMapWatcher.Stop()
 
-	var err error
 	botName := o.botName
 	if botName == "" {
 		botName = util.GetBotName(configAgent.Config)

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -17,11 +17,8 @@ limitations under the License.
 package config
 
 import (
-	"os"
 	"sync"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Delta represents the before and after states of a Config change detected by the Agent.
@@ -38,65 +35,6 @@ type Agent struct {
 	mut           sync.RWMutex // do not export Lock, etc methods
 	c             *Config
 	subscriptions []DeltaChan
-}
-
-// Start will begin polling the config file at the path. If the first load
-// fails, Start will return the error and abort. Future load failures will log
-// the failure message but continue attempting to load.
-func (ca *Agent) Start(prowConfig, jobConfig string) error {
-	c, err := Load(prowConfig, jobConfig)
-	if err != nil {
-		return err
-	}
-	ca.Set(c)
-	go func() {
-		var lastModTime time.Time
-		// Rarely, if two changes happen in the same second, mtime will
-		// be the same for the second change, and an mtime-based check would
-		// fail. Reload periodically just in case.
-		skips := 0
-		for range time.Tick(1 * time.Second) {
-			if skips < 600 {
-				// Check if the file changed to see if it needs to be re-read.
-				// os.Stat follows symbolic links, which is how ConfigMaps work.
-				prowStat, err := os.Stat(prowConfig)
-				if err != nil {
-					logrus.WithField("prowConfig", prowConfig).WithError(err).Error("Error loading prow config.")
-					continue
-				}
-
-				recentModTime := prowStat.ModTime()
-
-				// TODO(krzyzacy): allow empty jobConfig till fully migrate config to subdirs
-				if jobConfig != "" {
-					jobConfigStat, err := os.Stat(jobConfig)
-					if err != nil {
-						logrus.WithField("jobConfig", jobConfig).WithError(err).Error("Error loading job configs.")
-						continue
-					}
-
-					if jobConfigStat.ModTime().After(recentModTime) {
-						recentModTime = jobConfigStat.ModTime()
-					}
-				}
-
-				if !recentModTime.After(lastModTime) {
-					skips++
-					continue // file hasn't been modified
-				}
-				lastModTime = recentModTime
-			}
-			if c, err := Load(prowConfig, jobConfig); err != nil {
-				logrus.WithField("prowConfig", prowConfig).
-					WithField("jobConfig", jobConfig).
-					WithError(err).Error("Error loading config.")
-			} else {
-				skips = 0
-				ca.Set(c)
-			}
-		}
-	}()
-	return nil
 }
 
 // Subscribe registers the channel for messages on config reload.

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
 	lighthouseclient "github.com/jenkins-x/lighthouse/pkg/client/clientset/versioned/typed/lighthouse/v1alpha1"
@@ -286,23 +285,6 @@ func (pa *ConfigAgent) Set(pc *Configuration) {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
 	pa.configuration = pc
-}
-
-// Start starts polling path for plugin config. If the first attempt fails,
-// then start returns the error. Future errors will halt updates but not stop.
-func (pa *ConfigAgent) Start(path string) error {
-	if err := pa.Load(path); err != nil {
-		return err
-	}
-	ticker := time.Tick(1 * time.Minute)
-	go func() {
-		for range ticker {
-			if err := pa.Load(path); err != nil {
-				logrus.WithField("path", path).WithError(err).Error("Error loading plugin config.")
-			}
-		}
-	}()
-	return nil
 }
 
 // GenericCommentHandlers returns a map of plugin names to handlers for the repo.

--- a/pkg/watcher/configmap_watcher.go
+++ b/pkg/watcher/configmap_watcher.go
@@ -50,9 +50,9 @@ func SetupConfigMapWatchers(ns string, configAgent *config.Agent, pluginAgent *p
 			if text != "" {
 				loadedConfig, err := config.LoadYAMLConfig([]byte(text))
 				if err != nil {
-					logrus.WithError(err).Error("Error processing the prow Config YAML")
+					logrus.WithError(err).Error("Error processing the Lighthouse Config YAML")
 				} else {
-					logrus.Info("updating the prow core configuration")
+					logrus.Info("updating the Lighthouse core configuration")
 					configAgent.Set(loadedConfig)
 				}
 			}
@@ -67,12 +67,12 @@ func SetupConfigMapWatchers(ns string, configAgent *config.Agent, pluginAgent *p
 	if pluginAgent != nil {
 		onPluginsYamlChange := func(text string) {
 			if text != "" {
-				config, err := pluginAgent.LoadYAMLConfig([]byte(text))
+				loadedConfig, err := pluginAgent.LoadYAMLConfig([]byte(text))
 				if err != nil {
-					logrus.WithError(err).Error("Error processing the prow Plugins YAML")
+					logrus.WithError(err).Error("Error processing the Lighthouse Plugins YAML")
 				} else {
-					logrus.Info("updating the prow plugins configuration")
-					pluginAgent.Set(config)
+					logrus.Info("updating the Lighthouse plugins configuration")
+					pluginAgent.Set(loadedConfig)
 				}
 			}
 		}


### PR DESCRIPTION
This'll keep it from failing to start if the configmaps aren't present and/or are malformed, and avoids the need for mounting the configmap as well.

And I fixed up the out-of-the-box `config` configmap to not be invalid.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>