### PR TITLE
fix: bigger default memory limit for webhooks

### DIFF
--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -130,7 +130,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `webhooks.probe` | object | Liveness and readiness probes settings | `{"path":"/"}` |
 | `webhooks.readinessProbe` | object | Readiness probe configuration | `{"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `webhooks.replicaCount` | int | Number of replicas | `2` |
-| `webhooks.resources.limits` | object | Resource limits applied to the webhooks pods | `{"cpu":"100m","memory":"256Mi"}` |
+| `webhooks.resources.limits` | object | Resource limits applied to the webhooks pods | `{"cpu":"100m","memory":"512Mi"}` |
 | `webhooks.resources.requests` | object | Resource requests applied to the webhooks pods | `{"cpu":"80m","memory":"128Mi"}` |
 | `webhooks.service` | object | Service settings for the webhooks controller | `{"annotations":{},"externalPort":80,"internalPort":8080,"type":"ClusterIP"}` |
 | `webhooks.serviceName` | string | Allows overriding the service name, this is here for compatibility reasons, regular users should clear this out | `"hook"` |

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -104,7 +104,8 @@ webhooks:
     # webhooks.resources.limits -- Resource limits applied to the webhooks pods
     limits:
       cpu: 100m
-      memory: 256Mi
+      # may require more memory to perform the initial 'git clone' cmd for big repositories
+      memory: 512Mi
 
     # webhooks.resources.requests -- Resource requests applied to the webhooks pods
     requests:


### PR DESCRIPTION
the `webhooks` component needs to run the `git clone` command once for each repository. If you have big repositories, this could fail if you don't give enough memory to the container: the OOMKiller will kill the git process.
Let's used a "better" default value, and add a comment for people having the issue.

fixes:#1085