### PR TITLE
chore: remove unused files

### DIFF
--- a/Dockerfile.jxcontroller
+++ b/Dockerfile.jxcontroller
@@ -1,6 +1,0 @@
-FROM alpine:3.10
-RUN apk add --update --no-cache ca-certificates git
-COPY ./bin/lighthouse-jx-controller /lighthouse-jx-controller
-RUN mkdir /jxhome
-ENV JX_HOME /jxhome
-ENTRYPOINT ["/lighthouse-jx-controller"]


### PR DESCRIPTION
This PR removes two unused files `Dockerfile.jxcontroller` and `custom-boilerplate.go.txt`.

Not sure but `.helmignore` at the root of the repo could potentially be removed too.