### PR TITLE
refactor: synthesize plugin help provider based on plugin definition

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -100,7 +100,7 @@ var (
 <br>
 <br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
 <br>For more information see <a href="https://git.github.com/jenkins-x/lighthouse/pkg/prow/plugins/approve/approvers/README.md">here</a>.`,
-		HelpProvider:       helpProvider,
+		ConfigHelpProvider: configHelp,
 		ReviewEventHandler: handleReviewEvent,
 		PullRequestHandler: handlePullRequestEvent,
 		Commands: []plugins.Command{{
@@ -123,7 +123,7 @@ func init() {
 	plugins.RegisterPlugin(PluginName, plugin)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	doNot := func(b bool) string {
 		if b {
 			return ""
@@ -151,7 +151,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		approveConfig[repo] = fmt.Sprintf("Pull requests %s require an associated issue.<br>Pull request authors %s implicitly approve their own PRs.<br>The /lgtm [cancel] command(s) %s act as approval.<br>A GitHub approved or changes requested review %s act as approval or cancel respectively.", doNot(opts.IssueRequired), doNot(opts.HasSelfApproval()), willNot(opts.LgtmActsAsApprove), willNot(opts.ConsiderReviewState()))
 	}
-	return &pluginhelp.PluginHelp{Config: approveConfig}, nil
+	return approveConfig, nil
 }
 
 func handleGenericCommentEvent(_ []string, pc plugins.Agent, ce scmprovider.GenericCommentEvent) error {

--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -1926,7 +1926,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := helpProvider(c.config, c.enabledRepos)
+			_, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}

--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -39,8 +39,7 @@ var (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no user is specified the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
-		HelpProvider: helpProvider,
+		Description: "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no user is specified the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -63,11 +62,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/blockade/blockade.go
+++ b/pkg/plugins/blockade/blockade.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/sirupsen/logrus"
 )
@@ -61,13 +60,13 @@ func init() {
 		PluginName,
 		plugins.Plugin{
 			Description:        "The blockade plugin blocks pull requests from merging if they touch specific files. The plugin applies the '" + labels.BlockedPaths + "' label to pull requests that touch files that match a blockade's block regular expression and none of the corresponding exception regular expressions.",
-			HelpProvider:       helpProvider,
+			ConfigHelpProvider: configHelp,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin cannot be triggered manually.
 	blockConfig := map[string]string{}
 	for _, repo := range enabledRepos {
@@ -85,7 +84,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		blockConfig[repo] = buf.String()
 	}
-	return &pluginhelp.PluginHelp{Config: blockConfig}, nil
+	return blockConfig, nil
 }
 
 type blockCalc func([]*scm.Change, []blockade) summary

--- a/pkg/plugins/blockade/blockade_test.go
+++ b/pkg/plugins/blockade/blockade_test.go
@@ -396,7 +396,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := helpProvider(c.config, c.enabledRepos)
+			_, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}

--- a/pkg/plugins/branchcleaner/branchcleaner.go
+++ b/pkg/plugins/branchcleaner/branchcleaner.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
@@ -35,14 +34,9 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The branchcleaner plugin automatically deletes source branches for merged PRs between two branches on the same repository. This is helpful to keep repos that don't allow forking clean.",
-			HelpProvider:       helpProvider,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 func handlePullRequest(pc plugins.Agent, pre scm.PullRequestHook) error {

--- a/pkg/plugins/cat/cat.go
+++ b/pkg/plugins/cat/cat.go
@@ -51,8 +51,8 @@ const (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
-		HelpProvider: helpProvider,
+		Description:        "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
+		ConfigHelpProvider: configHelp,
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -72,11 +72,9 @@ func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{
-			Config: map[string]string{
-				"": fmt.Sprintf("The cat plugin uses an api key for thecatapi.com stored in %s.", config.Cat.KeyPath),
-			},
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
+	return map[string]string{
+			"": fmt.Sprintf("The cat plugin uses an api key for thecatapi.com stored in %s.", config.Cat.KeyPath),
 		},
 		nil
 }

--- a/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/pkg/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
@@ -42,25 +41,21 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "Label PRs against a release branch which do not have the `cherry-pick-approved` label with the `do-not-merge/cherry-pick-not-approved` label.",
-			HelpProvider:       helpProvider,
+			ConfigHelpProvider: configHelp,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// Only the 'Config' and Description' fields are necessary because this
-	// plugin does not react to any commands.
-	pluginHelp := &pluginhelp.PluginHelp{
-		Config: map[string]string{
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
+	return map[string]string{
 			"": fmt.Sprintf(
 				"The cherry-pick-unapproved plugin treats PRs against branch names satisfying the regular expression `%s` as cherry-pick PRs and adds the following comment:\n%s",
 				config.CherryPickUnapproved.BranchRegexp,
 				config.CherryPickUnapproved.Comment,
 			),
 		},
-	}
-	return pluginHelp, nil
+		nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/dog/dog.go
+++ b/pkg/plugins/dog/dog.go
@@ -51,8 +51,7 @@ const (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
-		HelpProvider: helpProvider,
+		Description: "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -69,11 +68,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/help/help.go
+++ b/pkg/plugins/help/help.go
@@ -58,8 +58,7 @@ by commenting with the ` + "`/remove-good-first-issue`" + ` command.
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The help plugin provides commands that add or remove the '" + labels.Help + "' and the '" + labels.GoodFirstIssue + "' labels from issues.",
-		HelpProvider: helpProvider,
+		Description: "The help plugin provides commands that add or remove the '" + labels.Help + "' and the '" + labels.GoodFirstIssue + "' labels from issues.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter: func(e scmprovider.GenericCommentEvent) bool {
@@ -78,11 +77,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -46,8 +46,7 @@ type hasLabelFunc func(label string, issueLabels []*scm.Label) bool
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
-		HelpProvider: helpProvider,
+		Description: "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -64,11 +63,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -42,8 +42,8 @@ var (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
-		HelpProvider: helpProvider,
+		Description:        "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'committee/*', 'kind/*', 'language/*', 'priority/*', 'sig/*', 'triage/*', and 'wg/*'. More labels can be configured to be used via the /label command.",
+		ConfigHelpProvider: configHelp,
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Help: []pluginhelp.Command{{
@@ -69,16 +69,14 @@ func configString(labels []string) string {
 	return fmt.Sprintf("The label plugin will work on %s and %s labels.", strings.Join(formattedLabels[:len(formattedLabels)-1], ", "), formattedLabels[len(formattedLabels)-1])
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	labels := []string{}
 	labels = append(labels, defaultLabels...)
 	labels = append(labels, config.Label.AdditionalLabels...)
-	pluginHelp := &pluginhelp.PluginHelp{
-		Config: map[string]string{
+	return map[string]string{
 			"": configString(labels),
 		},
-	}
-	return pluginHelp, nil
+		nil
 }
 
 func handleGenericComment(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -559,12 +559,12 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			pluginHelp, err := helpProvider(c.config, c.enabledRepos)
+			pluginHelp, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}
 			for _, msg := range c.configInfoIncludes {
-				if !strings.Contains(pluginHelp.Config[""], msg) {
+				if !strings.Contains(pluginHelp[""], msg) {
 					t.Fatalf("helpProvider.Config error mismatch: didn't get %v, but wanted it", msg)
 				}
 			}

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -59,8 +59,8 @@ type commentPruner interface {
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
-		HelpProvider: helpProvider,
+		Description:        "The lgtm plugin manages the application and removal of the 'lgtm' (Looks Good To Me) label which is typically used to gate merging.",
+		ConfigHelpProvider: configHelp,
 		PullRequestHandler: func(pc plugins.Agent, pe scm.PullRequestHook) error {
 			return handlePullRequestEvent(pc, pe)
 		},
@@ -86,7 +86,7 @@ func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	configInfo := map[string]string{}
 	for _, orgRepo := range enabledRepos {
 		parts := strings.Split(orgRepo, "/")
@@ -119,8 +119,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			configInfo[orgRepo] = strings.Join(configInfoStrings, "\n")
 		}
 	}
-	pluginHelp := &pluginhelp.PluginHelp{Config: configInfo}
-	return pluginHelp, nil
+	return configInfo, nil
 }
 
 // optionsForRepo gets the plugins.Lgtm struct that is applicable to the indicated repo.

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -1229,17 +1229,17 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			pluginHelp, err := helpProvider(c.config, c.enabledRepos)
+			pluginHelp, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}
 			for _, msg := range c.configInfoExcludes {
-				if strings.Contains(pluginHelp.Config["org2/repo"], msg) {
+				if strings.Contains(pluginHelp["org2/repo"], msg) {
 					t.Fatalf("helpProvider.Config error mismatch: got %v, but didn't want it", msg)
 				}
 			}
 			for _, msg := range c.configInfoIncludes {
-				if !strings.Contains(pluginHelp.Config["org2/repo"], msg) {
+				if !strings.Contains(pluginHelp["org2/repo"], msg) {
 					t.Fatalf("helpProvider.Config error mismatch: didn't get %v, but wanted it", msg)
 				}
 			}

--- a/pkg/plugins/lifecycle/lifecycle.go
+++ b/pkg/plugins/lifecycle/lifecycle.go
@@ -37,8 +37,7 @@ const pluginName = "lifecycle"
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
-		HelpProvider: help,
+		Description: "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
 		Commands: []plugins.Command{{
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
 			GenericCommentHandler: lifecycleHandleGenericComment,
@@ -67,10 +66,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type lifecycleClient interface {

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -46,8 +46,8 @@ var (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The milestonestatus plugin allows members of the milestone maintainers GitHub team to specify the 'status/*' label that should apply to a pull request.",
-		HelpProvider: helpProvider,
+		Description:        "The milestonestatus plugin allows members of the milestone maintainers GitHub team to specify the 'status/*' label that should apply to a pull request.",
+		ConfigHelpProvider: configHelp,
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -73,25 +73,19 @@ func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	msgForTeam := func(team plugins.Milestone) string {
 		return fmt.Sprintf(milestoneTeamMsg, team.MaintainersTeam, team.MaintainersID)
 	}
-
-	pluginHelp := &pluginhelp.PluginHelp{
-		Config: func() map[string]string {
-			configMap := make(map[string]string)
-			for _, repo := range enabledRepos {
-				team, exists := config.RepoMilestone[repo]
-				if exists {
-					configMap[repo] = msgForTeam(team)
-				}
-			}
-			configMap[""] = msgForTeam(config.RepoMilestone[""])
-			return configMap
-		}(),
+	configMap := make(map[string]string)
+	for _, repo := range enabledRepos {
+		team, exists := config.RepoMilestone[repo]
+		if exists {
+			configMap[repo] = msgForTeam(team)
+		}
 	}
-	return pluginHelp, nil
+	configMap[""] = msgForTeam(config.RepoMilestone[""])
+	return configMap, nil
 }
 
 func handleGenericComment(match []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -127,8 +127,7 @@ func (c client) presubmitForContext(org, repo, context string) *job.Presubmit {
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The override plugin allows repo admins to force a github status context to pass",
-		HelpProvider: helpProvider,
+		Description: "The override plugin allows repo admins to force a github status context to pass",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter: func(e scmprovider.GenericCommentEvent) bool {
@@ -147,10 +146,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 func handleGenericComment(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {

--- a/pkg/plugins/owners-label/owners-label.go
+++ b/pkg/plugins/owners-label/owners-label.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -36,14 +35,9 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes.",
-			HelpProvider:       helpProvider,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type ownersClient interface {

--- a/pkg/plugins/pony/pony.go
+++ b/pkg/plugins/pony/pony.go
@@ -57,8 +57,7 @@ var (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
-		HelpProvider: helpProvider,
+		Description: "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -75,11 +74,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 var client = http.Client{}

--- a/pkg/plugins/shrug/shrug.go
+++ b/pkg/plugins/shrug/shrug.go
@@ -50,8 +50,7 @@ type event struct {
 
 var (
 	plugin = plugins.Plugin{
-		Description:  labels.Shrug,
-		HelpProvider: helpProvider,
+		Description: labels.Shrug,
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
@@ -68,11 +67,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/sigmention/sigmention.go
+++ b/pkg/plugins/sigmention/sigmention.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
@@ -72,8 +71,8 @@ func init() {
 	plugins.RegisterPlugin(
 		pluginName,
 		plugins.Plugin{
-			Description:  description,
-			HelpProvider: helpProvider,
+			Description:        description,
+			ConfigHelpProvider: configHelp,
 			Commands: []plugins.Command{
 				sigmentionCommand,
 			},
@@ -81,11 +80,9 @@ func init() {
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{
-			Config: map[string]string{
-				"": fmt.Sprintf("Labels added by the plugin are triggered by mentions of GitHub teams matching the following regexp:\n%s", config.SigMention.Regexp),
-			},
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
+	return map[string]string{
+			"": fmt.Sprintf("Labels added by the plugin are triggered by mentions of GitHub teams matching the following regexp:\n%s", config.SigMention.Regexp),
 		},
 		nil
 }

--- a/pkg/plugins/size/size.go
+++ b/pkg/plugins/size/size.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/jenkins-x/lighthouse/pkg/genfiles"
 	"github.com/jenkins-x/lighthouse/pkg/gitattributes"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
@@ -49,17 +48,16 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions).",
-			HelpProvider:       helpProvider,
+			ConfigHelpProvider: configHelp,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	sizes := sizesOrDefault(config.Size)
-	return &pluginhelp.PluginHelp{
-			Config: map[string]string{
-				"": fmt.Sprintf(`The plugin has the following thresholds:<ul>
+	return map[string]string{
+			"": fmt.Sprintf(`The plugin has the following thresholds:<ul>
 <li>size/XS:  0-%d</li>
 <li>size/S:   %d-%d</li>
 <li>size/M:   %d-%d</li>
@@ -67,7 +65,6 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 <li>size/XL:  %d-%d</li>
 <li>size/XXL: %d+</li>
 </ul>`, sizes.S-1, sizes.S, sizes.M-1, sizes.M, sizes.L-1, sizes.L, sizes.Xl-1, sizes.Xl, sizes.Xxl-1, sizes.Xxl),
-			},
 		},
 		nil
 }

