### PR TITLE
chore: make plugin name private in approve blockade and wip plugins

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -40,8 +40,7 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = "approve"
+	pluginName = "approve"
 
 	approveCommand  = "APPROVE"
 	cancelArgument  = "cancel"
@@ -120,7 +119,7 @@ var (
 )
 
 func init() {
-	plugins.RegisterPlugin(PluginName, plugin)
+	plugins.RegisterPlugin(pluginName, plugin)
 }
 
 func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {

--- a/pkg/plugins/blockade/blockade.go
+++ b/pkg/plugins/blockade/blockade.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
-	PluginName = "blockade"
+	pluginName = "blockade"
 )
 
 var blockedPathsBody = fmt.Sprintf("Adding label: `%s` because PR changes a protected file.", labels.BlockedPaths)
@@ -57,7 +56,7 @@ type pruneClient interface {
 
 func init() {
 	plugins.RegisterPlugin(
-		PluginName,
+		pluginName,
 		plugins.Plugin{
 			Description:        "The blockade plugin blocks pull requests from merging if they touch specific files. The plugin applies the '" + labels.BlockedPaths + "' label to pull requests that touch files that match a blockade's block regular expression and none of the corresponding exception regular expressions.",
 			ConfigHelpProvider: configHelp,

--- a/pkg/plugins/blockade/blockade_test.go
+++ b/pkg/plugins/blockade/blockade_test.go
@@ -150,7 +150,7 @@ func TestCalculateBlocks(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		blockades := compileApplicableBlockades("org", "repo", logrus.WithField("plugin", PluginName), tc.config)
+		blockades := compileApplicableBlockades("org", "repo", logrus.WithField("plugin", pluginName), tc.config)
 		sum := calculateBlocks(tc.changes, blockades)
 		if !reflect.DeepEqual(sum, tc.expectedSummary) {
 			t.Errorf("[%s] Expected summary: %#v, actual summary: %#v.", tc.name, tc.expectedSummary, sum)
@@ -325,7 +325,7 @@ func TestHandle(t *testing.T) {
 				Number: 1,
 			},
 		}
-		if err := handle(fakeSCMProviderClient, logrus.WithField("plugin", PluginName), tc.config, &fakePruner{}, calcF, pre); err != nil {
+		if err := handle(fakeSCMProviderClient, logrus.WithField("plugin", pluginName), tc.config, &fakePruner{}, calcF, pre); err != nil {
 			t.Errorf("[%s] Unexpected error from handle: %v.", tc.name, err)
 			continue
 		}

--- a/pkg/plugins/wip/wip-label.go
+++ b/pkg/plugins/wip/wip-label.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	// PluginName defines this plugin's registered name.
 	pluginName = "wip"
 )
 


### PR DESCRIPTION
This PR makes plugin name private in approve blockade and wip plugins.