### PR TITLE
chore: replace GetXXXHandlers methods by GetPlugins

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -116,124 +116,6 @@ func HelpProviders() map[string]HelpProvider {
 	return pluginHelp
 }
 
-// GenericCommentHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) GenericCommentHandlers(owner, repo string) map[string]GenericCommentHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]GenericCommentHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.GenericCommentHandler != nil {
-			hs[p] = h.GenericCommentHandler
-		}
-	}
-	return hs
-}
-
-// IssueHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) IssueHandlers(owner, repo string) map[string]IssueHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]IssueHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.IssueHandler != nil {
-			hs[p] = h.IssueHandler
-		}
-	}
-	return hs
-}
-
-// IssueCommentHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) IssueCommentHandlers(owner, repo string) map[string]IssueCommentHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]IssueCommentHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.IssueCommentHandler != nil {
-			hs[p] = h.IssueCommentHandler
-		}
-	}
-
-	return hs
-}
-
-// PullRequestHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) PullRequestHandlers(owner, repo string) map[string]PullRequestHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]PullRequestHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.PullRequestHandler != nil {
-			hs[p] = h.PullRequestHandler
-		}
-	}
-
-	return hs
-}
-
-// ReviewEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) ReviewEventHandlers(owner, repo string) map[string]ReviewEventHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]ReviewEventHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.ReviewEventHandler != nil {
-			hs[p] = h.ReviewEventHandler
-		}
-	}
-
-	return hs
-}
-
-// ReviewCommentEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) ReviewCommentEventHandlers(owner, repo string) map[string]ReviewCommentEventHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]ReviewCommentEventHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.ReviewCommentEventHandler != nil {
-			hs[p] = h.ReviewCommentEventHandler
-		}
-	}
-
-	return hs
-}
-
-// StatusEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) StatusEventHandlers(owner, repo string) map[string]StatusEventHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]StatusEventHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.StatusEventHandler != nil {
-			hs[p] = h.StatusEventHandler
-		}
-	}
-
-	return hs
-}
-
-// PushEventHandlers returns a map of plugin names to handlers for the repo.
-func (pa *ConfigAgent) PushEventHandlers(owner, repo string) map[string]PushEventHandler {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	hs := map[string]PushEventHandler{}
-	for _, p := range pa.getPlugins(owner, repo) {
-		if h, ok := plugins[p]; ok && h.PushEventHandler != nil {
-			hs[p] = h.PushEventHandler
-		}
-	}
-
-	return hs
-}
-
 // Agent may be used concurrently, so each entry must be thread-safe.
 type Agent struct {
 	SCMProviderClient *scmprovider.Client
@@ -428,6 +310,20 @@ func (pa *ConfigAgent) getPlugins(owner, repo string) []string {
 	}
 	logrus.Infof("found plugins %s\n", strings.Join(plugins, ", "))
 	return plugins
+}
+
+// GetPlugins returns a map of plugin names to plugins for the repo.
+func (pa *ConfigAgent) GetPlugins(owner, repo string) map[string]Plugin {
+	pa.mut.Lock()
+	defer pa.mut.Unlock()
+
+	hs := map[string]Plugin{}
+	for _, p := range pa.getPlugins(owner, repo) {
+		if h, ok := plugins[p]; ok {
+			hs[p] = h
+		}
+	}
+	return hs
 }
 
 // EventsForPlugin returns the registered events for the passed plugin.


### PR DESCRIPTION
This PR replaces `GetXXXHandlers` methods by a single one `GetPlugins`.

The callers get the plugins and check if a handler is set for their specific needs.