### PR TITLE
chore: Add RegisterHelpProvider method for plugins help registration

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -95,9 +95,10 @@ type state struct {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterReviewEventHandler(PluginName, handleReviewEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequestEvent, helpProvider)
+	plugins.RegisterHelpProvider(PluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent)
+	plugins.RegisterReviewEventHandler(PluginName, handleReviewEvent)
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequestEvent)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -38,7 +38,8 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/blockade/blockade.go
+++ b/pkg/plugins/blockade/blockade.go
@@ -57,7 +57,8 @@ type pruneClient interface {
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(PluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/branchcleaner/branchcleaner.go
+++ b/pkg/plugins/branchcleaner/branchcleaner.go
@@ -31,7 +31,8 @@ const (
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/cat/cat.go
+++ b/pkg/plugins/cat/cat.go
@@ -51,7 +51,8 @@ const (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -34,12 +34,12 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = "cherry-pick-unapproved"
+	pluginName = "cherry-pick-unapproved"
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/dog/dog.go
+++ b/pkg/plugins/dog/dog.go
@@ -50,7 +50,8 @@ const (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/help/help.go
+++ b/pkg/plugins/help/help.go
@@ -57,7 +57,8 @@ by commenting with the ` + "`/remove-good-first-issue`" + ` command.
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = "hold"
+	pluginName = "hold"
 )
 
 var (
@@ -46,7 +45,8 @@ var (
 type hasLabelFunc func(label string, issueLabels []*scm.Label) bool
 
 func init() {
-	plugins.RegisterGenericCommentHandler(PluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/hold/hold_test.go
+++ b/pkg/plugins/hold/hold_test.go
@@ -101,7 +101,7 @@ func TestHandle(t *testing.T) {
 				return tc.hasLabel
 			}
 
-			if err := handle(scmprovider.ToTestClient(client), logrus.WithField("plugin", PluginName), e, hasLabel); err != nil {
+			if err := handle(scmprovider.ToTestClient(client), logrus.WithField("plugin", pluginName), e, hasLabel); err != nil {
 				t.Fatalf("For case %s, didn't expect error from hold: %v", tc.name, err)
 			}
 

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -41,7 +41,8 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func configString(labels []string) string {

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = labels.LGTM
+	pluginName = labels.LGTM
 )
 
 var (
@@ -59,11 +58,12 @@ type commentPruner interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(PluginName, func(pc plugins.Agent, pe scm.PullRequestHook) error {
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent)
+	plugins.RegisterPullRequestHandler(pluginName, func(pc plugins.Agent, pe scm.PullRequestHook) error {
 		return handlePullRequestEvent(pc, pe)
-	}, helpProvider)
-	plugins.RegisterReviewEventHandler(PluginName, handlePullRequestReviewEvent, helpProvider)
+	})
+	plugins.RegisterReviewEventHandler(pluginName, handlePullRequestReviewEvent)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -348,7 +348,7 @@ func TestLGTMComment(t *testing.T) {
 				SCMProviderClient:   fc,
 				PullRequestComments: fc.PullRequestComments[5],
 			}
-			if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
+			if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
 				t.Fatalf("didn't expect error from lgtmComment: %v", err)
 			}
 			if err := fakeClient.PopulateFakeLabelsFromComments("org", "repo", 5, fakeLabel, tc.hasLGTM && tc.shouldToggle); err != nil {
@@ -509,7 +509,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 			SCMProviderClient:   fc,
 			PullRequestComments: fc.PullRequestComments[5],
 		}
-		if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
+		if err := handleGenericComment(fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
 			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 			continue
 		}
@@ -706,7 +706,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 			SCMProviderClient:   fc,
 			PullRequestComments: fc.PullRequestComments[5],
 		}
-		if err := handlePullRequestReview(fakeClient, pc, oc, logrus.WithField("plugin", PluginName), fp, *e); err != nil {
+		if err := handlePullRequestReview(fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
 			t.Errorf("For case %s, didn't expect error from pull request review: %v", tc.name, err)
 			continue
 		}
@@ -1102,7 +1102,7 @@ func TestAddTreeHashComment(t *testing.T) {
 			commit := &scm.Commit{}
 			commit.Tree.Sha = treeSHA
 			fc.Commits[SHA] = commit
-			handle(true, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", PluginName), &fakePruner{})
+			handle(true, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", pluginName), &fakePruner{})
 			found := false
 			for _, body := range fc.PullRequestCommentsAdded {
 				if addLGTMLabelNotificationRe.MatchString(body) {
@@ -1157,7 +1157,7 @@ func TestRemoveTreeHashComment(t *testing.T) {
 		SCMProviderClient:   fc,
 		PullRequestComments: fc.PullRequestComments[101],
 	}
-	handle(false, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", PluginName), fp)
+	handle(false, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", pluginName), fp)
 	found := false
 	for _, body := range fc.PullRequestCommentsDeleted {
 		if addLGTMLabelNotificationRe.MatchString(body) {

--- a/pkg/plugins/lifecycle/lifecycle.go
+++ b/pkg/plugins/lifecycle/lifecycle.go
@@ -33,8 +33,11 @@ var (
 	lifecycleRe     = regexp.MustCompile(`(?mi)^/(?:lh-)?(remove-)?lifecycle (active|frozen|stale|rotten)\s*$`)
 )
 
+const pluginName = "lifecycle"
+
 func init() {
-	plugins.RegisterGenericCommentHandler("lifecycle", lifecycleHandleGenericComment, help)
+	plugins.RegisterHelpProvider(pluginName, help)
+	plugins.RegisterGenericCommentHandler(pluginName, lifecycleHandleGenericComment)
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/milestone/milestone.go
+++ b/pkg/plugins/milestone/milestone.go
@@ -52,7 +52,8 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -51,7 +51,8 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -127,7 +127,8 @@ func (c client) presubmitForContext(org, repo, context string) *job.Presubmit {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/owners-label/owners-label.go
+++ b/pkg/plugins/owners-label/owners-label.go
@@ -28,12 +28,12 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = "owners-label"
+	pluginName = "owners-label"
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/owners-label/owners-label_test.go
+++ b/pkg/plugins/owners-label/owners-label_test.go
@@ -193,7 +193,7 @@ func TestHandle(t *testing.T) {
 			Repo:        basicPR.Base.Repo,
 		}
 
-		err := handle(fakeClient, foc, logrus.WithField("plugin", PluginName), pre)
+		err := handle(fakeClient, foc, logrus.WithField("plugin", pluginName), pre)
 		if err != nil {
 			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
 			continue

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -55,6 +55,11 @@ var (
 // plugins. It takes into account the plugins configuration and enabled repositories.
 type HelpProvider func(config *Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error)
 
+// RegisterHelpProvider registers a plugin's help provider.
+func RegisterHelpProvider(name string, fn HelpProvider) {
+	pluginHelp[name] = fn
+}
+
 // HelpProviders returns the map of registered plugins with their associated HelpProvider.
 func HelpProviders() map[string]HelpProvider {
 	return pluginHelp
@@ -64,8 +69,7 @@ func HelpProviders() map[string]HelpProvider {
 type IssueHandler func(Agent, scm.Issue) error
 
 // RegisterIssueHandler registers a plugin's scm.Issue handler.
-func RegisterIssueHandler(name string, fn IssueHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterIssueHandler(name string, fn IssueHandler) {
 	issueHandlers[name] = fn
 }
 
@@ -73,8 +77,7 @@ func RegisterIssueHandler(name string, fn IssueHandler, help HelpProvider) {
 type IssueCommentHandler func(Agent, scm.IssueCommentHook) error
 
 // RegisterIssueCommentHandler registers a plugin's scm.Comment handler.
-func RegisterIssueCommentHandler(name string, fn IssueCommentHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterIssueCommentHandler(name string, fn IssueCommentHandler) {
 	issueCommentHandlers[name] = fn
 }
 
@@ -82,8 +85,7 @@ func RegisterIssueCommentHandler(name string, fn IssueCommentHandler, help HelpP
 type PullRequestHandler func(Agent, scm.PullRequestHook) error
 
 // RegisterPullRequestHandler registers a plugin's scm.PullRequest handler.
-func RegisterPullRequestHandler(name string, fn PullRequestHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterPullRequestHandler(name string, fn PullRequestHandler) {
 	pullRequestHandlers[name] = fn
 }
 
@@ -91,8 +93,7 @@ func RegisterPullRequestHandler(name string, fn PullRequestHandler, help HelpPro
 type StatusEventHandler func(Agent, scm.Status) error
 
 // RegisterStatusEventHandler registers a plugin's scm.Status handler.
-func RegisterStatusEventHandler(name string, fn StatusEventHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterStatusEventHandler(name string, fn StatusEventHandler) {
 	statusEventHandlers[name] = fn
 }
 
@@ -100,8 +101,7 @@ func RegisterStatusEventHandler(name string, fn StatusEventHandler, help HelpPro
 type PushEventHandler func(Agent, scm.PushHook) error
 
 // RegisterPushEventHandler registers a plugin's scm.PushHook handler.
-func RegisterPushEventHandler(name string, fn PushEventHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterPushEventHandler(name string, fn PushEventHandler) {
 	pushEventHandlers[name] = fn
 }
 
@@ -109,8 +109,7 @@ func RegisterPushEventHandler(name string, fn PushEventHandler, help HelpProvide
 type ReviewEventHandler func(Agent, scm.ReviewHook) error
 
 // RegisterReviewEventHandler registers a plugin's ReviewHook handler.
-func RegisterReviewEventHandler(name string, fn ReviewEventHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterReviewEventHandler(name string, fn ReviewEventHandler) {
 	reviewEventHandlers[name] = fn
 }
 
@@ -118,8 +117,7 @@ func RegisterReviewEventHandler(name string, fn ReviewEventHandler, help HelpPro
 type ReviewCommentEventHandler func(Agent, scm.PullRequestCommentHook) error
 
 // RegisterReviewCommentEventHandler registers a plugin's scm.PullRequestCommentHook handler.
-func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler) {
 	reviewCommentEventHandlers[name] = fn
 }
 
@@ -127,8 +125,7 @@ func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler
 type GenericCommentHandler func(Agent, scmprovider.GenericCommentEvent) error
 
 // RegisterGenericCommentHandler registers a plugin's scm.Comment handler.
-func RegisterGenericCommentHandler(name string, fn GenericCommentHandler, help HelpProvider) {
-	pluginHelp[name] = help
+func RegisterGenericCommentHandler(name string, fn GenericCommentHandler) {
 	genericCommentHandlers[name] = fn
 }
 

--- a/pkg/plugins/pony/pony.go
+++ b/pkg/plugins/pony/pony.go
@@ -56,7 +56,8 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/shrug/shrug.go
+++ b/pkg/plugins/shrug/shrug.go
@@ -49,7 +49,8 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/sigmention/sigmention.go
+++ b/pkg/plugins/sigmention/sigmention.go
@@ -57,7 +57,8 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/size/size.go
+++ b/pkg/plugins/size/size.go
@@ -45,7 +45,8 @@ var defaultSizes = plugins.Size{
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/skip/skip.go
+++ b/pkg/plugins/skip/skip.go
@@ -47,7 +47,8 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/stage/stage.go
+++ b/pkg/plugins/stage/stage.go
@@ -37,8 +37,11 @@ var (
 	stageRe     = regexp.MustCompile(`(?mi)^/(?:lh-)?(remove-)?stage (alpha|beta|stable)\s*$`)
 )
 
+const pluginName = "stage"
+
 func init() {
-	plugins.RegisterGenericCommentHandler("stage", stageHandleGenericComment, help)
+	plugins.RegisterHelpProvider(pluginName, help)
+	plugins.RegisterGenericCommentHandler(pluginName, stageHandleGenericComment)
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -878,7 +878,7 @@ func TestHandleGenericComment(t *testing.T) {
 				SCMProviderClient: g,
 				LauncherClient:    fakeLauncher,
 				Config:            fakeConfig,
-				Logger:            logrus.WithField("plugin", PluginName),
+				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			presubmits := tc.Presubmits
 			if presubmits == nil {

--- a/pkg/plugins/trigger/pull-request_test.go
+++ b/pkg/plugins/trigger/pull-request_test.go
@@ -282,7 +282,7 @@ func TestHandlePullRequest(t *testing.T) {
 			SCMProviderClient: g,
 			LauncherClient:    fakeLauncher,
 			Config:            &config.Config{},
-			Logger:            logrus.WithField("plugin", PluginName),
+			Logger:            logrus.WithField("plugin", pluginName),
 		}
 
 		presubmits := map[string][]job.Presubmit{

--- a/pkg/plugins/trigger/push_test.go
+++ b/pkg/plugins/trigger/push_test.go
@@ -138,7 +138,7 @@ func TestHandlePE(t *testing.T) {
 			SCMProviderClient: g,
 			LauncherClient:    fakeLauncher,
 			Config:            &config.Config{ProwConfig: config.ProwConfig{LighthouseJobNamespace: "lighthouseJobs"}},
-			Logger:            logrus.WithField("plugin", PluginName),
+			Logger:            logrus.WithField("plugin", pluginName),
 		}
 		postsubmits := map[string][]job.Postsubmit{
 			"org/repo": {

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -34,14 +34,15 @@ import (
 )
 
 const (
-	// PluginName is the name of the trigger plugin
-	PluginName = "trigger"
+	// pluginName is the name of the trigger plugin
+	pluginName = "trigger"
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
-	plugins.RegisterPushEventHandler(PluginName, handlePush, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPushEventHandler(pluginName, handlePush)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/updateconfig/updateconfig.go
+++ b/pkg/plugins/updateconfig/updateconfig.go
@@ -50,7 +50,8 @@ const (
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/welcome/welcome.go
+++ b/pkg/plugins/welcome/welcome.go
@@ -45,7 +45,8 @@ type PRInfo struct {
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/wip/wip-label.go
+++ b/pkg/plugins/wip/wip-label.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// PluginName defines this plugin's registered name.
-	PluginName = "wip"
+	pluginName = "wip"
 )
 
 var (
@@ -52,7 +52,8 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/pkg/plugins/wip/wip-label_test.go
+++ b/pkg/plugins/wip/wip-label_test.go
@@ -133,7 +133,7 @@ func TestWipLabel(t *testing.T) {
 				hasLabel: tc.hasLabel,
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", PluginName), e); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e); err != nil {
 				t.Fatalf("For case %s, didn't expect error from wip: %v", tc.name, err)
 			}
 

--- a/pkg/plugins/yuks/yuks.go
+++ b/pkg/plugins/yuks/yuks.go
@@ -43,7 +43,8 @@ const (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+	plugins.RegisterHelpProvider(pluginName, helpProvider)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {


### PR DESCRIPTION
This PR adds and uses a `RegisterHelpProvider` method for plugins help registration.

Fixes #1014 