### PR TITLE
WIP: feat: Working towards build/release outside of jx

### DIFF
--- a/bdd/capture-failed-pod-logs.sh
+++ b/bdd/capture-failed-pod-logs.sh
@@ -16,4 +16,5 @@ for lh_pod in $(kubectl get pod -l app=lighthouse-webhooks -o jsonpath='{.items[
   kubectl logs --tail=-1 "${lh_pod}" > extra-logs/lh.${lh_cnt}.log
 done
 
-jx step stash -c lighthouse-tests -p "extra-logs/*.log" --bucket-url gs://jx-prod-logs
+# TODO: Create a bucket, make sure our GCP creds can write to it
+gsutil rsync -d -r "${PWD}/extra-logs" "gs://BUCKET_TO_BE_DETERMINED/lighthouse-pr-logs/PR-${PR_NUMBER}/${CONTEXT}/${BUILD_ID}/"

--- a/bdd/helm-requirements.yaml.template
+++ b/bdd/helm-requirements.yaml.template
@@ -11,7 +11,7 @@ dependencies:
   - alias: lighthouse
     condition: lighthouse.enabled
     name: lighthouse
-    repository: https://chartmuseum.jenkins-x.io
+    repository: https://lighthouse-chatops.github.com/charts
     version: $VERSION
   - alias: lighthouse-jx
     condition: lighthouse.enabled

--- a/charts/lighthouse/Makefile
+++ b/charts/lighthouse/Makefile
@@ -30,12 +30,22 @@ clean:
 .PHONY: snapshot
 snapshot: update-version release
 
+# TODO: Gotta figure out the right way to get the git creds in here securely
 release: clean
 	helm dependency build
 	helm lint
 	helm init --client-only
 	helm package .
-	@curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	git clone https://github.com/lighthouse-chatops/charts.git
+	pushd charts
+	git checkout gh-pages
+	mv ../"@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" lighthouse
+	helm repo index . --url https://lighthouse-chatops.github.com/charts
+	git add -i
+	git commit -av
+	git push origin gh-pages
+	popd
+	rm -rf charts
 	rm -rf ${NAME}*.tgz%
 
 update-version:
@@ -57,4 +67,13 @@ tag: update-version
 	git push origin v$(VERSION)
 
 delete-from-chartmuseum:
-	@curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) -X DELETE $(CHART_REPO)/api/charts/$(NAME)/$(VERSION)
+	git clone https://github.com/lighthouse-chatops/charts.git
+	pushd charts
+	git checkout gh-pages
+	rm lighthouse/"@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz"
+	helm repo index . --url https://lighthouse-chatops.github.com/charts
+	git add -i
+	git commit -av
+	git push origin gh-pages
+	popd
+	rm -rf charts

--- a/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-pr.yml
@@ -28,6 +28,8 @@ spec:
   params:
     - name: BUILD_ID
       value: "7828158075477027098"
+    - name: CONTEXT_NAME
+      value: github
     - name: JOB_NAME
       value: github
     - name: JOB_SPEC

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
@@ -28,6 +28,8 @@ spec:
   params:
     - name: BUILD_ID
       value: "7828158075477027098"
+    - name: CONTEXT_NAME
+      value: github
     - name: JOB_NAME
       value: github
     - name: JOB_SPEC

--- a/pkg/engines/tekton/test_data/controller/start-push/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-push/expected-pr.yml
@@ -27,6 +27,8 @@ spec:
   params:
     - name: BUILD_ID
       value: "7828158075477027098"
+    - name: CONTEXT_NAME
+      value: github
     - name: JOB_NAME
       value: github
     - name: JOB_SPEC

--- a/pkg/engines/tekton/utils.go
+++ b/pkg/engines/tekton/utils.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	controllerName          = "tekton-controller"
+	contextNameParam        = "CONTEXT_NAME"
 	gitCloneCatalogTaskName = "git-clone"
 	gitCloneURLParam        = "url"
 	gitCloneRevisionParam   = "revision"
