### PR TITLE
fix: avoid processing the main branch twice

### DIFF
--- a/pkg/triggerconfig/inrepo/calculate.go
+++ b/pkg/triggerconfig/inrepo/calculate.go
@@ -1,6 +1,8 @@
 package inrepo
 
 import (
+	"strings"
+
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/lighthouse/pkg/config"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
@@ -30,7 +32,7 @@ func Generate(scmClient scmProviderClient, sharedConfig *config.Config, sharedPl
 
 	// lets load the main branch first then merge in any changes from this PR/branch
 	refs := []string{"master"}
-	if eventRef != "master" {
+	if eventRef != "master" && !strings.HasSuffix(eventRef, "/master") {
 		refs = append(refs, eventRef)
 	}
 	for _, ref := range refs {


### PR DESCRIPTION
if the ref "refs/origin/master" and we are processing "master" we load twice and possibly fail with duplicate contexts etc.

lets treat "master" and "refs/origin/master" as being effectively the same ref