### PR TITLE
refactor: refactor the plugin command system

### DIFF
--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -1493,7 +1493,7 @@ func TestHandleGenericComment(t *testing.T) {
 				Repos:             []string{test.commentEvent.Repo.Namespace},
 				LgtmActsAsApprove: test.lgtmActsAsApprove,
 			})
-			err := plugin.InvokeCommand(&test.commentEvent, func(match []string) error {
+			err := plugin.InvokeCommandHandler(&test.commentEvent, func(_ plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, _ plugins.CommandMatch) error {
 				return handleGenericComment(
 					logrus.WithField("plugin", "approve"),
 					fakeClient,

--- a/pkg/plugins/assign/assign_test.go
+++ b/pkg/plugins/assign/assign_test.go
@@ -420,15 +420,15 @@ func TestAssignAndReview(t *testing.T) {
 				Number: 5,
 			}
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(&e)
+			matches, err := cmd.FilterAndGetMatches(&e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handle(m[1] != "un", m[2], m[3], newAssignHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
+				if err := handle(m.Prefix != "un", m.Name, m.Arg, newAssignHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
 					t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
 				}
-				if err := handle(m[1] != "un", m[2], m[3], newReviewHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
+				if err := handle(m.Prefix != "un", m.Name, m.Arg, newReviewHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
 					t.Fatalf("For case %s, didn't expect error from handle: %v", tc.name, err)
 				}
 			}

--- a/pkg/plugins/cat/cat_test.go
+++ b/pkg/plugins/cat/cat_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 )
@@ -363,8 +364,8 @@ Available variants:
 		Number:     5,
 		IssueState: "open",
 	}
-	if err := plugin.InvokeCommand(e, func(match []string) error {
-		return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, &realClowder{url: ts.URL + "/?format=json"}, func() {})
+	if err := plugin.InvokeCommandHandler(e, func(_ plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
+		return handle(match.Name == "meowvie", match.Arg, fakeClient, logrus.WithField("plugin", pluginName), e, &realClowder{url: ts.URL + "/?format=json"}, func() {})
 	}); err != nil {
 		t.Errorf("didn't expect error: %v", err)
 		return
@@ -484,8 +485,8 @@ func TestCats(t *testing.T) {
 				IssueState: tc.state,
 				IsPR:       tc.pr,
 			}
-			err := plugin.InvokeCommand(e, func(match []string) error {
-				return handle(match, fakeClient, logrus.WithField("plugin", pluginName), e, fakeClowder("tubbs"), func() {})
+			err := plugin.InvokeCommandHandler(e, func(_ plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
+				return handle(match.Name == "meowvie", match.Arg, fakeClient, logrus.WithField("plugin", pluginName), e, fakeClowder("tubbs"), func() {})
 			})
 			if !tc.shouldError && err != nil {
 				t.Fatalf("%s: didn't expect error: %v", tc.name, err)

--- a/pkg/plugins/command.go
+++ b/pkg/plugins/command.go
@@ -1,0 +1,179 @@
+package plugins
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
+	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
+)
+
+// CommandArg defines a plugin command argument
+type CommandArg struct {
+	Usage    string
+	Pattern  string
+	Optional bool
+}
+
+// GetRegex returns the regex string corresponding to the definiition of a CommandArg
+func (a *CommandArg) GetRegex() string {
+	pattern := a.Pattern
+	if pattern == "" {
+		pattern = `[^\r\n]+`
+	}
+	re := `(?:[ \t]+(` + pattern + "))"
+	if a.Optional {
+		re += "?"
+	}
+	return re
+}
+
+// GetUsage returns the CommandArg usage
+func (a *CommandArg) GetUsage() string {
+	usage := a.Usage
+	if usage == "" {
+		usage = a.Pattern
+	}
+	if usage == "" {
+		usage = "anything"
+	}
+	if a.Optional {
+		return "[" + usage + "]"
+	}
+	return "<" + usage + ">"
+}
+
+// CommandMatch defines a plugin command match to be passed to the command handler
+type CommandMatch struct {
+	Prefix string
+	Name   string
+	Arg    string
+}
+
+// Command defines a plugin command sent through a comment
+type Command struct {
+	Prefix      string
+	Name        string
+	Arg         *CommandArg
+	Description string
+	Featured    bool
+	WhoCanUse   string
+	MaxMatches  int
+	Filter      func(e scmprovider.GenericCommentEvent) bool
+	Handler     CommandEventHandler
+	regex       *regexp.Regexp
+}
+
+// InvokeCommandHandler performs command checks (filter, then regex if any) the calls the handler with the match (if any)
+func (cmd Command) InvokeCommandHandler(ce *scmprovider.GenericCommentEvent, handler func(CommandEventHandler, *scmprovider.GenericCommentEvent, CommandMatch) error) error {
+	if cmd.Handler == nil || (cmd.Filter != nil && !cmd.Filter(*ce)) {
+		return nil
+	}
+	regex := cmd.GetRegex()
+	if regex != nil {
+		max := cmd.MaxMatches
+		if max == 0 {
+			max = -1
+		}
+		for _, m := range regex.FindAllStringSubmatch(ce.Body, max) {
+			if err := handler(cmd.Handler, ce, cmd.createMatch(m)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return errors.New("command must have a regexp configured")
+}
+
+// GetRegex creates the regular expression from a command syntax
+func (cmd *Command) GetRegex() *regexp.Regexp {
+	if cmd.regex != nil {
+		return cmd.regex
+	}
+	re := "(?mi)^/(?:lh-)?"
+	if cmd.Prefix != "" {
+		re += "(" + cmd.Prefix + ")?"
+	}
+	re += "(" + cmd.Name + ")"
+	if cmd.Arg != nil {
+		re += cmd.Arg.GetRegex()
+	}
+	re += `\s*$`
+	cmd.regex = regexp.MustCompile(re)
+	return cmd.regex
+}
+
+// GetMatches returns command matches
+func (cmd Command) GetMatches(content string) ([]CommandMatch, error) {
+	regex := cmd.GetRegex()
+	if regex != nil {
+		max := cmd.MaxMatches
+		if max == 0 {
+			max = -1
+		}
+		var matches []CommandMatch
+		for _, match := range regex.FindAllStringSubmatch(content, max) {
+			matches = append(matches, cmd.createMatch(match))
+		}
+		return matches, nil
+	}
+	return nil, errors.New("regex cannot be nil")
+}
+
+// FilterAndGetMatches filters the event and returns command matches
+func (cmd Command) FilterAndGetMatches(event *scmprovider.GenericCommentEvent) ([]CommandMatch, error) {
+	if cmd.Handler == nil || (cmd.Filter != nil && !cmd.Filter(*event)) {
+		return nil, nil
+	}
+	return cmd.GetMatches(event.Body)
+}
+
+// GetHelp returns command help
+func (cmd Command) GetHelp() pluginhelp.Command {
+	var examples []string
+	for _, name := range strings.Split(cmd.Name, "|") {
+		examples = append(examples, "/"+name, "/lh-"+name)
+	}
+	usage := "/[lh-]"
+	if cmd.Prefix != "" {
+		usage += "[" + cmd.Prefix + "]"
+		for _, name := range strings.Split(cmd.Name, "|") {
+			examples = append(examples, "/"+cmd.Prefix+name, "/lh-"+cmd.Prefix+name)
+		}
+	}
+	usage += cmd.Name
+	if cmd.Arg != nil {
+		usage += " " + cmd.Arg.GetUsage()
+		// TODO examples
+	}
+	who := "Anyone"
+	if cmd.WhoCanUse != "" {
+		who = cmd.WhoCanUse
+	}
+	return pluginhelp.Command{
+		Usage:       usage,
+		Featured:    cmd.Featured,
+		Description: cmd.Description,
+		Examples:    examples,
+		WhoCanUse:   who,
+	}
+}
+
+// CreateMatch creates a match from an array of strings
+func (cmd Command) createMatch(matches []string) CommandMatch {
+	match := CommandMatch{}
+	if cmd.Prefix != "" {
+		match.Prefix = matches[1]
+		match.Name = matches[2]
+		if cmd.Arg != nil {
+			match.Arg = matches[3]
+		}
+	} else {
+		match.Name = matches[1]
+		if cmd.Arg != nil {
+			match.Arg = matches[2]
+		}
+	}
+	return match
+}

--- a/pkg/plugins/command_test.go
+++ b/pkg/plugins/command_test.go
@@ -1,0 +1,671 @@
+package plugins_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
+	"github.com/jenkins-x/lighthouse/pkg/plugins"
+)
+
+func TestCommandArgGetRegex(t *testing.T) {
+	cases := []struct {
+		name       string
+		commandArg plugins.CommandArg
+		expected   string
+	}{
+		{
+			name: "optional",
+			commandArg: plugins.CommandArg{
+				Pattern:  "foo|bar",
+				Optional: true,
+			},
+			expected: `(?:[ \t]+(foo|bar))?`,
+		},
+		{
+			name: "not optional",
+			commandArg: plugins.CommandArg{
+				Pattern: "foo|bar",
+			},
+			expected: `(?:[ \t]+(foo|bar))`,
+		},
+		{
+			name: "no pattern means everything",
+			commandArg: plugins.CommandArg{
+				Optional: true,
+			},
+			expected: `(?:[ \t]+([^\r\n]+))?`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.commandArg.GetRegex()
+			if actual != tc.expected {
+				t.Errorf("actual regex does not match expected %s != expected %s", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCommandArgGetUsage(t *testing.T) {
+	cases := []struct {
+		name       string
+		commandArg plugins.CommandArg
+		expected   string
+	}{
+		{
+			name: "optional with no usage",
+			commandArg: plugins.CommandArg{
+				Pattern:  "foo|bar",
+				Optional: true,
+			},
+			expected: "[foo|bar]",
+		},
+		{
+			name: "not optional with no usage",
+			commandArg: plugins.CommandArg{
+				Pattern: "foo|bar",
+			},
+			expected: "<foo|bar>",
+		},
+		{
+			name: "optional no pattern",
+			commandArg: plugins.CommandArg{
+				Optional: true,
+			},
+			expected: "[anything]",
+		},
+		{
+			name:       "not optional no pattern",
+			commandArg: plugins.CommandArg{},
+			expected:   "<anything>",
+		},
+		{
+			name: "optional with usage",
+			commandArg: plugins.CommandArg{
+				Pattern:  "foo|bar",
+				Usage:    "option_name",
+				Optional: true,
+			},
+			expected: "[option_name]",
+		},
+		{
+			name: "not optional with usage",
+			commandArg: plugins.CommandArg{
+				Pattern: "foo|bar",
+				Usage:   "option_name",
+			},
+			expected: "<option_name>",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.commandArg.GetUsage()
+			if actual != tc.expected {
+				t.Errorf("actual usage does not match expected %s != expected %s", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCommandGetRegex(t *testing.T) {
+	cases := []struct {
+		name     string
+		command  plugins.Command
+		expected string
+	}{
+		{
+			name: "no prefix and no arg",
+			command: plugins.Command{
+				Name: "test",
+			},
+			expected: `(?mi)^/(?:lh-)?(test)\s*$`,
+		},
+		{
+			name: "prefix and no arg",
+			command: plugins.Command{
+				Prefix: "prefix",
+				Name:   "test",
+			},
+			expected: `(?mi)^/(?:lh-)?(prefix)?(test)\s*$`,
+		},
+		{
+			name: "prefix and optional arg",
+			command: plugins.Command{
+				Prefix: "prefix",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern:  "foo|bar",
+					Optional: true,
+				},
+			},
+			expected: `(?mi)^/(?:lh-)?(prefix)?(test)(?:[ \t]+(foo|bar))?\s*$`,
+		},
+		{
+			name: "prefix and arg",
+			command: plugins.Command{
+				Prefix: "prefix",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+			},
+			expected: `(?mi)^/(?:lh-)?(prefix)?(test)(?:[ \t]+(foo|bar))\s*$`,
+		},
+		{
+			name: "no prefix and optional arg",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern:  "foo|bar",
+					Optional: true,
+				},
+			},
+			expected: `(?mi)^/(?:lh-)?(test)(?:[ \t]+(foo|bar))?\s*$`,
+		},
+		{
+			name: "no prefix and arg",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+			},
+			expected: `(?mi)^/(?:lh-)?(test)(?:[ \t]+(foo|bar))\s*$`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.command.GetRegex()
+			if actual == nil {
+				t.Errorf("actual regex is nil")
+			} else {
+				if actual.String() != tc.expected {
+					t.Errorf("actual usage does not match expected %s != expected %s", actual, tc.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandGetRegexCached(t *testing.T) {
+	command := plugins.Command{
+		Prefix: "prefix",
+		Name:   "test",
+		Arg: &plugins.CommandArg{
+			Pattern: "foo|bar",
+		},
+	}
+	re1 := command.GetRegex()
+	re2 := command.GetRegex()
+	if re1 != re2 {
+		t.Errorf("command regex should have been cached")
+	}
+}
+
+func TestCommandGetMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		command  plugins.Command
+		content  string
+		expected []plugins.CommandMatch
+	}{
+		{
+			name: "no prefix and no arg, content match",
+			command: plugins.Command{
+				Name: "test",
+			},
+			content: "/test",
+			expected: []plugins.CommandMatch{{
+				Name: "test",
+			}},
+		},
+		{
+			name: "no prefix and no arg, content not match arg",
+			command: plugins.Command{
+				Name: "test",
+			},
+			content: "/test test",
+		},
+		{
+			name: "no prefix and no arg, content not match prefix",
+			command: plugins.Command{
+				Name: "test",
+			},
+			content: "/re-test",
+		},
+		{
+			name: "no prefix and no arg, content not match command",
+			command: plugins.Command{
+				Name: "test",
+			},
+			content: "/build",
+		},
+		{
+			name: "prefix and no arg, content match",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+			},
+			content: "/prefix-test",
+			expected: []plugins.CommandMatch{{
+				Prefix: "prefix-",
+				Name:   "test",
+			}},
+		},
+		{
+			name: "prefix and no arg, content not match arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+			},
+			content: "/prefix-test test",
+		},
+		{
+			name: "prefix and no arg, content not match prefix",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+			},
+			content: "/wrong-test",
+		},
+		{
+			name: "prefix and no arg, content not match command",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+			},
+			content: "/build",
+		},
+		{
+			name: "no prefix and arg, content match",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+			},
+			content: "/test foo",
+			expected: []plugins.CommandMatch{{
+				Name: "test",
+				Arg:  "foo",
+			}},
+		},
+		{
+			name: "no prefix and arg, content not match arg",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/test bar",
+		},
+		{
+			name: "no prefix and arg, content not match prefix",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/wrong-test foo",
+		},
+		{
+			name: "no prefix and arg, content not match command",
+			command: plugins.Command{
+				Name: "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/build foo",
+		},
+		{
+			name: "prefix and arg, content match with prefix",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+			},
+			content: "/prefix-test foo",
+			expected: []plugins.CommandMatch{{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg:    "foo",
+			}},
+		},
+		{
+			name: "prefix and arg, content match without prefix",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+			},
+			content: "/test foo",
+			expected: []plugins.CommandMatch{{
+				Name: "test",
+				Arg:  "foo",
+			}},
+		},
+		{
+			name: "prefix and arg, content match without arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern:  "foo|bar",
+					Optional: true,
+				},
+			},
+			content: "/test",
+			expected: []plugins.CommandMatch{{
+				Name: "test",
+			}},
+		},
+		{
+			name: "prefix and arg, content match with prefix and without arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern:  "foo|bar",
+					Optional: true,
+				},
+			},
+			content: "/prefix-test",
+			expected: []plugins.CommandMatch{{
+				Prefix: "prefix-",
+				Name:   "test",
+			}},
+		},
+		{
+			name: "prefix and arg, content not match arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/test bar",
+		},
+		{
+			name: "prefix and arg, content not match prefix",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/wrong-test foo",
+		},
+		{
+			name: "prefix and arg, content not match command",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo",
+				},
+			},
+			content: "/build foo",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := tc.command.GetMatches(tc.content)
+			if err != nil {
+				t.Errorf("an error has occured %w", err)
+			} else {
+				if !reflect.DeepEqual(tc.expected, matches) {
+					t.Errorf("expected matches %q, but got %q", tc.expected, matches)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandGetHelp(t *testing.T) {
+	cases := []struct {
+		name     string
+		command  plugins.Command
+		expected pluginhelp.Command
+	}{
+		{
+			name: "no prefix and no arg",
+			command: plugins.Command{
+				Name:        "test",
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-]test",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+				},
+			},
+		},
+		{
+			name: "prefix and no arg",
+			command: plugins.Command{
+				Prefix:      "prefix-",
+				Name:        "test",
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and optional arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern:  "foo|bar",
+					Optional: true,
+				},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test [foo|bar]",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and optional arg no pattern",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Optional: true,
+				},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test [anything]",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and optional arg with usage",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Usage:    "arg description",
+					Optional: true,
+				},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test [arg description]",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and arg",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test <foo|bar>",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and arg no pattern",
+			command: plugins.Command{
+				Prefix:      "prefix-",
+				Name:        "test",
+				Arg:         &plugins.CommandArg{},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test <anything>",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "prefix and arg with usage",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Usage: "arg description",
+				},
+				Description: "Some command description",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test <arg description>",
+				Featured:    false,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "featured",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+				Description: "Some command description",
+				Featured:    true,
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test <foo|bar>",
+				Featured:    true,
+				Description: "Some command description",
+				WhoCanUse:   "Anyone",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+		{
+			name: "who can use",
+			command: plugins.Command{
+				Prefix: "prefix-",
+				Name:   "test",
+				Arg: &plugins.CommandArg{
+					Pattern: "foo|bar",
+				},
+				Description: "Some command description",
+				WhoCanUse:   "only admins",
+			},
+			expected: pluginhelp.Command{
+				Usage:       "/[lh-][prefix-]test <foo|bar>",
+				Description: "Some command description",
+				WhoCanUse:   "only admins",
+				Examples: []string{
+					"/test",
+					"/lh-test",
+					"/prefix-test",
+					"/lh-prefix-test",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			help := tc.command.GetHelp()
+			if !reflect.DeepEqual(tc.expected, help) {
+				t.Errorf("expected help %v, but got %v", tc.expected, help)
+			}
+		})
+	}
+}

--- a/pkg/plugins/dog/dog.go
+++ b/pkg/plugins/dog/dog.go
@@ -29,16 +29,11 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
 var (
-	match           = regexp.MustCompile(`(?mi)^/(?:lh-)?(woof|bark)\s*$`)
-	fineRegex       = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-fine\s*$`)
-	notFineRegex    = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-not-fine\s*$`)
-	unbearableRegex = regexp.MustCompile(`(?mi)^/(?:lh-)?this-is-unbearable\s*$`)
-	filetypes       = regexp.MustCompile(`(?i)\.(jpg|gif|png)$`)
+	filetypes = regexp.MustCompile(`(?i)\.(jpg|gif|png)$`)
 )
 
 const (
@@ -53,57 +48,33 @@ func createPlugin(p pack) plugins.Plugin {
 	return plugins.Plugin{
 		Description: "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",
 		Commands: []plugins.Command{{
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  match,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "woof|bark",
+			Description: "Add a dog image to the issue or PR",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return handle(pc.SCMProviderClient, pc.Logger, &e, p)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/(lh-)?(woof|bark)",
-				Description: "Add a dog image to the issue or PR",
-				Featured:    false,
-				WhoCanUse:   "Anyone",
-				Examples:    []string{"/woof", "/bark"},
-			}},
 		}, {
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  fineRegex,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "this-is-fine",
+			Description: "Add a dog image to the issue or PR",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return formatURLAndSendResponse(pc.SCMProviderClient, &e, fineURL)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/(lh-)?this-is-fine",
-				Description: "Add a dog image to the issue or PR",
-				Featured:    false,
-				WhoCanUse:   "Anyone",
-				Examples:    []string{"/this-is-fine", "/lh-this-is-fine"},
-			}},
 		}, {
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  notFineRegex,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "this-is-not-fine",
+			Description: "Add a dog image to the issue or PR",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return formatURLAndSendResponse(pc.SCMProviderClient, &e, notFineURL)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/(lh-)?this-is-not-fine",
-				Description: "Add a dog image to the issue or PR",
-				Featured:    false,
-				WhoCanUse:   "Anyone",
-				Examples:    []string{"/this-is-not-fine", "/lh-this-is-not-fine"},
-			}},
 		}, {
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  unbearableRegex,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "this-is-unbearable",
+			Description: "Add a dog image to the issue or PR",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return formatURLAndSendResponse(pc.SCMProviderClient, &e, unbearableURL)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/(lh-)?this-is-unbearable",
-				Description: "Add a dog image to the issue or PR",
-				Featured:    false,
-				WhoCanUse:   "Anyone",
-				Examples:    []string{"/this-is-unbearable", "/lh-this-is-unbearable"},
-			}},
 		}},
 	}
 }

--- a/pkg/plugins/dog/dog_test.go
+++ b/pkg/plugins/dog/dog_test.go
@@ -230,7 +230,7 @@ func TestHttpResponse(t *testing.T) {
 			Logger:            logrus.WithField("plugin", pluginName),
 		}
 		plugin := createPlugin(realPack(ts.URL))
-		err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 			return handler(match, agent, *e)
 		})
 		if err != nil {
@@ -357,7 +357,7 @@ func TestDogs(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(fakePack("http://127.0.0.1"))
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {

--- a/pkg/plugins/help/help_test.go
+++ b/pkg/plugins/help/help_test.go
@@ -216,12 +216,12 @@ func TestLabel(t *testing.T) {
 				Author:     scm.User{Login: "Alice"},
 			}
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handle(m[1], &fakeSCMProviderClient.Client, logrus.WithField("plugin", pluginName), &fakePruner{}, e); err != nil {
+				if err := handle(m.Prefix != "", m.Name, &fakeSCMProviderClient.Client, logrus.WithField("plugin", pluginName), &fakePruner{}, e); err != nil {
 					t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				}
 			}

--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -22,23 +22,17 @@ package hold
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
 const (
 	pluginName = "hold"
-)
-
-var (
-	match = regexp.MustCompile(`(?mi)^/(?:lh-)?hold(?:\s+(cancel))?\s*$`)
 )
 
 type hasLabelFunc func(label string, issueLabels []*scm.Label) bool
@@ -47,18 +41,16 @@ var (
 	plugin = plugins.Plugin{
 		Description: "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
 		Commands: []plugins.Command{{
-			GenericCommentHandler: func(match []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
-				return handleGenericComment(match[1] == "cancel", pc, e)
+			Name:        "hold",
+			Description: "Adds or removes the `" + labels.Hold + "` Label which is used to indicate that the PR should not be automatically merged.",
+			Arg: &plugins.CommandArg{
+				Pattern:  "cancel",
+				Optional: true,
+			},
+			Handler: func(match plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+				return handleGenericComment(match.Arg == "cancel", pc, e)
 			},
 			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  match,
-			Help: []pluginhelp.Command{{
-				Usage:       "/hold [cancel]",
-				Description: "Adds or removes the `" + labels.Hold + "` Label which is used to indicate that the PR should not be automatically merged.",
-				Featured:    false,
-				WhoCanUse:   "Anyone can use the /hold command to add or remove the '" + labels.Hold + "' Label.",
-				Examples:    []string{"/hold", "/hold cancel"},
-			}},
 		}},
 	}
 )

--- a/pkg/plugins/hold/hold_test.go
+++ b/pkg/plugins/hold/hold_test.go
@@ -101,12 +101,12 @@ func TestHandle(t *testing.T) {
 				return tc.hasLabel
 			}
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handle(m[1] == "cancel", scmprovider.ToTestClient(client), logrus.WithField("plugin", pluginName), e, hasLabel); err != nil {
+				if err := handle(m.Arg == "cancel", scmprovider.ToTestClient(client), logrus.WithField("plugin", pluginName), e, hasLabel); err != nil {
 					t.Fatalf("For case %s, didn't expect error from hold: %v", tc.name, err)
 				}
 			}

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -496,7 +496,7 @@ func TestLabel(t *testing.T) {
 					},
 				},
 			}
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -349,12 +349,12 @@ func TestLGTMComment(t *testing.T) {
 				PullRequestComments: fc.PullRequestComments[5],
 			}
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handleGenericComment(m[1] == "cancel", fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
+				if err := handleGenericComment(m.Arg == "cancel", fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
 					t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				}
 			}
@@ -517,12 +517,12 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 			PullRequestComments: fc.PullRequestComments[5],
 		}
 		cmd := plugin.Commands[0]
-		matches, err := cmd.GetMatches(e)
+		matches, err := cmd.FilterAndGetMatches(e)
 		if err != nil {
 			t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 		}
 		for _, m := range matches {
-			if err := handleGenericComment(m[1] == "cancel", fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
+			if err := handleGenericComment(m.Arg == "cancel", fakeClient, pc, oc, logrus.WithField("plugin", pluginName), fp, *e); err != nil {
 				t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 				continue
 			}

--- a/pkg/plugins/lifecycle/close_test.go
+++ b/pkg/plugins/lifecycle/close_test.go
@@ -195,7 +195,7 @@ func TestCloseComment(t *testing.T) {
 				IssueAuthor: scm.User{Login: "author"},
 			}
 			cmd := plugin.Commands[1]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}

--- a/pkg/plugins/lifecycle/lifecycle_test.go
+++ b/pkg/plugins/lifecycle/lifecycle_test.go
@@ -232,12 +232,12 @@ func TestAddLifecycleLabels(t *testing.T) {
 				Action: scm.ActionCreate,
 			}
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handleOne(m[1] != "", "lifecycle/"+m[2], fc, logrus.WithField("plugin", pluginName), e); err != nil {
+				if err := handleOne(m.Prefix != "", "lifecycle/"+m.Arg, fc, logrus.WithField("plugin", pluginName), e); err != nil {
 					t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				}
 			}

--- a/pkg/plugins/lifecycle/reopen.go
+++ b/pkg/plugins/lifecycle/reopen.go
@@ -99,6 +99,7 @@ func handleReopen(spc scmProviderClient, log *logrus.Entry, e *scmprovider.Gener
 		}
 		return err
 	}
+
 	// Add a comment after reopening the issue to leave an audit trail of who
 	// asked to reopen it.
 	return spc.CreateComment(

--- a/pkg/plugins/lifecycle/reopen_test.go
+++ b/pkg/plugins/lifecycle/reopen_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lifecycle
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -150,10 +151,11 @@ func TestReopenComment(t *testing.T) {
 				IssueAuthor: scm.User{Login: "author"},
 			}
 			cmd := plugin.Commands[2]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
+			fmt.Println(matches)
 			for range matches {
 				if err := handleReopen(fc, logrus.WithField("plugin", pluginName), e); err != nil {
 					t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)

--- a/pkg/plugins/milestone/milestone_test.go
+++ b/pkg/plugins/milestone/milestone_test.go
@@ -146,12 +146,12 @@ func TestMilestoneStatus(t *testing.T) {
 			}
 
 			cmd := plugin.Commands[0]
-			matches, err := cmd.GetMatches(e)
+			matches, err := cmd.FilterAndGetMatches(e)
 			if err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 			}
 			for _, m := range matches {
-				if err := handle(m[1], fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {
+				if err := handle(m.Arg, fakeClient, logrus.WithField("plugin", pluginName), e, repoMilestone); err != nil {
 					t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)
 				}
 			}

--- a/pkg/plugins/milestonestatus/milestonestatus_test.go
+++ b/pkg/plugins/milestonestatus/milestonestatus_test.go
@@ -152,7 +152,7 @@ func TestMilestoneStatus(t *testing.T) {
 					RepoMilestone: repoMilestone,
 				},
 			}
-			if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			}); err != nil {
 				t.Fatalf("(%s): Unexpected error from handle: %v.", tc.name, err)

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -429,7 +429,7 @@ func TestHandle(t *testing.T) {
 					},
 				},
 			}
-			err := plugin.InvokeCommandHandler(&event, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(&event, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, event)
 			})
 			switch {

--- a/pkg/plugins/pony/pony.go
+++ b/pkg/plugins/pony/pony.go
@@ -23,10 +23,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
@@ -51,26 +49,20 @@ const (
 	pluginName = "pony"
 )
 
-var (
-	match = regexp.MustCompile(`(?mi)^/(?:lh-)?pony(?: +(.+))?\s*$`)
-)
-
 func createPlugin(h herd) plugins.Plugin {
 	return plugins.Plugin{
 		Description: "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",
 		Commands: []plugins.Command{{
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  match,
-			GenericCommentHandler: func(match []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
-				return handle(match[1], pc.SCMProviderClient, pc.Logger, &e, h)
+			Name: "pony",
+			Arg: &plugins.CommandArg{
+				Pattern:  ".+",
+				Optional: true,
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/pony [pony]",
-				Description: "Add a little pony image to the issue or PR. A particular pony can optionally be named for a picture of that specific pony.",
-				Featured:    false,
-				WhoCanUse:   "Anyone",
-				Examples:    []string{"/pony", "/pony Twilight Sparkle", "/lh-pony"},
-			}},
+			Description: "Add a little pony image to the issue or PR. A particular pony can optionally be named for a picture of that specific pony.",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(match plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+				return handle(match.Arg, pc.SCMProviderClient, pc.Logger, &e, h)
+			},
 		}},
 	}
 }

--- a/pkg/plugins/pony/pony_test.go
+++ b/pkg/plugins/pony/pony_test.go
@@ -230,7 +230,7 @@ func TestHttpResponse(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(realHerd(ts.URL + testcase.path))
-			err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err = plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			})
 			if err != nil {
@@ -331,7 +331,7 @@ func TestPonies(t *testing.T) {
 			Logger:            logrus.WithField("plugin", pluginName),
 		}
 		plugin := createPlugin(fakeHerd("pone"))
-		err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 			return handler(match, agent, *e)
 		})
 		if err != nil {

--- a/pkg/plugins/shrug/shrug.go
+++ b/pkg/plugins/shrug/shrug.go
@@ -18,65 +18,34 @@ package shrug
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/labels"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
 const pluginName = "shrug"
 
 var (
-	shrugRe   = regexp.MustCompile(`(?mi)^/(?:lh-)?shrug\s*$`)
-	unshrugRe = regexp.MustCompile(`(?mi)^/(?:lh-)?unshrug\s*$`)
-)
-
-type event struct {
-	org           string
-	repo          string
-	number        int
-	prAuthor      string
-	commentAuthor string
-	body          string
-	assignees     []scm.User
-	hasLabel      func(label string) (bool, error)
-	htmlurl       string
-}
-
-var (
 	plugin = plugins.Plugin{
 		Description: labels.Shrug,
 		Commands: []plugins.Command{{
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  shrugRe,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "shrug",
+			Description: "Adds the " + labels.Shrug + " label",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return addLabel(pc.SCMProviderClient, pc.Logger, &e)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/shrug",
-				Description: "Adds the " + labels.Shrug + " label",
-				Featured:    false,
-				WhoCanUse:   "Anyone, " + labels.Shrug,
-				Examples:    []string{"/shrug", "/lh-shrug"},
-			}},
 		}, {
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  unshrugRe,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "unshrug",
+			Description: "Removes the " + labels.Shrug + " label",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return removeLabel(pc.SCMProviderClient, pc.Logger, &e)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/unshrug",
-				Description: "Removes the " + labels.Shrug + " label",
-				Featured:    false,
-				WhoCanUse:   "Anyone, " + labels.Shrug,
-				Examples:    []string{"/unshrug", "/lh-unshrug"},
-			}},
 		}},
 	}
 )

