### PR TITLE
fix: improve the validation of presubmit jobs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -523,7 +523,7 @@ presubmits:
     context: bar
     branches:
     - other
-    name: presubmit-bar
+    name: presubmit-bar2
     spec:
       containers:
       - image: alpine`,
@@ -566,7 +566,7 @@ presubmits:
     context: bar
     branches:
     - master
-    name: presubmit-bar
+    name: presubmit-bar2
     spec:
       containers:
       - image: alpine`,

--- a/pkg/config/job/config.go
+++ b/pkg/config/job/config.go
@@ -155,7 +155,7 @@ func (c *Config) Validate(lh lighthouse.Config) error {
 		for _, job := range jobs {
 			repoJobName := orgRepoJobName{repo, job.Name}
 			for _, existingJob := range validPresubmits[repoJobName] {
-				if existingJob.Brancher.Intersects(job.Brancher) {
+				if existingJob.Name == job.Name {
 					return fmt.Errorf("duplicated presubmit job: %s", job.Name)
 				}
 			}


### PR DESCRIPTION
we should be able to have multiple presubmit jobs with different names on the same branches. e.g. one job for linting, one for preview environments; or N jobs for different kinds of system/integration tests etc