### PR TITLE
chore: make webhook event handlers private

### DIFF
--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -43,8 +43,8 @@ type Server struct {
 
 const failedCommentCoerceFmt = "Could not coerce %s event to a GenericCommentEvent. Unknown 'action': %q."
 
-// HandleIssueCommentEvent handle comment events
-func (s *Server) HandleIssueCommentEvent(l *logrus.Entry, ic scm.IssueCommentHook) {
+// handleIssueCommentEvent handle comment events
+func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic scm.IssueCommentHook) {
 	l = l.WithFields(logrus.Fields{
 		scmprovider.OrgLogField:  ic.Repo.Namespace,
 		scmprovider.RepoLogField: ic.Repo.Name,
@@ -89,8 +89,8 @@ func (s *Server) HandleIssueCommentEvent(l *logrus.Entry, ic scm.IssueCommentHoo
 	)
 }
 
-// HandlePullRequestCommentEvent handles pull request comments events
-func (s *Server) HandlePullRequestCommentEvent(l *logrus.Entry, pc scm.PullRequestCommentHook) {
+// handlePullRequestCommentEvent handles pull request comments events
+func (s *Server) handlePullRequestCommentEvent(l *logrus.Entry, pc scm.PullRequestCommentHook) {
 	l = l.WithFields(logrus.Fields{
 		scmprovider.OrgLogField:  pc.Repo.Namespace,
 		scmprovider.RepoLogField: pc.Repo.Name,
@@ -138,8 +138,8 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *scmprovider.GenericCo
 	}
 }
 
-// HandlePushEvent handles a push event
-func (s *Server) HandlePushEvent(l *logrus.Entry, pe *scm.PushHook) {
+// handlePushEvent handles a push event
+func (s *Server) handlePushEvent(l *logrus.Entry, pe *scm.PushHook) {
 	repo := pe.Repository()
 	l = l.WithFields(logrus.Fields{
 		scmprovider.OrgLogField:  repo.Namespace,
@@ -163,8 +163,8 @@ func (s *Server) HandlePushEvent(l *logrus.Entry, pe *scm.PushHook) {
 	l.WithField("count", strconv.Itoa(c)).Info("number of push handlers")
 }
 
-// HandlePullRequestEvent handles a pull request event
-func (s *Server) HandlePullRequestEvent(l *logrus.Entry, pr *scm.PullRequestHook) {
+// handlePullRequestEvent handles a pull request event
+func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr *scm.PullRequestHook) {
 	l = l.WithFields(logrus.Fields{
 		scmprovider.OrgLogField:  pr.Repo.Namespace,
 		scmprovider.RepoLogField: pr.Repo.Name,
@@ -220,13 +220,13 @@ func (s *Server) HandlePullRequestEvent(l *logrus.Entry, pr *scm.PullRequestHook
 	)
 }
 
-// HandleBranchEvent handles a branch event
-func (s *Server) HandleBranchEvent(entry *logrus.Entry, hook *scm.BranchHook) {
+// handleBranchEvent handles a branch event
+func (s *Server) handleBranchEvent(entry *logrus.Entry, hook *scm.BranchHook) {
 	// TODO
 }
 
-// HandleReviewEvent handles a PR review event
-func (s *Server) HandleReviewEvent(l *logrus.Entry, re scm.ReviewHook) {
+// handleReviewEvent handles a PR review event
+func (s *Server) handleReviewEvent(l *logrus.Entry, re scm.ReviewHook) {
 	l = l.WithFields(logrus.Fields{
 		scmprovider.OrgLogField:  re.Repo.Namespace,
 		scmprovider.RepoLogField: re.Repo.Name,

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -255,7 +255,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking Push handler")
 
-		o.server.HandlePushEvent(l, pushHook)
+		o.server.handlePushEvent(l, pushHook)
 		return l, "processed push hook", nil
 	}
 	prHook, ok := webhook.(*scm.PullRequestHook)
@@ -271,7 +271,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking PR handler")
 
-		o.server.HandlePullRequestEvent(l, prHook)
+		o.server.handlePullRequestEvent(l, prHook)
 		return l, "processed PR hook", nil
 	}
 	branchHook, ok := webhook.(*scm.BranchHook)
@@ -285,7 +285,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking branch handler")
 
-		o.server.HandleBranchEvent(l, branchHook)
+		o.server.handleBranchEvent(l, branchHook)
 		return l, "processed branch hook", nil
 	}
 	issueCommentHook, ok := webhook.(*scm.IssueCommentHook)
@@ -305,7 +305,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking Issue Comment handler")
 
-		o.server.HandleIssueCommentEvent(l, *issueCommentHook)
+		o.server.handleIssueCommentEvent(l, *issueCommentHook)
 		return l, "processed issue comment hook", nil
 	}
 	prCommentHook, ok := webhook.(*scm.PullRequestCommentHook)
@@ -329,7 +329,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking Issue Comment handler")
 
-		o.server.HandlePullRequestCommentEvent(l, *prCommentHook)
+		o.server.handlePullRequestCommentEvent(l, *prCommentHook)
 		return l, "processed PR comment hook", nil
 	}
 	prReviewHook, ok := webhook.(*scm.ReviewHook)
@@ -349,7 +349,7 @@ func (o *WebhooksController) ProcessWebHook(l *logrus.Entry, webhook scm.Webhook
 
 		l.Info("invoking PR Review handler")
 
-		o.server.HandleReviewEvent(l, *prReviewHook)
+		o.server.handleReviewEvent(l, *prReviewHook)
 		return l, "processed PR review hook", nil
 	}
 	l.Debugf("unknown kind %s webhook %#v", webhook.Kind(), webhook)


### PR DESCRIPTION
This PR makes webhook event handlers private (they don't need to be public)