### PR TITLE
chore: add missing chart values for tekton controller

### DIFF
--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -98,15 +98,19 @@ Current chart version is `0.1.0-SNAPSHOT`
 | `lighthouseJobNamespace` | string | Namespace where `LighthouseJob`s and `Pod`s are created | Deployment namespace |
 | `logFormat` | string | Log format | `"json"` |
 | `oauthToken` | string | Git token (used when GitHub app authentication is not enabled) | `""` |
+| `tektoncontroller.affinity` | object | [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods | `{}` |
 | `tektoncontroller.dashboardURL` | string | Tekton dashboard URL | `""` |
 | `tektoncontroller.image.pullPolicy` | string | Template for computing the tekton controller docker image pull policy | `"{{ .Values.image.pullPolicy }}"` |
 | `tektoncontroller.image.repository` | string | Template for computing the tekton controller docker image repository | `"{{ .Values.image.parentRepository }}/lighthouse-tekton-controller"` |
 | `tektoncontroller.image.tag` | string | Template for computing the tekton controller docker image tag | `"{{ .Values.image.tag }}"` |
+| `tektoncontroller.nodeSelector` | object | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods | `{}` |
+| `tektoncontroller.podAnnotations` | object | Annotations applied to the tekton controller pods | `{}` |
 | `tektoncontroller.replicaCount` | int | Number of replicas | `1` |
 | `tektoncontroller.resources.limits` | object | Resource limits applied to the tekton controller pods | `{"cpu":"100m","memory":"256Mi"}` |
 | `tektoncontroller.resources.requests` | object | Resource requests applied to the tekton controller pods | `{"cpu":"80m","memory":"128Mi"}` |
 | `tektoncontroller.service` | object | Service settings for the tekton controller | `{"annotations":{}}` |
 | `tektoncontroller.terminationGracePeriodSeconds` | int | Termination grace period for tekton controller pods | `180` |
+| `tektoncontroller.tolerations` | list | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods | `[]` |
 | `user` | string | Git user name (used when GitHub app authentication is not enabled) | `""` |
 | `webhooks.image.pullPolicy` | string | Template for computing the webhooks controller docker image pull policy | `"{{ .Values.image.pullPolicy }}"` |
 | `webhooks.image.repository` | string | Template for computing the webhooks controller docker image repository | `"{{ .Values.image.parentRepository }}/lighthouse-webhooks"` |

--- a/charts/lighthouse/templates/tekton-controller-deployment.yaml
+++ b/charts/lighthouse/templates/tekton-controller-deployment.yaml
@@ -18,48 +18,34 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "tektoncontroller.name" . }}
-{{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
+        {{- toYaml .Values.tektoncontroller.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ template "tektoncontroller.name" . }}
       containers:
       - name: {{ template "tektoncontroller.name" . }}
-        image: {{ tpl .Values.tektoncontroller.image.repository . }}:{{ tpl .Values.tektoncontroller.image.tag . }}
+        image: {{ printf "%s:%s" (tpl .Values.tektoncontroller.image.repository .) (tpl .Values.tektoncontroller.image.tag .) }}
         imagePullPolicy: {{ tpl .Values.tektoncontroller.image.pullPolicy . }}
         args:
-          - "--namespace={{ .Release.Namespace }}"
-{{- if ne .Values.tektoncontroller.dashboardURL "" }}
-          - "--dashboard-url={{ .Values.tektoncontroller.dashboardURL}}"
-{{- end }}
+          - --namespace={{ .Release.Namespace }}
+          - --dashboard-url={{ .Values.tektoncontroller.dashboardURL }}
         ports:
           - name: metrics
             containerPort: 8080
         env:
           - name: "LOGRUS_FORMAT"
             value: "{{ .Values.logFormat }}"
-{{- if hasKey .Values "env" }}
-{{- range $pkey, $pval := .Values.env }}
+          {{- range $pkey, $pval := .Values.env }}
           - name: {{ $pkey }}
             value: {{ quote $pval }}
-{{- end }}
-{{- end }}
-{{- with .Values.tektoncontroller.resources }}
+          {{- end }}
         resources:
-{{ toYaml . | indent 12 }}
-{{- end }}
+          {{- toYaml .Values.tektoncontroller.resources | nindent 12 }}
       terminationGracePeriodSeconds: {{ .Values.tektoncontroller.terminationGracePeriodSeconds }}
-{{- with .Values.tektoncontroller.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.tektoncontroller.affinity }}
+        {{- toYaml .Values.tektoncontroller.nodeSelector | nindent 8 }}
       affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.tektoncontroller.tolerations }}
+        {{- toYaml .Values.tektoncontroller.affinity | nindent 8 }}
       tolerations:
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- toYaml .Values.tektoncontroller.tolerations | nindent 8 }}
 {{- end }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -174,6 +174,18 @@ tektoncontroller:
     # tektoncontroller.image.pullPolicy -- Template for computing the tekton controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
+  # tektoncontroller.podAnnotations -- Annotations applied to the tekton controller pods
+  podAnnotations: {}
+
+  # tektoncontroller.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods
+  nodeSelector: {}
+
+  # tektoncontroller.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods
+  affinity: {}
+
+  # tektoncontroller.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods
+  tolerations: []
+
   resources:
     # tektoncontroller.resources.limits -- Resource limits applied to the tekton controller pods
     limits:


### PR DESCRIPTION
This PR adds missing chart values for tekton controller (node selector, affinity, pod annotations, tolerations).

I also took the opportunity to reformat a little bit the deployment template to make it easier to read.