--- a/pkg/plugins/shrug/shrug_test.go
+++ b/pkg/plugins/shrug/shrug_test.go
@@ -89,7 +89,7 @@ func TestShrugComment(t *testing.T) {
 		if tc.hasShrug {
 			fc.IssueLabelsAdded = []string{"org/repo#5:" + labels.Shrug}
 		}
-		if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+		if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 			return handler(match, agent, *e)
 		}); err != nil {
 			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)

--- a/pkg/plugins/skip/skip.go
+++ b/pkg/plugins/skip/skip.go
@@ -20,11 +20,9 @@ package skip
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/config/job"
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/plugins/trigger"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
@@ -32,10 +30,6 @@ import (
 )
 
 const pluginName = "skip"
-
-var (
-	skipRe = regexp.MustCompile(`(?mi)^/(?:lh-)?skip\s*$`)
-)
 
 type scmProviderClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
@@ -50,18 +44,12 @@ var (
 	plugin = plugins.Plugin{
 		Description: "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
 		Commands: []plugins.Command{{
-			GenericCommentHandler: handleGenericComment,
+			Name:        "skip",
+			Description: "Cleans up GitHub stale commit statuses for non-blocking jobs on a PR.",
+			Handler:     handleGenericComment,
 			Filter: func(e scmprovider.GenericCommentEvent) bool {
 				return !(!e.IsPR || e.IssueState != "open" || e.Action != scm.ActionCreate)
 			},
-			Regex: skipRe,
-			Help: []pluginhelp.Command{{
-				Usage:       "/skip",
-				Description: "Cleans up GitHub stale commit statuses for non-blocking jobs on a PR.",
-				Featured:    false,
-				WhoCanUse:   "Anyone can trigger this command on a PR.",
-				Examples:    []string{"/skip", "/lh-skip"},
-			}},
 		}},
 	}
 )
