### PR TITLE
feat: add scm providers exclusion support to plugins

### DIFF
--- a/pkg/pluginhelp/pluginhelp.go
+++ b/pkg/pluginhelp/pluginhelp.go
@@ -41,6 +41,8 @@ type PluginHelp struct {
 	// Description is a description of what the plugin does and what purpose it achieves.
 	// This field may include HTML.
 	Description string
+	// ExcludedProviders is the list of scm providers that are not supported by a plugin.
+	ExcludedProviders []string
 	// Config is a map from org/repo strings to a string describing the configuration for that repo.
 	// The key "" should map to a string describing configuration that applies to all repos if any.
 	// This configuration strings may include HTML.

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -1,0 +1,76 @@
+package plugins
+
+import (
+	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
+	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Plugin defines a plugin and its handlers
+type Plugin struct {
+	Description           string
+	ExcludedProviders     sets.String
+	ConfigHelpProvider    ConfigHelpProvider
+	IssueHandler          IssueHandler
+	PullRequestHandler    PullRequestHandler
+	PushEventHandler      PushEventHandler
+	ReviewEventHandler    ReviewEventHandler
+	StatusEventHandler    StatusEventHandler
+	GenericCommentHandler GenericCommentHandler
+	Commands              []Command
+}
+
+// InvokeCommandHandler calls InvokeHandler on all commands
+func (plugin Plugin) InvokeCommandHandler(ce *scmprovider.GenericCommentEvent, handler func(CommandEventHandler, *scmprovider.GenericCommentEvent, CommandMatch) error) error {
+	for _, cmd := range plugin.Commands {
+		if err := cmd.InvokeCommandHandler(ce, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetHelp returns plugin help
+func (plugin Plugin) GetHelp(config *Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	var err error
+	h := &pluginhelp.PluginHelp{
+		Description:       plugin.Description,
+		Events:            plugin.getEvents(),
+		ExcludedProviders: plugin.ExcludedProviders.List(),
+	}
+	if plugin.ConfigHelpProvider != nil {
+		h.Config, err = plugin.ConfigHelpProvider(config, enabledRepos)
+	}
+	for _, c := range plugin.Commands {
+		h.AddCommand(c.GetHelp())
+	}
+	return h, err
+}
+
+// IsProviderExcluded returns true if the given provider is excluded, false otherwise
+func (plugin Plugin) IsProviderExcluded(provider string) bool {
+	return plugin.ExcludedProviders.Has(provider)
+}
+
+func (plugin Plugin) getEvents() []string {
+	var events []string
+	if plugin.IssueHandler != nil {
+		events = append(events, "issue")
+	}
+	if plugin.PullRequestHandler != nil {
+		events = append(events, "pull_request")
+	}
+	if plugin.PushEventHandler != nil {
+		events = append(events, "push")
+	}
+	if plugin.ReviewEventHandler != nil {
+		events = append(events, "pull_request_review")
+	}
+	if plugin.StatusEventHandler != nil {
+		events = append(events, "status")
+	}
+	if plugin.GenericCommentHandler != nil {
+		events = append(events, "GenericCommentEvent (any event for user text)")
+	}
+	return events
+}

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -1,0 +1,102 @@
+package plugins_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jenkins-x/lighthouse/pkg/pluginhelp"
+	"github.com/jenkins-x/lighthouse/pkg/plugins"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestPluginIsProviderExcluded(t *testing.T) {
+	cases := []struct {
+		name     string
+		plugin   plugins.Plugin
+		provider string
+		expected bool
+	}{
+		{
+			name:     "no exclusion",
+			plugin:   plugins.Plugin{},
+			provider: "foo",
+			expected: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.plugin.IsProviderExcluded(tc.provider)
+			if actual != tc.expected {
+				t.Errorf("provider exclusion check for provider %s does not match expected %t != expected %t", tc.provider, actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestPluginGetHelp(t *testing.T) {
+	cases := []struct {
+		name         string
+		plugin       plugins.Plugin
+		config       *plugins.Configuration
+		enabledRepos []string
+		expected     *pluginhelp.PluginHelp
+		shouldError  bool
+	}{
+		{
+			name: "no config help provider",
+			plugin: plugins.Plugin{
+				Description:           "Some plugin description",
+				ExcludedProviders:     sets.NewString(),
+				ConfigHelpProvider:    nil,
+				IssueHandler:          nil,
+				PullRequestHandler:    nil,
+				PushEventHandler:      nil,
+				ReviewEventHandler:    nil,
+				StatusEventHandler:    nil,
+				GenericCommentHandler: nil,
+			},
+			config:       nil,
+			enabledRepos: nil,
+			expected: &pluginhelp.PluginHelp{
+				Description:       "Some plugin description",
+				ExcludedProviders: []string{},
+			},
+		},
+		{
+			name: "excluded providers",
+			plugin: plugins.Plugin{
+				Description:           "Some plugin description",
+				ExcludedProviders:     sets.NewString("foo"),
+				ConfigHelpProvider:    nil,
+				IssueHandler:          nil,
+				PullRequestHandler:    nil,
+				PushEventHandler:      nil,
+				ReviewEventHandler:    nil,
+				StatusEventHandler:    nil,
+				GenericCommentHandler: nil,
+			},
+			config:       nil,
+			enabledRepos: nil,
+			expected: &pluginhelp.PluginHelp{
+				Description: "Some plugin description",
+				ExcludedProviders: []string{
+					"foo",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.plugin.GetHelp(tc.config, tc.enabledRepos)
+			if !tc.shouldError && err != nil {
+				t.Errorf("%s: didn't expect error: %v", tc.name, err)
+			} else if tc.shouldError && err == nil {
+				t.Errorf("%s: expected an error to occur", tc.name)
+			} else {
+				if !reflect.DeepEqual(tc.expected, actual) {
+					t.Errorf("plugin help does not match expected %+v != expected %+v", actual, tc.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds scm providers exclusion support for plugins.

I also moved the `Plugin` struct to its own file and started adding unit tests.

I also added the `ExcludedProviders` field in the `PluginHelp` struct.