### PR TITLE
refactor: Make RegisterPlugin more declarative

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -95,10 +95,19 @@ type state struct {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(PluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent)
-	plugins.RegisterReviewEventHandler(PluginName, handleReviewEvent)
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequestEvent)
+	plugins.RegisterPlugin(
+		PluginName,
+		plugins.Plugin{
+			Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
+<br>
+<br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
+<br>For more information see <a href="https://git.github.com/jenkins-x/lighthouse/pkg/prow/plugins/approve/approvers/README.md">here</a>.`,
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericCommentEvent,
+			ReviewEventHandler:    handleReviewEvent,
+			PullRequestHandler:    handlePullRequestEvent,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -130,10 +139,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.HasSelfApproval()), willNot(opts.LgtmActsAsApprove), willNot(opts.ConsiderReviewState()))
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
-<br>
-<br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
-<br>For more information see <a href="https://git.github.com/jenkins-x/lighthouse/pkg/prow/plugins/approve/approvers/README.md">here</a>.`,
 		Config: approveConfig,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{

--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -38,15 +38,19 @@ var (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no user is specified the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no user is specified the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[un]assign [[@]<username>...]",
 		Description: "Assigns an assignee to the PR",

--- a/pkg/plugins/blockade/blockade.go
+++ b/pkg/plugins/blockade/blockade.go
@@ -57,8 +57,14 @@ type pruneClient interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(PluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		PluginName,
+		plugins.Plugin{
+			Description:        "The blockade plugin blocks pull requests from merging if they touch specific files. The plugin applies the '" + labels.BlockedPaths + "' label to pull requests that touch files that match a blockade's block regular expression and none of the corresponding exception regular expressions.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -79,11 +85,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		blockConfig[repo] = buf.String()
 	}
-	return &pluginhelp.PluginHelp{
-			Description: "The blockade plugin blocks pull requests from merging if they touch specific files. The plugin applies the '" + labels.BlockedPaths + "' label to pull requests that touch files that match a blockade's block regular expression and none of the corresponding exception regular expressions.",
-			Config:      blockConfig,
-		},
-		nil
+	return &pluginhelp.PluginHelp{Config: blockConfig}, nil
 }
 
 type blockCalc func([]*scm.Change, []blockade) summary

--- a/pkg/plugins/branchcleaner/branchcleaner.go
+++ b/pkg/plugins/branchcleaner/branchcleaner.go
@@ -31,13 +31,18 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The branchcleaner plugin automatically deletes source branches for merged PRs between two branches on the same repository. This is helpful to keep repos that don't allow forking clean.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{
-		Description: "The branchcleaner plugin automatically deletes source branches for merged PRs between two branches on the same repository. This is helpful to keep repos that don't allow forking clean."}, nil
+	return &pluginhelp.PluginHelp{}, nil
 }
 
 func handlePullRequest(pc plugins.Agent, pre scm.PullRequestHook) error {

--- a/pkg/plugins/cat/cat.go
+++ b/pkg/plugins/cat/cat.go
@@ -51,13 +51,18 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
 		Config: map[string]string{
 			"": fmt.Sprintf("The cat plugin uses an api key for thecatapi.com stored in %s.", config.Cat.KeyPath),
 		},

--- a/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -38,15 +38,20 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "Label PRs against a release branch which do not have the `cherry-pick-approved` label with the `do-not-merge/cherry-pick-not-approved` label.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// Only the 'Config' and Description' fields are necessary because this
 	// plugin does not react to any commands.
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "Label PRs against a release branch which do not have the `cherry-pick-approved` label with the `do-not-merge/cherry-pick-not-approved` label.",
 		Config: map[string]string{
 			"": fmt.Sprintf(
 				"The cherry-pick-unapproved plugin treats PRs against branch names satisfying the regular expression `%s` as cherry-pick PRs and adds the following comment:\n%s",

--- a/pkg/plugins/dog/dog.go
+++ b/pkg/plugins/dog/dog.go
@@ -50,15 +50,19 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(lh-)?(woof|bark|this-is-{fine|not-fine|unbearable})",
 		Description: "Add a dog image to the issue or PR",

--- a/pkg/plugins/help/help.go
+++ b/pkg/plugins/help/help.go
@@ -57,15 +57,19 @@ by commenting with the ` + "`/remove-good-first-issue`" + ` command.
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The help plugin provides commands that add or remove the '" + labels.Help + "' and the '" + labels.GoodFirstIssue + "' labels from issues.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The help plugin provides commands that add or remove the '" + labels.Help + "' and the '" + labels.GoodFirstIssue + "' labels from issues.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[remove-](help|good-first-issue)",
 		Description: "Applies or removes the '" + labels.Help + "' and '" + labels.GoodFirstIssue + "' labels to an issue.",

--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -45,15 +45,19 @@ var (
 type hasLabelFunc func(label string, issueLabels []*scm.Label) bool
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/hold [cancel]",
 		Description: "Adds or removes the `" + labels.Hold + "` Label which is used to indicate that the PR should not be automatically merged.",

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -41,8 +41,14 @@ var (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func configString(labels []string) string {
@@ -58,7 +64,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	labels = append(labels, defaultLabels...)
 	labels = append(labels, config.Label.AdditionalLabels...)
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
 		Config: map[string]string{
 			"": configString(labels),
 		},

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -58,12 +58,18 @@ type commentPruner interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent)
-	plugins.RegisterPullRequestHandler(pluginName, func(pc plugins.Agent, pe scm.PullRequestHook) error {
-		return handlePullRequestEvent(pc, pe)
-	})
-	plugins.RegisterReviewEventHandler(pluginName, handlePullRequestReviewEvent)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericCommentEvent,
+			PullRequestHandler: func(pc plugins.Agent, pe scm.PullRequestHook) error {
+				return handlePullRequestEvent(pc, pe)
+			},
+			ReviewEventHandler: handlePullRequestReviewEvent,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -99,10 +105,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			configInfo[orgRepo] = strings.Join(configInfoStrings, "\n")
 		}
 	}
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
-		Config:      configInfo,
-	}
+	pluginHelp := &pluginhelp.PluginHelp{Config: configInfo}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/lgtm [cancel] or GitHub Review action",
 		Description: "Adds or removes the 'lgtm' label which is typically used to gate merging.",

--- a/pkg/plugins/lifecycle/lifecycle.go
+++ b/pkg/plugins/lifecycle/lifecycle.go
@@ -36,14 +36,18 @@ var (
 const pluginName = "lifecycle"
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, help)
-	plugins.RegisterGenericCommentHandler(pluginName, lifecycleHandleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
+			HelpProvider:          help,
+			GenericCommentHandler: lifecycleHandleGenericComment,
+		},
+	)
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/close",
 		Description: "Closes an issue or PR.",

--- a/pkg/plugins/milestone/milestone.go
+++ b/pkg/plugins/milestone/milestone.go
@@ -52,8 +52,14 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The milestone plugin allows members of a configurable GitHub team to set the milestone on an issue or pull request.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -62,7 +68,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	}
 
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The milestone plugin allows members of a configurable GitHub team to set the milestone on an issue or pull request.",
 		Config: func(repos []string) map[string]string {
 			configMap := make(map[string]string)
 			for _, repo := range repos {

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -51,8 +51,14 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The milestonestatus plugin allows members of the milestone maintainers GitHub team to specify the 'status/*' label that should apply to a pull request.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -61,7 +67,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	}
 
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The milestonestatus plugin allows members of the milestone maintainers GitHub team to specify the 'status/*' label that should apply to a pull request.",
 		Config: func() map[string]string {
 			configMap := make(map[string]string)
 			for _, repo := range enabledRepos {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -127,14 +127,18 @@ func (c client) presubmitForContext(org, repo, context string) *job.Presubmit {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The override plugin allows repo admins to force a github status context to pass",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The override plugin allows repo admins to force a github status context to pass",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override [context]",
 		Description: "Forces a github status context to green (one per line).",

--- a/pkg/plugins/owners-label/owners-label.go
+++ b/pkg/plugins/owners-label/owners-label.go
@@ -32,15 +32,18 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{
-			Description: "The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes.",
-		},
-		nil
+	return &pluginhelp.PluginHelp{}, nil
 }
 
 type ownersClient interface {

--- a/pkg/plugins/pony/pony.go
+++ b/pkg/plugins/pony/pony.go
@@ -56,15 +56,19 @@ var (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/(pony) [pony]",
 		Description: "Add a little pony image to the issue or PR. A particular pony can optionally be named for a picture of that specific pony.",

--- a/pkg/plugins/shrug/shrug.go
+++ b/pkg/plugins/shrug/shrug.go
@@ -49,15 +49,19 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           labels.Shrug,
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: labels.Shrug,
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[un]shrug",
 		Description: labels.Shrug,

--- a/pkg/plugins/sigmention/sigmention.go
+++ b/pkg/plugins/sigmention/sigmention.go
@@ -57,15 +57,20 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description: `The sigmention plugin responds to SIG (Special Interest Group) GitHub team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
+<ol><li> The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.</li>
+<li> If the user who mentioned the GitHub team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger GitHub notifications.</li></ol>`,
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
-			Description: `The sigmention plugin responds to SIG (Special Interest Group) GitHub team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
-<ol><li> The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.</li>
-<li> If the user who mentioned the GitHub team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger GitHub notifications.</li></ol>`,
 			Config: map[string]string{
 				"": fmt.Sprintf("Labels added by the plugin are triggered by mentions of GitHub teams matching the following regexp:\n%s", config.SigMention.Regexp),
 			},

--- a/pkg/plugins/size/size.go
+++ b/pkg/plugins/size/size.go
@@ -45,14 +45,19 @@ var defaultSizes = plugins.Size{
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions).",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	sizes := sizesOrDefault(config.Size)
 	return &pluginhelp.PluginHelp{
-			Description: "The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions).",
 			Config: map[string]string{
 				"": fmt.Sprintf(`The plugin has the following thresholds:<ul>
 <li>size/XS:  0-%d</li>

--- a/pkg/plugins/skip/skip.go
+++ b/pkg/plugins/skip/skip.go
@@ -47,14 +47,18 @@ type scmProviderClient interface {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/skip",
 		Description: "Cleans up GitHub stale commit statuses for non-blocking jobs on a PR.",

--- a/pkg/plugins/stage/stage.go
+++ b/pkg/plugins/stage/stage.go
@@ -40,15 +40,19 @@ var (
 const pluginName = "stage"
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, help)
-	plugins.RegisterGenericCommentHandler(pluginName, stageHandleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "Label the stage of an issue as alpha/beta/stable",
+			HelpProvider:          help,
+			GenericCommentHandler: stageHandleGenericComment,
+		},
+	)
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "Label the stage of an issue as alpha/beta/stable",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[remove-]stage <alpha|beta|stable>",
 		Description: "Labels the stage of an issue as alpha/beta/stable",

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -39,10 +39,18 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
-	plugins.RegisterPushEventHandler(pluginName, handlePush)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
+<br>Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command.
+<br>The '/retest' command can be used to rerun jobs that have reported failure.`,
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericCommentEvent,
+			PullRequestHandler:    handlePullRequest,
+			PushEventHandler:      handlePush,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -65,9 +73,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		configInfo[orgRepo] = fmt.Sprintf("The trusted GitHub organization for this repository is %q.", org)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
-<br>Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command.
-<br>The '/retest' command can be used to rerun jobs that have reported failure.`,
 		Config: configInfo,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{

--- a/pkg/plugins/updateconfig/updateconfig.go
+++ b/pkg/plugins/updateconfig/updateconfig.go
@@ -50,8 +50,14 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The config-updater plugin automatically redeploys configuration and plugin configuration files when they change. The plugin watches for pull request merges that modify either of the config files and updates the cluster's configmap resources in response.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -66,11 +72,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		)
 		configInfo = map[string]string{"": msg}
 	}
-	return &pluginhelp.PluginHelp{
-			Description: "The config-updater plugin automatically redeploys configuration and plugin configuration files when they change. The plugin watches for pull request merges that modify either of the config files and updates the cluster's configmap resources in response.",
-			Config:      configInfo,
-		},
-		nil
+	return &pluginhelp.PluginHelp{Config: configInfo}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/welcome/welcome.go
+++ b/pkg/plugins/welcome/welcome.go
@@ -45,8 +45,14 @@ type PRInfo struct {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The welcome plugin posts a welcoming message when it detects a user's first contribution to a repo.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -66,11 +72,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	}
 
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
-	return &pluginhelp.PluginHelp{
-			Description: "The welcome plugin posts a welcoming message when it detects a user's first contribution to a repo.",
-			Config:      welcomeConfig,
-		},
-		nil
+	return &pluginhelp.PluginHelp{Config: welcomeConfig}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/wip/wip-label.go
+++ b/pkg/plugins/wip/wip-label.go
@@ -52,16 +52,19 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:        "The wip (Work In Progress) plugin applies the '" + labels.WorkInProgress + "' Label to pull requests whose title starts with 'WIP' or are in the 'draft' stage, and removes it from pull requests when they remove the title prefix or become ready for review. The '" + labels.WorkInProgress + "' Label is typically used to block a pull request from merging while it is still in progress.",
+			HelpProvider:       helpProvider,
+			PullRequestHandler: handlePullRequest,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
-	return &pluginhelp.PluginHelp{
-			Description: "The wip (Work In Progress) plugin applies the '" + labels.WorkInProgress + "' Label to pull requests whose title starts with 'WIP' or are in the 'draft' stage, and removes it from pull requests when they remove the title prefix or become ready for review. The '" + labels.WorkInProgress + "' Label is typically used to block a pull request from merging while it is still in progress.",
-		},
-		nil
+	return &pluginhelp.PluginHelp{}, nil
 }
 
 // Strict subset of gitprovider.Client methods.

--- a/pkg/plugins/yuks/yuks.go
+++ b/pkg/plugins/yuks/yuks.go
@@ -43,15 +43,19 @@ const (
 )
 
 func init() {
-	plugins.RegisterHelpProvider(pluginName, helpProvider)
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterPlugin(
+		pluginName,
+		plugins.Plugin{
+			Description:           "The yuks plugin comments with jokes in response to the `/joke` command.",
+			HelpProvider:          helpProvider,
+			GenericCommentHandler: handleGenericComment,
+		},
+	)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The yuks plugin comments with jokes in response to the `/joke` command.",
-	}
+	pluginHelp := &pluginhelp.PluginHelp{}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/joke",
 		Description: "Tells a joke.",


### PR DESCRIPTION
This PR changes the way plugins register with the host.

Instead of an imperative approach, it uses a more declarative approach.

A plugin calls `RegisterPlugin` with a struct that describes the plugin handlers and other infos.

This will help having a clear contract between the host and the plugins and will allow to move some boilerplate code to the host progressively.

Moved into the `Plugin` descriptor struct:
- handlers
- description