### PR TITLE
WIP: feat: Add AdditionalFields map to LighthouseJobSpec and JobBase

### DIFF
--- a/docs/config/Lighthouse config.md
+++ b/docs/config/Lighthouse config.md
@@ -172,6 +172,7 @@ JobBase contains attributes common to all job types
 | Spec | `spec` | *v1.PodSpec | No | Spec is the Kubernetes pod spec used if Agent is kubernetes. |
 | PipelineRunSpec | `pipeline_run_spec` | *tektonv1beta1.PipelineRunSpec | No | PipelineRunSpec is the Tekton PipelineRun spec used if agent is tekton-pipeline |
 | PipelineRunParams | `pipeline_run_params` | [][PipelineRunParam](#PipelineRunParam) | No | PipelineRunParams are the params used by the pipeline run |
+| AdditionalFields | `additional_fields` | map[string]string | No | AdditionalFields is a string/string map for specifying additional fields. This can be used by agent implementations<br />for configuration that's not baked into the spec. |
 |  |  | [UtilityConfig](#UtilityConfig) | Yes |  |
 
 ## JobConfig

--- a/docs/crds/Lighthouse (v1alpha1).md
+++ b/docs/crds/Lighthouse (v1alpha1).md
@@ -118,6 +118,7 @@ LighthouseJobSpec the spec of a pipeline request
 | PipelineRunSpec | `pipeline_run_spec` | *tektonv1beta1.PipelineRunSpec | No | PipelineRunSpec provides the basis for running the test as a Tekton Pipeline<br />https://github.com/tektoncd/pipeline |
 | PipelineRunParams | `pipeline_run_params` | []config.PipelineRunParam | No | PipelineRunParams are the params used by the pipeline run |
 | PodSpec | `pod_spec` | *corev1.PodSpec | No | PodSpec provides the basis for running the test under a Kubernetes agent |
+| AdditionalFields | `additional_fields` | map[string]string | No | AdditionalFields is a string/string map for specifying additional fields. This can be used by agent implementations<br />for configuration that's not baked into the spec. |
 
 ## LighthouseJobStatus
 

--- a/pkg/apis/lighthouse/v1alpha1/types.go
+++ b/pkg/apis/lighthouse/v1alpha1/types.go
@@ -148,6 +148,9 @@ type LighthouseJobSpec struct {
 	PipelineRunParams []config.PipelineRunParam `json:"pipeline_run_params,omitempty"`
 	// PodSpec provides the basis for running the test under a Kubernetes agent
 	PodSpec *corev1.PodSpec `json:"pod_spec,omitempty"`
+	// AdditionalFields is a string/string map for specifying additional fields. This can be used by agent implementations
+	// for configuration that's not baked into the spec.
+	AdditionalFields map[string]string `json:"additional_fields,omitempty"`
 }
 
 // GetBranch returns the branch name corresponding to the refs on this spec.

--- a/pkg/apis/lighthouse/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/lighthouse/v1alpha1/zz_generated.deepcopy.go
@@ -271,6 +271,13 @@ func (in *LighthouseJobSpec) DeepCopyInto(out *LighthouseJobSpec) {
 		*out = new(v1.PodSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AdditionalFields != nil {
+		in, out := &in.AdditionalFields, &out.AdditionalFields
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -117,6 +117,9 @@ type JobBase struct {
 	PipelineRunSpec *tektonv1beta1.PipelineRunSpec `json:"pipeline_run_spec,omitempty"`
 	// PipelineRunParams are the params used by the pipeline run
 	PipelineRunParams []PipelineRunParam `json:"pipeline_run_params,omitempty"`
+	// AdditionalFields is a string/string map for specifying additional fields. This can be used by agent implementations
+	// for configuration that's not baked into the spec.
+	AdditionalFields map[string]string `json:"additional_fields,omitempty"`
 
 	UtilityConfig
 }


### PR DESCRIPTION
This is the best option I've got currently for a way for agent engine implementations to have their own configuration fields without requiring that we have those fields baked into `LighthouseJobSpec` and `JobBase`. I'm open to other approaches.

fixes #969

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>