### PR TITLE
 fix: merging postsubmits & presubmits together by name to avoid duplicates

### DIFF
--- a/pkg/triggerconfig/inrepo/calculate_test.go
+++ b/pkg/triggerconfig/inrepo/calculate_test.go
@@ -110,6 +110,6 @@ func TestTriggersInBranchMergeToMaster(t *testing.T) {
 	assert.Contains(t, presubmitNames, "lint", "presubmits for repo %s", fullName)
 	assert.Contains(t, presubmitNames, "newthingy", "presubmits for repo %s", fullName)
 
-	assert.Len(t, cfg.Postsubmits[fullName], 0, "postsubmits for repo %s", fullName)
+	assert.Len(t, cfg.Postsubmits[fullName], 1, "postsubmits for repo %s", fullName)
 
 }

--- a/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/master/.lighthouse/triggers/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/master/.lighthouse/triggers/triggers.yaml
@@ -9,4 +9,7 @@ spec:
     trigger: "/lint"
     rerunCommand: "/relint"
     agent: tekton-pipeline
-
+  postsubmits:
+  - name: release
+    context: "release"
+    agent: tekton-pipeline

--- a/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/mybranch/.lighthouse/triggers/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/mybranch/.lighthouse/triggers/triggers.yaml
@@ -2,6 +2,13 @@ apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
 kind: TriggerConfig
 spec:
   presubmits:
+  - name: lint
+    context: "lint"
+    alwaysRun: true
+    optional: false
+    trigger: "/lint"
+    rerunCommand: "/relint"
+    agent: tekton-pipeline
   - name: newthingy
     context: "newthingy"
     alwaysRun: true
@@ -9,4 +16,7 @@ spec:
     trigger: "/newthingy"
     rerunCommand: "/renewthingy"
     agent: tekton-pipeline
-
+  postsubmits:
+  - name: release
+    context: "release"
+    agent: tekton-pipeline

--- a/pkg/triggerconfig/merge/merge.go
+++ b/pkg/triggerconfig/merge/merge.go
@@ -17,8 +17,17 @@ func ConfigMerge(cfg *config.Config, pluginsCfg *plugins.Configuration, repoConf
 		}
 
 		ps := cfg.Presubmits[repoKey]
-		for _, p := range repoConfig.Spec.Presubmits {
-			ps = append(ps, p)
+		for i, p := range repoConfig.Spec.Presubmits {
+			found := false
+			for _, pt2 := range ps {
+				if pt2.Name == p.Name {
+					ps[i] = p
+					found = true
+				}
+			}
+			if !found {
+				ps = append(ps, p)
+			}
 		}
 		cfg.Presubmits[repoKey] = ps
 	}
@@ -28,8 +37,17 @@ func ConfigMerge(cfg *config.Config, pluginsCfg *plugins.Configuration, repoConf
 		}
 
 		ps := cfg.Postsubmits[repoKey]
-		for _, p := range repoConfig.Spec.Postsubmits {
-			ps = append(ps, p)
+		for i, p := range repoConfig.Spec.Postsubmits {
+			found := false
+			for _, pt2 := range ps {
+				if pt2.Name == p.Name {
+					ps[i] = p
+					found = true
+				}
+			}
+			if !found {
+				ps = append(ps, p)
+			}
 		}
 		cfg.Postsubmits[repoKey] = ps
 	}


### PR DESCRIPTION
We merge presubmits or postsubmits by name when using shared configurations and in-repo configurations; or when using in-repo configurations on a particular branch versus master.

When merging triggers we need to make sure we combine them together if they have the same name; otherwise we end up with a configuration validation error with duplicate presubmits/postsubmits by name or for the same branch on a post submit

Without this fix, its quite easy to get lighthouse to fail to process a webhook if it has in-repo configurations as it ends up creating a duplicate Presubmit/Postsubmit and then refuses to process the webhook
