### PR TITLE
chore: Switch Tekton engine build ID to epoch milliseconds

### DIFF
--- a/pkg/engines/tekton/controller.go
+++ b/pkg/engines/tekton/controller.go
@@ -26,6 +26,7 @@ type LighthouseJobReconciler struct {
 	apiReader    client.Reader
 	logger       *logrus.Entry
 	scheme       *runtime.Scheme
+	idGenerator  buildIDGenerator
 	dashboardURL string
 	namespace    string
 }
@@ -39,6 +40,7 @@ func NewLighthouseJobReconciler(client client.Client, apiReader client.Reader, s
 		scheme:       scheme,
 		dashboardURL: dashboardURL,
 		namespace:    namespace,
+		idGenerator:  &epochBuildIDGenerator{},
 	}
 }
 
@@ -95,7 +97,7 @@ func (r *LighthouseJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	if len(pipelineRunList.Items) == 0 {
 		if job.Status.State == lighthousev1alpha1.TriggeredState {
 			// construct a pipeline run
-			pipelineRun, err := makePipelineRun(ctx, job, r.namespace, r.logger, r.apiReader)
+			pipelineRun, err := makePipelineRun(ctx, job, r.namespace, r.logger, r.idGenerator, r.apiReader)
 			if err != nil {
 				r.logger.Errorf("Failed to make pipeline run: %s", err)
 				return ctrl.Result{}, err

--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,6 +29,11 @@ const (
 	dashboardBaseURL = "https://example.com/"
 )
 
+type seededRandIDGenerator struct{}
+
+func (s *seededRandIDGenerator) GenerateBuildID() string {
+	return strconv.Itoa(utilrand.Int())
+}
 func TestReconcile(t *testing.T) {
 	testCases := []string{
 		"start-pullrequest",
@@ -77,6 +83,7 @@ func TestReconcile(t *testing.T) {
 			assert.NoError(t, err)
 			c := fake.NewFakeClientWithScheme(scheme, state...)
 			reconciler := NewLighthouseJobReconciler(c, c, scheme, dashboardBaseURL, ns)
+			reconciler.idGenerator = &seededRandIDGenerator{}
 
 			// invoke reconcile
 			_, err = reconciler.Reconcile(ctrl.Request{


### PR DESCRIPTION
fixes #950, replaces #951, relevant for #991 

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>