### PR TITLE
fix: make welcome plugin work

### DIFF
--- a/pkg/plugins/welcome/welcome.go
+++ b/pkg/plugins/welcome/welcome.go
@@ -76,7 +76,7 @@ func configHelp(config *plugins.Configuration, enabledRepos []string) (map[strin
 
 type scmProviderClient interface {
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
-	FindIssues(query, sort string, asc bool) ([]scm.Issue, error)
+	FindPullRequestsByAuthor(owner, repo string, author string) ([]*scm.PullRequest, error)
 }
 
 type client struct {
@@ -105,8 +105,7 @@ func handlePR(c client, pre scm.PullRequestHook, welcomeTemplate string) error {
 	org := pre.PullRequest.Base.Repo.Namespace
 	repo := pre.PullRequest.Base.Repo.Name
 	user := pre.PullRequest.Author.Login
-	query := fmt.Sprintf("is:pr repo:%s/%s author:%s", org, repo, user)
-	issues, err := c.SCMProviderClient.FindIssues(query, "", false)
+	issues, err := c.SCMProviderClient.FindPullRequestsByAuthor(org, repo, user)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/welcome/welcome_test.go
+++ b/pkg/plugins/welcome/welcome_test.go
@@ -19,7 +19,6 @@ package welcome
 import (
 	"fmt"
 	"io/ioutil"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -68,10 +67,6 @@ func (fc *fakeClient) NumComments() int {
 	return n
 }
 
-var (
-	expectedQueryRegex = regexp.MustCompile(`is:pr repo:(.+)/(.+) author:(.+)`)
-)
-
 // AddPR records an PR in the client
 func (fc *fakeClient) AddPR(owner, repo, author string, number int) {
 	key := fmt.Sprintf("%s,%s,%s", owner, repo, author)
@@ -88,18 +83,13 @@ func (fc *fakeClient) ClearPRs() {
 
 // FindIssues fails if the query does not match the expected query regex and
 // looks up issues based on parsing the expected query format
-func (fc *fakeClient) FindIssues(query, sort string, asc bool) ([]scm.Issue, error) {
-	fields := expectedQueryRegex.FindStringSubmatch(query)
-	if fields == nil || len(fields) != 4 {
-		return nil, fmt.Errorf("invalid query: `%s` does not match expected regex `%s`", query, expectedQueryRegex.String())
-	}
+func (fc *fakeClient) FindPullRequestsByAuthor(owner, repo string, author string) ([]*scm.PullRequest, error) {
 	// "find" results
-	owner, repo, author := fields[1], fields[2], fields[3]
 	key := fmt.Sprintf("%s,%s,%s", owner, repo, author)
 
-	issues := []scm.Issue{}
+	issues := []*scm.PullRequest{}
 	for _, number := range fc.prs[key].List() {
-		issues = append(issues, scm.Issue{
+		issues = append(issues, &scm.PullRequest{
 			Number: number,
 		})
 	}

--- a/pkg/scmprovider/client.go
+++ b/pkg/scmprovider/client.go
@@ -67,6 +67,7 @@ type SCMClient interface {
 	ReopenPR(string, string, int) error
 	ClosePR(string, string, int) error
 	ListAllPullRequestsForFullNameRepo(string, scm.PullRequestListOptions) ([]*scm.PullRequest, error)
+	FindPullRequestsByAuthor(string, string, string) ([]*scm.PullRequest, error)
 
 	// Functions implemented in repositories.go
 	GetRepoLabels(string, string) ([]*scm.Label, error)


### PR DESCRIPTION
This PR makes the welcome plugin work.

The `FindIssues` method in the scm provider client is not implemented, i created a `FindPullRequestsByAuthor` method to be used by the welcome plugin.