### PR TITLE
chore: make e2e tests non sensible to the ingress name

### DIFF
--- a/bdd/tekton/values.yaml.template
+++ b/bdd/tekton/values.yaml.template
@@ -30,4 +30,3 @@ webhooks:
 
   # we need this for the tests
   serviceName: hook
-  ingressName: hook

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -115,7 +115,6 @@ Current chart version is `0.1.0-SNAPSHOT`
 | `webhooks.ingress.annotations` | object | Webhooks ingress annotations | `{}` |
 | `webhooks.ingress.enabled` | bool | Enable webhooks ingress | `false` |
 | `webhooks.ingress.hosts` | list | Webhooks ingress host names | `[]` |
-| `webhooks.ingressName` | string | Allows overriding the ingress name, this is here for compatibility reasons and a regular user should not need it | `nil` |
 | `webhooks.livenessProbe` | object | Liveness probe configuration | `{"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `webhooks.probe` | object | Liveness and readiness probes settings | `{"path":"/"}` |
 | `webhooks.readinessProbe` | object | Readiness probe configuration | `{"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |

--- a/charts/lighthouse/templates/webhooks-ingress.yaml
+++ b/charts/lighthouse/templates/webhooks-ingress.yaml
@@ -2,7 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ default (include "webhooks.name" .) .Values.webhooks.ingressName }}
+  name: {{ template "webhooks.name" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    app: {{ template "webhooks.name" . }}
   annotations:
     {{- toYaml .Values.webhooks.ingress.annotations | nindent 4 }}
 spec:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -128,9 +128,6 @@ webhooks:
     successThreshold: 1
     timeoutSeconds: 1
 
-  # webhooks.ingressName -- (string) Allows overriding the ingress name, this is here for compatibility reasons and a regular user should not need it
-  ingressName: null
-
   ingress:
     # webhooks.ingress.enabled -- Enable webhooks ingress
     enabled: false

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -344,7 +344,7 @@ func ProcessConfigAndPlugins(owner, repo, namespace, agent string) (*config.Conf
 
 // CreateWebHook creates a webhook on the SCM provider for the repository
 func CreateWebHook(scmClient *scm.Client, repo *scm.Repository, hmacToken string) error {
-	output, err := exec.Command("kubectl", "get", "ingress", "hook", "-o", "jsonpath={.spec.rules[0].host}").CombinedOutput()
+	output, err := exec.Command("kubectl", "get", "ingress", "-l", "app=lighthouse-webhooks", "-o", "jsonpath={.items[0].spec.rules[0].host}").CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "failed to get hook ingress")
 	}


### PR DESCRIPTION
This PR makes e2e tests non sensible to the ingress name.

The ingress is looked up by labels rather than by name.