### PR TITLE
fix: use numeric user for the image

### DIFF
--- a/docker/foghorn/Dockerfile
+++ b/docker/foghorn/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
 ENV JX_HOME /home/jx
-USER jx
+USER 1000
 
 COPY ./bin/foghorn /home/jx/
 ENTRYPOINT ["/home/jx/foghorn"]

--- a/docker/gc/Dockerfile
+++ b/docker/gc/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
 ENV JX_HOME /home/jx
-USER jx
+USER 1000
 
 COPY ./bin/gc-jobs /home/jx/
 ENTRYPOINT ["/home/jx/gc-jobs"]

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
-USER jx
+USER 1000
 
 COPY ./bin/jenkins-controller /home/jx/
 ENTRYPOINT ["/home/jx/jenkins-controller"]

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
-USER jx
+USER 1000
 
 COPY ./bin/keeper /home/jx/
 ENTRYPOINT ["/home/jx/keeper"]

--- a/docker/tekton/Dockerfile
+++ b/docker/tekton/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
-USER jx
+USER 1000
 
 COPY ./bin/lighthouse-tekton-controller /home/jx/
 ENTRYPOINT ["/home/jx/lighthouse-tekton-controller"]

--- a/docker/webhooks/Dockerfile
+++ b/docker/webhooks/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.12
 
 RUN apk add --update --no-cache ca-certificates git \
-    && adduser -D jx
+    && adduser -D -u 1000 jx
 
 ENV JX_HOME /home/jx
-USER jx
+USER 1000
 
 COPY ./bin/webhooks /home/jx/
 ENTRYPOINT ["/home/jx/webhooks"]


### PR DESCRIPTION
While #1080 did what it was supposed to do (run as a non-root user), it didn't solve the problem I originally wanted to solve - have lighthouse run under a restrictive PodSecurityPolicy.

It currently fails with `container has runAsNonRoot and image has non-numeric user`.
From the official docs for MustRunAsNonRoot:
> Requires that the pod be submitted with a non-zero runAsUser or have the USER directive defined (**using a numeric UID**) in the image