--- a/pkg/plugins/size/size_test.go
+++ b/pkg/plugins/size/size_test.go
@@ -670,7 +670,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := helpProvider(c.config, c.enabledRepos)
+			_, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}

--- a/pkg/plugins/skip/skip.go
+++ b/pkg/plugins/skip/skip.go
@@ -48,8 +48,7 @@ type scmProviderClient interface {
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
-		HelpProvider: helpProvider,
+		Description: "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
 		Commands: []plugins.Command{{
 			GenericCommentHandler: handleGenericComment,
 			Filter: func(e scmprovider.GenericCommentEvent) bool {
@@ -69,10 +68,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 func handleGenericComment(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {

--- a/pkg/plugins/stage/stage.go
+++ b/pkg/plugins/stage/stage.go
@@ -41,8 +41,7 @@ const pluginName = "stage"
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "Label the stage of an issue as alpha/beta/stable",
-		HelpProvider: help,
+		Description: "Label the stage of an issue as alpha/beta/stable",
 		Commands: []plugins.Command{{
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
 			Regex:                 stageRe,
@@ -60,11 +59,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type stageClient interface {

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -43,7 +43,7 @@ var (
 		Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
 <br>Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command.
 <br>The '/retest' command can be used to rerun jobs that have reported failure.`,
-		HelpProvider:       helpProvider,
+		ConfigHelpProvider: configHelp,
 		PullRequestHandler: handlePullRequest,
 		PushEventHandler:   handlePush,
 		Commands: []plugins.Command{{
@@ -78,7 +78,7 @@ func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	configInfo := map[string]string{}
 	for _, orgRepo := range enabledRepos {
 		parts := strings.Split(orgRepo, "/")
@@ -97,7 +97,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		}
 		configInfo[orgRepo] = fmt.Sprintf("The trusted GitHub organization for this repository is %q.", org)
 	}
-	return &pluginhelp.PluginHelp{Config: configInfo}, nil
+	return configInfo, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/trigger/trigger_test.go
+++ b/pkg/plugins/trigger/trigger_test.go
@@ -71,7 +71,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := helpProvider(c.config, c.enabledRepos)
+			_, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}

--- a/pkg/plugins/updateconfig/updateconfig.go
+++ b/pkg/plugins/updateconfig/updateconfig.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	config2 "github.com/jenkins-x/lighthouse/pkg/config"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	zglob "github.com/mattn/go-zglob"
@@ -54,13 +53,13 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The config-updater plugin automatically redeploys configuration and plugin configuration files when they change. The plugin watches for pull request merges that modify either of the config files and updates the cluster's configmap resources in response.",
-			HelpProvider:       helpProvider,
+			ConfigHelpProvider: configHelp,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	var configInfo map[string]string
 	if len(enabledRepos) == 1 {
 		msg := fmt.Sprintf(
@@ -72,7 +71,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		)
 		configInfo = map[string]string{"": msg}
 	}
-	return &pluginhelp.PluginHelp{Config: configInfo}, nil
+	return configInfo, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/welcome/welcome.go
+++ b/pkg/plugins/welcome/welcome.go
@@ -26,7 +26,6 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -49,13 +48,13 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The welcome plugin posts a welcoming message when it detects a user's first contribution to a repo.",
-			HelpProvider:       helpProvider,
+			ConfigHelpProvider: configHelp,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
 	welcomeConfig := map[string]string{}
 	for _, repo := range enabledRepos {
 		parts := strings.Split(repo, "/")
@@ -72,7 +71,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	}
 
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
-	return &pluginhelp.PluginHelp{Config: welcomeConfig}, nil
+	return welcomeConfig, nil
 }
 
 type scmProviderClient interface {

--- a/pkg/plugins/welcome/welcome_test.go
+++ b/pkg/plugins/welcome/welcome_test.go
@@ -365,7 +365,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := helpProvider(c.config, c.enabledRepos)
+			_, err := configHelp(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
 			}

--- a/pkg/plugins/wip/wip-label.go
+++ b/pkg/plugins/wip/wip-label.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
@@ -56,15 +55,9 @@ func init() {
 		pluginName,
 		plugins.Plugin{
 			Description:        "The wip (Work In Progress) plugin applies the '" + labels.WorkInProgress + "' Label to pull requests whose title starts with 'WIP' or are in the 'draft' stage, and removes it from pull requests when they remove the title prefix or become ready for review. The '" + labels.WorkInProgress + "' Label is typically used to block a pull request from merging while it is still in progress.",
-			HelpProvider:       helpProvider,
 			PullRequestHandler: handlePullRequest,
 		},
 	)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 // Strict subset of gitprovider.Client methods.

--- a/pkg/plugins/yuks/yuks.go
+++ b/pkg/plugins/yuks/yuks.go
@@ -44,8 +44,7 @@ const (
 
 var (
 	plugin = plugins.Plugin{
-		Description:  "The yuks plugin comments with jokes in response to the `/joke` command.",
-		HelpProvider: helpProvider,
+		Description: "The yuks plugin comments with jokes in response to the `/joke` command.",
 		Commands: []plugins.Command{{
 			Filter:                func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
 			Regex:                 match,
@@ -63,11 +62,6 @@ var (
 
 func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
-}
-
-func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
-	return &pluginhelp.PluginHelp{}, nil
 }
 
 type scmProviderClient interface {


### PR DESCRIPTION
This PR uses plugin definition to synthesize plugin help provider.

The plugin definition is enough to synthesize the plugin provider help, no need for an help provider anymore.