### PR TITLE
feat: Make inrepo config merge current PR branch config

### DIFF
--- a/pkg/scmprovider/legacy_helpers.go
+++ b/pkg/scmprovider/legacy_helpers.go
@@ -149,6 +149,7 @@ type GenericCommentEvent struct {
 	IssueBody   string
 	IssueLink   string
 	GUID        string
+	HeadSha     string
 }
 
 // ReviewAction is the action that a review can be made with.


### PR DESCRIPTION
Hello, 

In https://github.com/jenkins-x/lighthouse/blob/08b0ae6ebc6a1feb4efafb2d77cae1149f151393/pkg/triggerconfig/inrepo/calculate.go#L48-L52 we add `eventRef` to the list of for for which we merge inrepoconfigs

But in a lot of case, `eventRef` is actually an empty string, because the agent created in pkg/webhook/events.go is given an empty string :

https://github.com/jenkins-x/lighthouse/blob/08b0ae6ebc6a1feb4efafb2d77cae1149f151393/pkg/webhook/events.go#L118

This PR makes it so that it is not the case anymore.

Please note that this is my first PR on this project and that I've not been using lighthouse for a very long time, so I might have missed a good reason for not doing this.