@@ -70,7 +58,7 @@ func init() {
 	plugins.RegisterPlugin(pluginName, plugin)
 }
 
-func handleGenericComment(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+func handleGenericComment(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 	honorOkToTest := trigger.HonorOkToTest(pc.PluginConfig.TriggerFor(e.Repo.Namespace, e.Repo.Name))
 	return handle(pc.SCMProviderClient, pc.Logger, &e, pc.Config.GetPresubmits(e.Repo), honorOkToTest)
 }

--- a/pkg/plugins/stage/stage.go
+++ b/pkg/plugins/stage/stage.go
@@ -19,13 +19,10 @@ limitations under the License.
 package stage
 
 import (
-	"regexp"
-
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
@@ -34,8 +31,6 @@ var (
 	stageBeta   = "stage/beta"
 	stageStable = "stage/stable"
 	stageLabels = []string{stageAlpha, stageBeta, stageStable}
-	stageRe     = regexp.MustCompile(`(?mi)^/(?:lh-)?stage (alpha|beta|stable)\s*$`)
-	unstageRe   = regexp.MustCompile(`(?mi)^/(?:lh-)?remove-stage (alpha|beta|stable)\s*$`)
 )
 
 const pluginName = "stage"
@@ -44,31 +39,25 @@ var (
 	plugin = plugins.Plugin{
 		Description: "Label the stage of an issue as alpha/beta/stable",
 		Commands: []plugins.Command{{
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  stageRe,
-			GenericCommentHandler: func(match []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
-				return stage(pc.SCMProviderClient, pc.Logger, &e, match[1])
+			Name: "stage",
+			Arg: &plugins.CommandArg{
+				Pattern: "alpha|beta|stable",
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/stage <alpha|beta|stable>",
-				Description: "Labels the stage of an issue as alpha/beta/stable",
-				Featured:    false,
-				WhoCanUse:   "Anyone can trigger this command.",
-				Examples:    []string{"/stage alpha"},
-			}},
+			Description: "Labels the stage of an issue as alpha/beta/stable",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(match plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+				return stage(pc.SCMProviderClient, pc.Logger, &e, match.Arg)
+			},
 		}, {
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  unstageRe,
-			GenericCommentHandler: func(match []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
-				return unstage(pc.SCMProviderClient, pc.Logger, &e, match[1])
+			Name: "remove-stage",
+			Arg: &plugins.CommandArg{
+				Pattern: "alpha|beta|stable",
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/remove-stage <alpha|beta|stable>",
-				Description: "Removes the stage label of an issue as alpha/beta/stable",
-				Featured:    false,
-				WhoCanUse:   "Anyone can trigger this command.",
-				Examples:    []string{"/remove-stage alpha"},
-			}},
+			Description: "Removes the stage label of an issue as alpha/beta/stable",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(match plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+				return unstage(pc.SCMProviderClient, pc.Logger, &e, match.Arg)
+			},
 		}},
 	}
 )

--- a/pkg/plugins/stage/stage_test.go
+++ b/pkg/plugins/stage/stage_test.go
@@ -203,7 +203,7 @@ func TestStageLabels(t *testing.T) {
 				SCMProviderClient: &fakeClient.Client,
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			})
 			switch {

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -937,14 +937,14 @@ func TestHandleGenericComment(t *testing.T) {
 			// In some cases handleGenericComment can be called twice for the same event.
 			// For instance on Issue/PR creation and modification.
 			// Let's call it twice to ensure idempotency.
-			if err := plugin.InvokeCommand(&event, func(match []string) error {
-				return handleGenericComment(c, trigger, event)
+			if err := plugin.InvokeCommandHandler(&event, func(_ plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, _ plugins.CommandMatch) error {
+				return handleGenericComment(c, trigger, *e)
 			}); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}
 			validate(tc.name, fakeLauncher, g, tc, t)
-			if err := plugin.InvokeCommand(&event, func(match []string) error {
-				return handleGenericComment(c, trigger, event)
+			if err := plugin.InvokeCommandHandler(&event, func(_ plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, _ plugins.CommandMatch) error {
+				return handleGenericComment(c, trigger, *e)
 			}); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}

--- a/pkg/plugins/yuks/yuks.go
+++ b/pkg/plugins/yuks/yuks.go
@@ -27,12 +27,10 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 )
 
 var (
-	match  = regexp.MustCompile(`(?mi)^/(?:lh-)?joke\s*$`)
 	simple = regexp.MustCompile(`^[\w?'!., ]+$`)
 )
 
@@ -45,18 +43,12 @@ func createPlugin(j joker) plugins.Plugin {
 	return plugins.Plugin{
 		Description: "The yuks plugin comments with jokes in response to the `/joke` command.",
 		Commands: []plugins.Command{{
-			Filter: func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
-			Regex:  match,
-			GenericCommentHandler: func(_ []string, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
+			Name:        "joke",
+			Description: "Tells a joke.",
+			Filter:      func(e scmprovider.GenericCommentEvent) bool { return e.Action == scm.ActionCreate },
+			Handler: func(_ plugins.CommandMatch, pc plugins.Agent, e scmprovider.GenericCommentEvent) error {
 				return joke(pc.SCMProviderClient, pc.Logger, &e, j)
 			},
-			Help: []pluginhelp.Command{{
-				Usage:       "/joke",
-				Description: "Tells a joke.",
-				Featured:    false,
-				WhoCanUse:   "Anyone can use the `/joke` command.",
-				Examples:    []string{"/joke", "/lh-joke"},
-			}},
 		}},
 	}
 }

--- a/pkg/plugins/yuks/yuks_test.go
+++ b/pkg/plugins/yuks/yuks_test.go
@@ -73,7 +73,7 @@ func TestJokesMedium(t *testing.T) {
 		Logger:            logrus.WithField("plugin", pluginName),
 	}
 	plugin := createPlugin(realJoke(ts.URL))
-	if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+	if err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 		return handler(match, agent, *e)
 	}); err != nil {
 		t.Errorf("didn't expect error: %v", err)
@@ -174,7 +174,7 @@ func TestJokes(t *testing.T) {
 				Logger:            logrus.WithField("plugin", pluginName),
 			}
 			plugin := createPlugin(tc.joke)
-			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match []string) error {
+			err := plugin.InvokeCommandHandler(e, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				return handler(match, agent, *e)
 			})
 			if !tc.shouldError && err != nil {

--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -118,9 +118,9 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *scmprovider.GenericCo
 			}(p, h.GenericCommentHandler)
 		}
 		for _, cmd := range h.Commands {
-			err := cmd.InvokeHandler(ce, func(match []string) error {
+			err := cmd.InvokeCommandHandler(ce, func(handler plugins.CommandEventHandler, e *scmprovider.GenericCommentEvent, match plugins.CommandMatch) error {
 				s.wg.Add(1)
-				go func(p string, h plugins.CommandEventHandler, m []string) {
+				go func(p string, h plugins.CommandEventHandler, m plugins.CommandMatch) {
 					defer s.wg.Done()
 					agent := plugins.NewAgent(s.ConfigAgent, s.Plugins, s.ClientAgent, s.ServerURL, l.WithField("plugin", p))
 					agent.InitializeCommentPruner(
@@ -131,7 +131,7 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *scmprovider.GenericCo
 					if err := h(m, agent, *ce); err != nil {
 						agent.Logger.WithError(err).Error("Error handling GenericCommentEvent.")
 					}
-				}(p, cmd.GenericCommentHandler, match)
+				}(p, handler, match)
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
This PR refactors the plugin command system.

It makes the command system non regex dependent. A command has the format `/[PREFIX]COMMAND [ARG]`, this is declared at the command level and is also used to generate the command usage and examples help.
The command description is also added to the command and is used to generate the command help.

I added unit tests for the `Command` struct.

I also clean up some obsolete code that was created at the start of refactoring and not used anymore.


I'll have to write a doc on how to write a plugin command.