### PR TITLE
fix: avoid possible concurrent write issue on ConfigUpdater

### DIFF
--- a/pkg/triggerconfig/inrepo/calculate.go
+++ b/pkg/triggerconfig/inrepo/calculate.go
@@ -24,6 +24,12 @@ func Generate(scmClient scmProviderClient, sharedConfig *config.Config, sharedPl
 	pluginCfg := plugins.Configuration{}
 	if sharedPlugins != nil {
 		pluginCfg = *sharedPlugins
+
+		// lets avoid concurrent modification issues sharing the config updater
+		pluginCfg.ConfigUpdater = plugins.ConfigUpdater{
+			Maps: map[string]plugins.ConfigMapSpec{},
+			GZIP: false,
+		}
 	}
 
 	if eventRef == "" {


### PR DESCRIPTION
when using in-repo config and we call `configuration.Validate()` we don't want to interfere with the global shared configuration.

so this PR just uses a dummy local ConfigUpdater for in-repo configurations

fixes #1093