### PR TITLE
chore: tighten tekton controller rbac permissions

### DIFF
--- a/charts/lighthouse/templates/tekton-controller-role.yaml
+++ b/charts/lighthouse/templates/tekton-controller-role.yaml
@@ -5,50 +5,34 @@ metadata:
   name: {{ template "tektoncontroller.name" . }}
 rules:
 - apiGroups:
-  - ""
+  - tekton.dev
   resources:
-  - namespaces
-  - configmaps
-  - secrets
+  - pipelines
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - tekton.dev
   resources:
-  - pipelineresources
-  - tasks
-  - pipelines
   - pipelineruns
   verbs:
   - create
   - list
   - get
-  - update
   - watch
-  - patch
-  - delete
 - apiGroups:
   - lighthouse.jenkins.io
   resources:
   - lighthousejobs
   verbs:
-  - create
-  - delete
-  - list
-  - update
   - get
+  - update
+  - list
   - watch
-  - patch
 - apiGroups:
   - lighthouse.jenkins.io
   resources:
   - lighthousejobs/status
   verbs:
-  - create
-  - delete
-  - list
   - update
   - get
   - watch

--- a/cmd/tektoncontroller/main.go
+++ b/cmd/tektoncontroller/main.go
@@ -62,7 +62,7 @@ func main() {
 		logrus.WithError(err).Fatal("Unable to start manager")
 	}
 
-	reconciler := tektonengine.NewLighthouseJobReconciler(mgr.GetClient(), mgr.GetScheme(), o.dashboardURL, o.namespace)
+	reconciler := tektonengine.NewLighthouseJobReconciler(mgr.GetClient(), mgr.GetAPIReader(), mgr.GetScheme(), o.dashboardURL, o.namespace)
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithError(err).Fatal("Unable to create controller")
 	}

--- a/pkg/engines/tekton/controller.go
+++ b/pkg/engines/tekton/controller.go
@@ -23,6 +23,7 @@ var apiGVStr = lighthousev1alpha1.SchemeGroupVersion.String()
 // LighthouseJobReconciler reconciles a LighthouseJob object
 type LighthouseJobReconciler struct {
 	client       client.Client
+	apiReader    client.Reader
 	logger       *logrus.Entry
 	scheme       *runtime.Scheme
 	dashboardURL string
@@ -30,9 +31,10 @@ type LighthouseJobReconciler struct {
 }
 
 // NewLighthouseJobReconciler creates a LighthouseJob reconciler
-func NewLighthouseJobReconciler(client client.Client, scheme *runtime.Scheme, dashboardURL string, namespace string) *LighthouseJobReconciler {
+func NewLighthouseJobReconciler(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, dashboardURL string, namespace string) *LighthouseJobReconciler {
 	return &LighthouseJobReconciler{
 		client:       client,
+		apiReader:    apiReader,
 		logger:       logrus.NewEntry(logrus.StandardLogger()).WithField("controller", controllerName),
 		scheme:       scheme,
 		dashboardURL: dashboardURL,
@@ -93,7 +95,7 @@ func (r *LighthouseJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	if len(pipelineRunList.Items) == 0 {
 		if job.Status.State == lighthousev1alpha1.TriggeredState {
 			// construct a pipeline run
-			pipelineRun, err := makePipelineRun(ctx, job, r.namespace, r.logger, r.client)
+			pipelineRun, err := makePipelineRun(ctx, job, r.namespace, r.logger, r.apiReader)
 			if err != nil {
 				r.logger.Errorf("Failed to make pipeline run: %s", err)
 				return ctrl.Result{}, err

--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -76,7 +76,7 @@ func TestReconcile(t *testing.T) {
 			err = pipelinev1beta1.AddToScheme(scheme)
 			assert.NoError(t, err)
 			c := fake.NewFakeClientWithScheme(scheme, state...)
-			reconciler := NewLighthouseJobReconciler(c, scheme, dashboardBaseURL, ns)
+			reconciler := NewLighthouseJobReconciler(c, c, scheme, dashboardBaseURL, ns)
 
 			// invoke reconcile
 			_, err = reconciler.Reconcile(ctrl.Request{

--- a/pkg/engines/tekton/utils.go
+++ b/pkg/engines/tekton/utils.go
@@ -42,7 +42,7 @@ func trimDashboardURL(base string) string {
 
 // makePipeline creates a PipelineRun and substitutes LighthouseJob managed pipeline resources with ResourceSpec instead of ResourceRef
 // so that we don't have to take care of potentially dangling created pipeline resources.
-func makePipelineRun(ctx context.Context, lj v1alpha1.LighthouseJob, namespace string, logger *logrus.Entry, c client.Client) (*tektonv1beta1.PipelineRun, error) {
+func makePipelineRun(ctx context.Context, lj v1alpha1.LighthouseJob, namespace string, logger *logrus.Entry, c client.Reader) (*tektonv1beta1.PipelineRun, error) {
 	// First validate.
 	if lj.Spec.PipelineRunSpec == nil {
 		return nil, errors.New("no PipelineSpec defined")
@@ -144,7 +144,7 @@ type gitTaskParamNames struct {
 	baseRevisionParam string
 }
 
-func determineGitCloneOrMergeTaskParams(ctx context.Context, pr *tektonv1beta1.PipelineRun, c client.Client) (*gitTaskParamNames, error) {
+func determineGitCloneOrMergeTaskParams(ctx context.Context, pr *tektonv1beta1.PipelineRun, c client.Reader) (*gitTaskParamNames, error) {
 	if pr == nil {
 		return nil, errors.New("provided PipelineRun is nil")
 	}


### PR DESCRIPTION
This PR removes unnecessary rbac permissions to the tekton controller.