@@ -79,6 +80,10 @@ func makePipelineRun(ctx context.Context, lj v1alpha1.LighthouseJob, namespace s
 	env := lj.Spec.GetEnvVars()
 	env[v1alpha1.BuildIDEnv] = buildID
 	env[v1alpha1.RepoURLEnv] = lj.Spec.Refs.CloneURI
+	env[contextNameParam] = lj.Spec.Context
+	if env[contextNameParam] == "" {
+		env[contextNameParam] = lj.Spec.Job
+	}
 	var batchedRefsVals []string
 	for _, pull := range lj.Spec.Refs.Pulls {
 		if pull.Ref != "" {

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,0 +1,26 @@
+#### Bootstrapping and updating `Task`s and `Pipeline`s
+
+Run `kubectl apply -f tekton/tasks/*.yaml` and `kubectl apply -f tekton/pipelines/*.yaml` to load initial versions of
+the resources. Once they're in and the Lighthouse postsubmit is set properly, [the `lh-update-tekton-resources-pipeline`](https://github.com/jenkins-x/lighthouse/blob/master/tekton/pipelines/lh-update-tekton-resources-pipeline.yaml)
+will automatically update the resources whenever the relevant directories have changed in a merged PR.
+
+#### Tasks which need to be installed in the cluster from the catalog:
+* https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-batch-merge/0.2/git-batch-merge.yaml
+* https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.2/git-clone.yaml
+* https://raw.githubusercontent.com/tektoncd/catalog/master/task/kaniko/0.1/kaniko.yaml
+
+#### Performing a release
+
+Choose the revision to release and run, from the root directory of the repo:
+```shell script
+tkn pipeline start \
+  --prefix-name=lighthouse-release- \
+  --serviceaccount=TODO \
+  --workspace=name=source,volumeClaimTemplateFile=./tekton/pvc/release-pvc.yaml \
+  --param=version=0.1.1 \          # The new release, without the leading "v"
+  --param=previous-version=0.1.0 \ # The previous release, also without the leading "v"
+  --param=revision=(the SHA to release) \
+  lh-release-pipeline
+```
+
+Watch the resulting `PipelineRun`'s log to make sure it passes, and then edit the draft release on GitHub.

--- a/tekton/pipelines/lh-pr-checks-pipeline.yaml
+++ b/tekton/pipelines/lh-pr-checks-pipeline.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: lh-pr-checks-pipeline
+spec:
+  params:
+    - name: batch-refs
+      type: string
+  workspaces:
+    - name: source
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-batch-merge
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: "https://github.com/jenkins-x/lighthouse.git"
+        - name: batchedRefs
+          value: $(params.batch-refs)
+        - name: subdirectory
+          value: ""
+        - name: depth
+          value: "0"
+    - name: pr-checks
+      taskRef:
+        name: lh-pr-checks
+      runAfter:
+        - fetch-repo
+      workspaces:
+        - name: source
+          workspace: source

--- a/tekton/pipelines/lh-pr-e2e-pipeline.yaml
+++ b/tekton/pipelines/lh-pr-e2e-pipeline.yaml
@@ -1,0 +1,132 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: lh-pr-e2e-pipeline
+spec:
+  params:
+    - name: CONTEXT_NAME
+      type: string
+    - name: BUILD_ID
+      type: string
+    - name: PULL_NUMBER
+      type: string
+    - name: gitKind
+      type: string
+    - name: gitServer
+      type: string
+    - name: batch-refs
+      type: string
+  workspaces:
+    - name: source
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-batch-merge
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: "https://github.com/jenkins-x/lighthouse.git"
+        - name: batchedRefs
+          value: $(params.batch-refs)
+        - name: subdirectory
+          value: ""
+        - name: depth
+          value: "0"
+    - name: build-binaries
+      taskRef:
+        name: lh-build-binaries
+      runAfter:
+        - fetch-repo
+      workspaces:
+        - name: source
+          workspace: source
+    - name: build-and-push-webhooks
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-webhooks:0.0.0-SNAPSHOT-$(params.BUILD_ID)
+        - name: DOCKERFILE
+          value: ./Dockerfile.webhooks
+    - name: build-and-push-foghorn
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-foghorn:0.0.0-SNAPSHOT-$(params.BUILD_ID)
+        - name: DOCKERFILE
+          value: ./Dockerfile.foghorn
+    - name: build-and-push-keeper
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-keeper:0.0.0-SNAPSHOT-$(params.BUILD_ID)
+        - name: DOCKERFILE
+          value: ./Dockerfile.keeper
+    - name: build-and-push-tekton-controller
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-tekton-controller:0.0.0-SNAPSHOT-$(params.BUILD_ID)
+        - name: DOCKERFILE
+          value: ./Dockerfile.tektoncontroller
+    - name: build-and-push-gcjobs
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-gc-jobs:0.0.0-SNAPSHOT-$(params.BUILD_ID)
+        - name: DOCKERFILE
+          value: ./Dockerfile.gcJobs
+    - name: run-e2e
+      runAfter:
+        - build-and-push-gcjobs
+        - build-and-push-webhooks
+        - build-and-push-keeper
+        - build-and-push-foghorn
+        - build-and-push-tekton-controller
+      taskRef:
+        name: lh-run-e2e-tests
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: context
+          value: $(params.CONTEXT_NAME)
+        - name: build_id
+          value: $(params.BUILD_ID)
+        - name: gitKind
+          value: $(params.gitKind)
+        - name: gitServer
+          value: $(params.gitServer)
+        - name: prNumber
+          value: $(params.PULL_NUMBER)

--- a/tekton/pipelines/lh-release-pipeline.yaml
+++ b/tekton/pipelines/lh-release-pipeline.yaml
@@ -1,0 +1,136 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: lh-release-pipeline
+spec:
+  params:
+    - name: version
+      type: string
+      description: The version to release, without a leading "v"
+    - name: previous-version
+      type: string
+      description: The previous version, without a leading "v"
+    - name: revision
+      type: string
+      description: The revision to tag and release
+  workspaces:
+    - name: source
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: "https://github.com/jenkins-x/lighthouse.git"
+        - name: revision
+          value: $(params.revision)
+        - name: subdirectory
+          value: ""
+        - name: depth
+          value: "0"
+    - name: build-binaries
+      taskRef:
+        name: lh-build-binaries
+      runAfter:
+        - fetch-repo
+      workspaces:
+        - name: source
+          workspace: source
+    - name: build-and-push-webhooks
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-webhooks:$(params.version)
+        - name: DOCKERFILE
+          value: ./Dockerfile.webhooks
+    - name: build-and-push-foghorn
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-foghorn:$(params.version)
+        - name: DOCKERFILE
+          value: ./Dockerfile.foghorn
+    - name: build-and-push-keeper
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-keeper:$(params.version)
+        - name: DOCKERFILE
+          value: ./Dockerfile.keeper
+    - name: build-and-push-tekton-controller
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-tekton-controller:$(params.version)
+        - name: DOCKERFILE
+          value: ./Dockerfile.tektoncontroller
+    - name: build-and-push-gcjobs
+      taskRef:
+        name: kaniko
+      runAfter:
+        - build-binaries
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: gcr.io/jenkinsxio/lighthouse-gc-jobs:$(params.version)
+        - name: DOCKERFILE
+          value: ./Dockerfile.gcJobs
+    - name: helm-release
+      runAfter:
+        - build-and-push-gcjobs
+        - build-and-push-webhooks
+        - build-and-push-keeper
+        - build-and-push-foghorn
+        - build-and-push-tekton-controller
+      taskRef:
+        name: lh-helm-release
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: version
+          value: $(params.version)
+    - name: github-release
+      runAfter:
+        - helm-release
+      taskRef:
+        name: create-github-release
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: revision
+          value: $(params.revision)
+        - name: release-tag
+          value: "v$(params.version)"
+        - name: previous-release-tag
+          value: "v$(params.previous-version)"

--- a/tekton/pipelines/lh-update-tekton-resources-pipeline.yaml
+++ b/tekton/pipelines/lh-update-tekton-resources-pipeline.yaml
@@ -1,0 +1,34 @@
+# This pipeline will be run on merges to master if there are changes in the "tekton/pipelines" or "tekton/tasks"
+# directories.
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: lh-update-tekton-resources-pipeline
+spec:
+  workspaces:
+    - name: source
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: "https://github.com/jenkins-x/lighthouse.git"
+        - name: revision
+          value: master
+        - name: subdirectory
+          value: ""
+        - name: depth
+          value: "0"
+    - name: update-resources
+      taskRef:
+        name: lh-update-tekton-resources
+      runAfter:
+        - fetch-repo
+      workspaces:
+        - name: source
+          workspace: source

--- a/tekton/pvc/release-pvc.yaml
+++ b/tekton/pvc/release-pvc.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/tekton/tasks/lh-build-binaries.yaml
+++ b/tekton/tasks/lh-build-binaries.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-build-binaries
+spec:
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+  steps:
+    - name: make-binaries
+      resources:
+        requests:
+          cpu: 1
+          memory: 2048Mi
+        limits:
+          cpu: 4
+          memory: 6144Mi
+      workingDir: $(workspaces.source.path)
+      image: golang:1.13.8
+      command:
+        - make
+      args:
+        - build-linux
+      env:
+        - name: GOPATH
+          value: /workspace
+        - name: GO111MODULE
+          value: "on"

--- a/tekton/tasks/lh-create-draft-release.yaml
+++ b/tekton/tasks/lh-create-draft-release.yaml
@@ -1,0 +1,174 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-create-draft-release
+spec:
+  params:
+    - name: revision
+      type: string
+      description: The revision which will be tagged and released.
+    - name: release-tag
+      type: string
+      description: Release number and git tag to be applied (e.g. 0.888.1, with 'v')
+    - name: previous-release-tag
+      type: string
+      description: Previous release number - for author and PR list calculation
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+
+  stepTemplate:
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-token
+            key: GITHUB_TOKEN
+      - name: VERSION
+        value: $(params.release-tag)
+      - name: OLD_VERSION
+        value: $(params.previous-release-tag)
+  steps:
+    - name: header
+      image: gcr.io/tekton-releases/dogfooding/hub
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/bash
+        set -ex
+        cat <<EOF | tee release.md
+        Lighthouse release ${VERSION}
+        # 🎉 [Tag Line - to be done] 🎉
+        -[Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
+        -[Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
+        ## Installation one-liner
+        \`\`\`
+        TODO: Helm
+        \`\`\`
+        ## Upgrade Notices
+        [TBD]
+        ## Changes
+        EOF
+    - name: filter-data
+      image: gcr.io/tekton-releases/dogfooding/hub
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        # Restore full git history
+        git fetch --unshallow
+        # UPPER_THRESHOLD is the newest sha we are interested in
+        UPPER_THRESHOLD=$(params.revision)
+        # COMMON_ANCESTOR is the common ancestore between the OLD_VERSION and UPPER_THRESHOLD
+        COMMON_ANCESTOR=$(git merge-base ${OLD_VERSION} ${UPPER_THRESHOLD})
+        # OLD_RELEASE_SUBJECTS is the list of commit subjects cherry-picked (probably?) from master
+        OLD_RELEASE_SUBJECTS=old_subjects.txt
+        echo "Cherry-picked commits:"
+        git log --format="%s" $COMMON_ANCESTOR..$OLD_VERSION | sort -u | tee $OLD_RELEASE_SUBJECTS
+        echo "OLD_VERSION: $OLD_VERSION"
+        echo "COMMON_ANCESTOR: $COMMON_ANCESTOR"
+        echo "UPPER_THRESHOLD: $UPPER_THRESHOLD"
+        # Save the PR data in CSV. Only consider PRs whose sha verifies the condition
+        # COMMON_ANCESTOR is ancestor of SHA is ancestor of UPPER_THRESHOLD
+        # And title no in the OLD_VERSION branch.
+        # Working Assumptions:
+        #   - there are no duplicate titles in commits
+        #   - we always cherry-pick full PRs, never commits out of a multi-commit PR
+        # Format of output data:
+        # "author;number;title"
+        hub pr list --state merged -L 300 -f "%sm;%au;%i;%t;%L%n" | \
+          while read pr; do
+            SHA=$(echo $pr | cut -d';' -f1)
+            SUBJECT=$(git log -1 --format="%s" $SHA || echo "__NOT_FOUND__")
+            git merge-base --is-ancestor $SHA $UPPER_THRESHOLD && \
+            git merge-base --is-ancestor $COMMON_ANCESTOR $SHA && \
+            ! $(egrep "^${SUBJECT}$" $OLD_RELEASE_SUBJECTS &> /dev/null) &&
+            echo $pr | cut -d';' -f2-
+          done > pr.csv || true  # We do not want to fail is the last of the loop is not a match
+        echo "$(wc -l pr.csv | awk '{ print $1}') PRs in the new release."
+        cat pr.csv
+    - name: body
+      image: busybox
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        cat <<EOF | tee -a release.md
+        # Features
+        * :sparkles: [Feature Title]
+        $(awk -F";" '/kind\/feature/{ print "* :sparkles: "$3" ("$2")" }' pr.csv)
+        [Detailed feature description] (#Number).
+        [Fill list here]
+        # Deprecation Notices
+        * :rotating_light: [Deprecation Notice Title]
+        [Detailed deprecation notice description] (#Number).
+        [Fill list here]
+        # Backwards incompatible changes
+        In current release:
+        * :rotating_light: [Change Title]
+        [Detailed change description] (#Number).
+        [Fill list here]
+        # Fixes
+        * :bug: [Description (#Number)]
+        $(awk -F";" '/kind\/bug/{ print "* :bug: "$3" ("$2")" }' pr.csv)
+        $(awk -F";" '/kind\/flake/{ print "* :bug: "$3" ("$2")" }' pr.csv)
+        [Fill list here]
+        # Misc
+        * :hammer: [Description (#Number)]
+        $(awk -F";" '/kind\/cleanup/{ print "* :hammer: "$3" ("$2")" }' pr.csv)
+        $(awk -F";" '/kind\/misc/{ print "* :hammer: "$3" ("$2")" }' pr.csv)
+        [Fill list here]
+        # Docs
+        * :book: [Description (#Number)]
+        $(awk -F";" '/kind\/documentation/{ print "* :book: "$3" ("$2")" }' pr.csv)
+        [Fill list here]
+        EOF
+    - name: authors
+      image: gcr.io/tekton-releases/dogfooding/hub
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        cat <<EOF | tee -a release.md
+        ## Thanks
+        Thanks to these contributors who contributed to ${VERSION}!
+        EOF
+        awk -F";" '{ print "- :heart: @"$1 }' pr.csv | sort -u | tee -a release.md
+        cat <<EOF | tee -a release.md
+        Extra shout-out for awesome release notes:
+        * :heart_eyes: [@GitHub Nickname] [Fill list here]
+        EOF
+    - name: pr-data
+      image: gcr.io/tekton-releases/dogfooding/hub
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        cat <<EOF | tee -a release.md
+        ## Unsorted PR List
+        # List of PRs merged between $OLD_VERSION and $VERSION
+        To Be Done: Categorize these PRs into Features, Deprecation Notices,
+        Backward Incompatible Changes, Fixes, Docs, Misc.
+        EOF
+        egrep -v 'kind/(feature|documentation|cleanup|flake|bug|misc)' pr.csv | awk -F";" '{ print "- "$3" ("$2")" }' | tee -a release.md
+    - name: create-draft
+      image: gcr.io/tekton-releases/dogfooding/hub
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        hub release create --draft --prerelease \
+          --commitish $(params.revision) \
+          --file release.md ${VERSION}

--- a/tekton/tasks/lh-helm-release.yaml
+++ b/tekton/tasks/lh-helm-release.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-pr-checks
+spec:
+  params:
+    - name: version
+      type: string
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+
+  stepTemplate:
+    env:
+      - name: GOPATH
+        value: /workspace
+      - name: GO111MODULE
+        value: "on"
+      - name: VERSION
+        value: $(params.version)
+      - name: CHARTMUSEUM_USER
+        valueFrom:
+          secretKeyRef:
+            name: jenkins-x-chartmuseum
+            key: BASIC_AUTH_USER
+      - name: CHARTMUSEUM_PASS
+        valueFrom:
+          secretKeyRef:
+            name: jenkins-x-chartmuseum
+            key: BASIC_AUTH_PASS
+
+  steps:
+    - name: init-helm
+      workingDir: $(workspaces.source.path)
+      image: alpine/helm:2.12.3
+      command:
+        - helm
+      args:
+        - init
+        - --client-only
+    - name: helm-lint
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - make
+      args:
+        - build
+        - release
+      workingDir: $(workspaces.source.path)/charts/lighthouse

--- a/tekton/tasks/lh-pr-checks.yaml
+++ b/tekton/tasks/lh-pr-checks.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-pr-checks
+spec:
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+  stepTemplate:
+    env:
+      - name: GOPATH
+        value: /workspace
+      - name: GO111MODULE
+        value: "on"
+    resources:
+      requests:
+        cpu: 1
+        memory: 2048Mi
+      limits:
+        cpu: 4
+        memory: 6144Mi
+
+  steps:
+    - name: init-helm
+      workingDir: $(workspaces.source.path)
+      image: alpine/helm:2.12.3
+      command:
+        - helm
+      args:
+        - init
+        - --client-only
+    - name: helm-lint
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - make
+      args:
+        - build
+      workingDir: $(workspaces.source.path)/charts/lighthouse
+    - name: lint-checks
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - make
+      args:
+        - check
+        - generate-client
+        - docs
+        - verify-code-unchanged
+      workingDir: $(workspaces.source.path)
+    - name: unit-test-and-build
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - make
+      args:
+        - build-linux
+        - test
+      workingDir: $(workspaces.source.path)

--- a/tekton/tasks/lh-run-e2e-tests.yaml
+++ b/tekton/tasks/lh-run-e2e-tests.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-run-e2e-tests
+spec:
+  params:
+    - name: context
+      description: the e2e context
+    - name: build_id
+      description: the unique build ID
+    - name: gitKind
+      description: Git provider kind
+    - name: gitServer
+      description: Git provider base URL
+    - name: prNumber
+      description: PR number being built
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+  volumes:
+    - name: sa
+      secret:
+        secretName: bdd-secret
+        items:
+          - key: bdd-credentials.json
+            path: bdd/sa.json
+  steps:
+    - name: run-e2e
+      resources:
+        requests:
+          cpu: 500m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 2048Mi
+      volumeMounts:
+        - mountPath: /secrets
+          name: sa
+      workingDir: $(workspaces.source.path)
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - ./bdd/$(params.context)/ci.sh # TODO: Archiving away the captured logfiles somewhere needs to change
+      env:
+        - name: GOPATH
+          value: /workspace
+        - name: GO111MODULE
+          value: "on"
+        - name: VERSION
+          value: 0.0.0-SNAPSHOT-$(params.build_id)
+        - name: CHARTMUSEUM_USER
+          valueFrom:
+            secretKeyRef:
+              name: jenkins-x-chartmuseum
+              key: BASIC_AUTH_USER
+        - name: CHARTMUSEUM_PASS
+          valueFrom:
+            secretKeyRef:
+              name: jenkins-x-chartmuseum
+              key: BASIC_AUTH_PASS
+        - name: E2E_PRIMARY_SCM_USER
+          valueFrom:
+            secretKeyRef:
+              name: lighthouse-bot-test-$(params.context)
+              key: username
+        - name: E2E_PRIMARY_SCM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: lighthouse-bot-test-$(params.context)
+              key: password
+        - name: E2E_APPROVER_SCM_USER
+          valueFrom:
+            secretKeyRef:
+              name: lighthouse-bot-test-approver-$(params.context)
+              key: username
+        - name: E2E_APPROVER_SCM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: lighthouse-bot-test-approver-$(params.context)
+              key: password
+        - name: GKE_SA
+          value: /secrets/bdd/sa.json
+        - name: E2E_GIT_KIND
+          value: $(params.gitKind)
+        - name: E2E_GIT_SERVER
+          value: $(params.gitServer)
+        - name: PR_NUMBER
+          value: $(params.prNumber)
+        - name: BUILD_ID
+          value: $(params.build_id)
+        - name: CONTEXT
+          value: $(params.context)

--- a/tekton/tasks/lh-update-tekton-resources.yaml
+++ b/tekton/tasks/lh-update-tekton-resources.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lh-update-tekton-resources
+spec:
+  workspaces:
+    - name: source
+      mountPath: /workspace/src/github.com/jenkins-x/lighthouse
+  steps:
+    - name: update-tasks
+      workingDir: $(workspaces.source.path)
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - kubectl
+      args:
+        - apply
+        - "-f"
+        - ./tekton/tasks/*.yaml
+    - name: update-pipelines
+      workingDir: $(workspaces.source.path)
+      image: gcr.io/jenkinsxio/builder-go:2.1.113-737
+      command:
+        - kubectl
+      args:
+        - apply
+        - "-f"
+        - ./tekton/pipelines/*.yaml


### PR DESCRIPTION
relates to #990, but this isn't happening any time soon.

For now I'm just trying to make sure the `Pipeline`s I'm coming up with make sense.

e2e clusters will still get deleted by https://github.com/jenkins-x/jx/blob/master/pkg/cmd/step/e2e/step_e2e_gc.go or something with the same behavior - we'll need to make sure the cluster names are `pr-(number)-(context)-(monotonically increasing number)`, so we probably want to end up with `BUILD_ID` being milliseconds since epoch or something. I'll probably have a non-WIP PR up for that to replace #951 shortly.

I haven't figured out how we want to deal with capturing build logs and artifacts. Re artifacts, for the moment, I've got a `gsutil` call in `bdd/capture-failed-pod-logs.sh` for saving the various controller logs from failed runs, but I intend to go dig into how Tekton's doing this in dogfooding.

EDIT: They're not really doing anything like that in dogfooding. =) Need to think about that more.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>