### PR TITLE
refactor: manage commands in Plugin descriptor

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -94,20 +94,33 @@ type state struct {
 	htmlURL   string
 }
 
-func init() {
-	plugins.RegisterPlugin(
-		PluginName,
-		plugins.Plugin{
-			Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
+var (
+	plugin = plugins.Plugin{
+		Description: `The approve plugin implements a pull request approval process that manages the '` + labels.Approved + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
 <br>
 <br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
 <br>For more information see <a href="https://git.github.com/jenkins-x/lighthouse/pkg/prow/plugins/approve/approvers/README.md">here</a>.`,
-			HelpProvider:          helpProvider,
+		HelpProvider:       helpProvider,
+		ReviewEventHandler: handleReviewEvent,
+		PullRequestHandler: handlePullRequestEvent,
+		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericCommentEvent,
-			ReviewEventHandler:    handleReviewEvent,
-			PullRequestHandler:    handlePullRequestEvent,
-		},
-	)
+			Filter: func(e scmprovider.GenericCommentEvent) bool {
+				return !(e.Action != scm.ActionCreate || !e.IsPR || e.IssueState == "closed")
+			},
+			Help: []pluginhelp.Command{{
+				Usage:       "/approve [no-issue|cancel]",
+				Description: "Approves a pull request",
+				Featured:    true,
+				WhoCanUse:   "Users listed as 'approvers' in appropriate OWNERS files.",
+				Examples:    []string{"/approve", "/approve no-issue", "/lh-approve"},
+			}},
+		}},
+	}
+)
+
+func init() {
+	plugins.RegisterPlugin(PluginName, plugin)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -138,20 +151,10 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.HasSelfApproval()), willNot(opts.LgtmActsAsApprove), willNot(opts.ConsiderReviewState()))
 	}
-	pluginHelp := &pluginhelp.PluginHelp{
-		Config: approveConfig,
-	}
-	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/approve [no-issue|cancel]",
-		Description: "Approves a pull request",
-		Featured:    true,
-		WhoCanUse:   "Users listed as 'approvers' in appropriate OWNERS files.",
-		Examples:    []string{"/approve", "/approve no-issue", "/lh-approve"},
-	})
-	return pluginHelp, nil
+	return &pluginhelp.PluginHelp{Config: approveConfig}, nil
 }
 
-func handleGenericCommentEvent(pc plugins.Agent, ce scmprovider.GenericCommentEvent) error {
+func handleGenericCommentEvent(_ []string, pc plugins.Agent, ce scmprovider.GenericCommentEvent) error {
 	baseURL, err := url.Parse(ce.IssueLink)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse URL %s", ce.Link)
@@ -169,10 +172,6 @@ func handleGenericCommentEvent(pc plugins.Agent, ce scmprovider.GenericCommentEv
 }
 
 func handleGenericComment(log *logrus.Entry, spc scmProviderClient, oc ownersClient, serverURL *url.URL, config *plugins.Configuration, ce *scmprovider.GenericCommentEvent) error {
-	if ce.Action != scm.ActionCreate || !ce.IsPR || ce.IssueState == "closed" {
-		return nil
-	}
-
 	botName, err := spc.BotName()
 	if err != nil {
 		return err

--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -1493,17 +1493,19 @@ func TestHandleGenericComment(t *testing.T) {
 				Repos:             []string{test.commentEvent.Repo.Namespace},
 				LgtmActsAsApprove: test.lgtmActsAsApprove,
 			})
-			err := handleGenericComment(
-				logrus.WithField("plugin", "approve"),
-				fakeClient,
-				fakeOwnersClient{},
-				&url.URL{
-					Scheme: "https",
-					Host:   "github.com",
-				},
-				config,
-				&test.commentEvent,
-			)
+			err := plugin.InvokeCommand(&test.commentEvent, func(match []string) error {
+				return handleGenericComment(
+					logrus.WithField("plugin", "approve"),
+					fakeClient,
+					fakeOwnersClient{},
+					&url.URL{
+						Scheme: "https",
+						Host:   "github.com",
+					},
+					config,
+					&test.commentEvent,
+				)
+			})
 
 			if test.expectHandle && !handled {
 				t.Errorf("%s: expected call to handleFunc, but it wasn't called", test.name)

--- a/pkg/plugins/cat/cat_test.go
+++ b/pkg/plugins/cat/cat_test.go
@@ -363,7 +363,9 @@ Available variants:
 		Number:     5,
 		IssueState: "open",
 	}
-	if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, &realClowder{url: ts.URL + "/?format=json"}, func() {}); err != nil {
+	if err := plugin.InvokeCommand(e, func(match []string) error {
+		return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, &realClowder{url: ts.URL + "/?format=json"}, func() {})
+	}); err != nil {
 		t.Errorf("didn't expect error: %v", err)
 		return
 	}
@@ -482,7 +484,9 @@ func TestCats(t *testing.T) {
 				IssueState: tc.state,
 				IsPR:       tc.pr,
 			}
-			err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakeClowder("tubbs"), func() {})
+			err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, fakeClowder("tubbs"), func() {})
+			})
 			if !tc.shouldError && err != nil {
 				t.Fatalf("%s: didn't expect error: %v", tc.name, err)
 			} else if tc.shouldError && err == nil {

--- a/pkg/plugins/dog/dog_test.go
+++ b/pkg/plugins/dog/dog_test.go
@@ -228,7 +228,9 @@ func TestHttpResponse(t *testing.T) {
 			Number:     5,
 			IssueState: "open",
 		}
-		err = handle(fakeClient, logrus.WithField("plugin", pluginName), e, realPack(ts.URL))
+		err = plugin.InvokeCommand(e, func(match []string) error {
+			return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, realPack(ts.URL))
+		})
 		if err != nil {
 			t.Errorf("tc %s: For comment %s, didn't expect error: %v", testcase.name, testcase.comment, err)
 		}
@@ -348,7 +350,9 @@ func TestDogs(t *testing.T) {
 				IssueState: tc.state,
 				IsPR:       tc.pr,
 			}
-			err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakePack("doge"))
+			err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, fakePack("doge"))
+			})
 			if err != nil {
 				t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
 			}

--- a/pkg/plugins/help/help_test.go
+++ b/pkg/plugins/help/help_test.go
@@ -215,7 +215,9 @@ func TestLabel(t *testing.T) {
 				Repo:       scm.Repository{Namespace: "org", Name: "repo"},
 				Author:     scm.User{Login: "Alice"},
 			}
-			err := handle(fakeSCMProviderClient, logrus.WithField("plugin", pluginName), &fakePruner{}, e)
+			err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fakeSCMProviderClient, logrus.WithField("plugin", pluginName), &fakePruner{}, e)
+			})
 			if err != nil {
 				t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 			}

--- a/pkg/plugins/hold/hold_test.go
+++ b/pkg/plugins/hold/hold_test.go
@@ -101,7 +101,9 @@ func TestHandle(t *testing.T) {
 				return tc.hasLabel
 			}
 
-			if err := handle(scmprovider.ToTestClient(client), logrus.WithField("plugin", pluginName), e, hasLabel); err != nil {
+			if err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, scmprovider.ToTestClient(client), logrus.WithField("plugin", pluginName), e, hasLabel)
+			}); err != nil {
 				t.Fatalf("For case %s, didn't expect error from hold: %v", tc.name, err)
 			}
 

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -40,15 +40,25 @@ var (
 	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
 )
 
-func init() {
-	plugins.RegisterPlugin(
-		pluginName,
-		plugins.Plugin{
-			Description:           "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
-			HelpProvider:          helpProvider,
+var (
+	plugin = plugins.Plugin{
+		Description:  "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
+		HelpProvider: helpProvider,
+		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
-		},
-	)
+			Help: []pluginhelp.Command{{
+				Usage:       "/[remove-](area|committee|kind|language|priority|sig|triage|wg|label) <target>",
+				Description: "Applies or removes a label from one of the recognized types of labels.",
+				Featured:    false,
+				WhoCanUse:   "Anyone can trigger this command on a PR.",
+				Examples:    []string{"/kind bug", "/remove-area prow", "/sig testing", "/language zh"},
+			}},
+		}},
+	}
+)
+
+func init() {
+	plugins.RegisterPlugin(pluginName, plugin)
 }
 
 func configString(labels []string) string {
@@ -68,17 +78,10 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			"": configString(labels),
 		},
 	}
-	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/[remove-](area|committee|kind|language|priority|sig|triage|wg|label) <target>",
-		Description: "Applies or removes a label from one of the recognized types of labels.",
-		Featured:    false,
-		WhoCanUse:   "Anyone can trigger this command on a PR.",
-		Examples:    []string{"/kind bug", "/remove-area prow", "/sig testing", "/language zh"},
-	})
 	return pluginHelp, nil
 }
 
-func handleGenericComment(pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+func handleGenericComment(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 	return handle(pc.SCMProviderClient, pc.Logger, pc.PluginConfig.Label.AdditionalLabels, &e)
 }
 

--- a/pkg/plugins/milestone/milestone_test.go
+++ b/pkg/plugins/milestone/milestone_test.go
@@ -145,7 +145,9 @@ func TestMilestoneStatus(t *testing.T) {
 				repoMilestone["org/repo"] = plugins.Milestone{MaintainersID: maintainersID, MaintainersTeam: maintainersName}
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {
+			if err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone)
+			}); err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 

--- a/pkg/plugins/milestonestatus/milestonestatus_test.go
+++ b/pkg/plugins/milestonestatus/milestonestatus_test.go
@@ -149,7 +149,9 @@ func TestMilestoneStatus(t *testing.T) {
 				repoMilestone["org/repo"] = plugins.Milestone{MaintainersID: 42}
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {
+			if err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone)
+			}); err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -560,7 +560,9 @@ func TestHandle(t *testing.T) {
 				tc.jobs = sets.String{}
 			}
 
-			err := handle(&fc, log, &event)
+			err := plugin.InvokeCommand(&event, func(match []string) error {
+				return handle(&fc, log, &event)
+			})
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/pkg/plugins/pony/pony_test.go
+++ b/pkg/plugins/pony/pony_test.go
@@ -224,7 +224,9 @@ func TestHttpResponse(t *testing.T) {
 				Number:     5,
 				IssueState: "open",
 			}
-			err = handle(fakeClient, logrus.WithField("plugin", pluginName), e, realHerd(ts.URL+testcase.path))
+			err = plugin.InvokeCommand(e, func(match []string) error {
+				return handle(fakeClient, logrus.WithField("plugin", pluginName), e, realHerd(ts.URL+testcase.path))
+			})
 			if err != nil {
 				t.Errorf("tc %s: For comment %s, didn't expect error: %v", testcase.name, testcase.comment, err)
 			}
@@ -318,7 +320,9 @@ func TestPonies(t *testing.T) {
 			IssueState: tc.state,
 			IsPR:       tc.pr,
 		}
-		err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakeHerd("pone"))
+		err := plugin.InvokeCommand(e, func(match []string) error {
+			return handle(fakeClient, logrus.WithField("plugin", pluginName), e, fakeHerd("pone"))
+		})
 		if err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
 		}

--- a/pkg/plugins/stage/stage_test.go
+++ b/pkg/plugins/stage/stage_test.go
@@ -222,7 +222,9 @@ func TestStageLabels(t *testing.T) {
 				Body:   tc.body,
 				Action: scm.ActionCreate,
 			}
-			err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+			err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(match, fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+			})
 			switch {
 			case err != nil:
 				t.Errorf("%s: unexpected error: %v", tc.name, err)

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -35,12 +35,7 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.Gen
 	repo := gc.Repo.Name
 	number := gc.Number
 	commentAuthor := gc.Author.Login
-	// Only take action when a comment is first created,
-	// when it belongs to a PR,
-	// and the PR is open.
-	if gc.Action != scm.ActionCreate || !gc.IsPR || gc.IssueState != "open" {
-		return nil
-	}
+
 	// Skip comments not germane to this plugin
 	if !jobutil.RetestRe.MatchString(gc.Body) && !jobutil.OkToTestRe.MatchString(gc.Body) && !jobutil.TestAllRe.MatchString(gc.Body) {
 		matched := false

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -937,11 +937,15 @@ func TestHandleGenericComment(t *testing.T) {
 			// In some cases handleGenericComment can be called twice for the same event.
 			// For instance on Issue/PR creation and modification.
 			// Let's call it twice to ensure idempotency.
-			if err := handleGenericComment(c, trigger, event); err != nil {
+			if err := plugin.InvokeCommand(&event, func(match []string) error {
+				return handleGenericComment(c, trigger, event)
+			}); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}
 			validate(tc.name, fakeLauncher, g, tc, t)
-			if err := handleGenericComment(c, trigger, event); err != nil {
+			if err := plugin.InvokeCommand(&event, func(match []string) error {
+				return handleGenericComment(c, trigger, event)
+			}); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}
 			validate(tc.name, fakeLauncher, g, tc, t)

--- a/pkg/plugins/yuks/yuks_test.go
+++ b/pkg/plugins/yuks/yuks_test.go
@@ -67,7 +67,9 @@ func TestJokesMedium(t *testing.T) {
 		Number:     5,
 		IssueState: "open",
 	}
-	if err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, realJoke(ts.URL)); err != nil {
+	if err := plugin.InvokeCommand(e, func(match []string) error {
+		return handle(fakeClient, logrus.WithField("plugin", pluginName), e, realJoke(ts.URL))
+	}); err != nil {
 		t.Errorf("didn't expect error: %v", err)
 		return
 	}
@@ -161,7 +163,9 @@ func TestJokes(t *testing.T) {
 				IssueState: tc.state,
 				IsPR:       tc.pr,
 			}
-			err := handle(fakeClient, logrus.WithField("plugin", pluginName), e, tc.joke)
+			err := plugin.InvokeCommand(e, func(match []string) error {
+				return handle(fakeClient, logrus.WithField("plugin", pluginName), e, tc.joke)
+			})
 			if !tc.shouldError && err != nil {
 				t.Fatalf("For case %s, didn't expect error: %v", tc.name, err)
 			} else if tc.shouldError && err == nil {


### PR DESCRIPTION
This PR changes the way plugin commands are managed by the plugin engine.

Before, the commands were registered separately from the help provider, it was simply a `GenericCommentEventHandler` and there was no guarantee that the command and the help provider were consistent.

Now, the commands are part of the definition of a plugin, the help is moved in the command definition, this makes it easier to keep the command and its help consistent.
The command registration can specify the regex to use and a filter func, these parameters will be taken care of by the plugin engine automatically and the regex match will be passed to the handler when being invoked by the plugin engine.

If the command definition does not specify a regex or a filter func, it will behave like before (receive all events and the filtering/matching has to be done by the handler).
