### PR TITLE
refactor: sigmention plugin

### DIFF
--- a/pkg/plugins/dog/dog_test.go
+++ b/pkg/plugins/dog/dog_test.go
@@ -230,7 +230,7 @@ func TestHttpResponse(t *testing.T) {
 			Logger:            logrus.WithField("plugin", pluginName),
 		}
 		plugin := createPlugin(realPack(ts.URL))
-		err = plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 			return handler(match, agent, *e)
 		})
 		if err != nil {
@@ -357,7 +357,7 @@ func TestDogs(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(fakePack("http://127.0.0.1"))
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -496,7 +496,7 @@ func TestLabel(t *testing.T) {
 					},
 				},
 			}
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {

--- a/pkg/plugins/milestonestatus/milestonestatus_test.go
+++ b/pkg/plugins/milestonestatus/milestonestatus_test.go
@@ -152,7 +152,7 @@ func TestMilestoneStatus(t *testing.T) {
 					RepoMilestone: repoMilestone,
 				},
 			}
-			if err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			}); err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -429,7 +429,7 @@ func TestHandle(t *testing.T) {
 					},
 				},
 			}
-			err := plugin.InvokeCommandHandler(&event, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(&event, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, event)
 			})
 			switch {

--- a/pkg/plugins/pony/pony_test.go
+++ b/pkg/plugins/pony/pony_test.go
@@ -230,7 +230,7 @@ func TestHttpResponse(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(realHerd(ts.URL + testcase.path))
-			err = plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {
@@ -331,7 +331,7 @@ func TestPonies(t *testing.T) {
 			Logger:            logrus.WithField("plugin", pluginName),
 		}
 		plugin := createPlugin(fakeHerd("pone"))
-		err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 			return handler(match, agent, *e)
 		})
 		if err != nil {

--- a/pkg/plugins/shrug/shurg_test.go
+++ b/pkg/plugins/shrug/shurg_test.go
@@ -89,7 +89,7 @@ func TestShrugComment(t *testing.T) {
 		if tc.hasShrug {
 			fc.IssueLabelsAdded = []string{"org/repo#5:" + labels.Shrug}
 		}
-		if err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 			return handler(match, agent, *e)
 		}); err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)

--- a/pkg/plugins/stage/stage_test.go
+++ b/pkg/plugins/stage/stage_test.go
@@ -203,7 +203,7 @@ func TestStageLabels(t *testing.T) {
 				SCMProviderClient: &fakeClient.Client,
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			})
 			switch {

--- a/pkg/plugins/yuks/yuks_test.go
+++ b/pkg/plugins/yuks/yuks_test.go
@@ -73,7 +73,7 @@ func TestJokesMedium(t *testing.T) {
 		Logger:            logrus.WithField("plugin", pluginName),
 	}
 	plugin := createPlugin(realJoke(ts.URL))
-	if err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+	if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 		return handler(match, agent, *e)
 	}); err != nil {
 		t.Errorf("didn't expect error: %v", err)
@@ -174,7 +174,7 @@ func TestJokes(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(tc.joke)
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.GenericCommentHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
 				return handler(match, agent, *e)
 			})
 			if !tc.shouldError && err != nil {


### PR DESCRIPTION
This PR refactors the sigmention plugin.

The sigmention plugin does not follow the command concept, it catches all generic comment events and doesn't require matching a regex with a command like format.

To address this behavior i decoupled the `CommandEventHandler` and `GenericCommentEventHandler`. The former receives a regex match while the latter just receives the event and doesn't have an associated command help. 