### PR TITLE
fix: avoid lots of boilerplate YAML for in-repo PipelineRuns

### DIFF
--- a/pkg/triggerconfig/inrepo/default_parameters.go
+++ b/pkg/triggerconfig/inrepo/default_parameters.go
@@ -1,0 +1,189 @@
+package inrepo
+
+import (
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	// defaultParameterSpecs the default Lighthouse Pipeline Parameters which can be injected by the
+	// lighthouse tekton engine
+	defaultParameterSpecs = []v1beta1.ParamSpec{
+		{
+			Description: "the unique build number",
+			Name:        "BUILD_ID",
+			Type:        "string",
+		},
+		{
+			Description: "the name of the job which is the trigger context name",
+			Name:        "JOB_NAME",
+			Type:        "string",
+		},
+		{
+			Description: "the specification of the job",
+			Name:        "JOB_SPEC",
+			Type:        "string",
+		},
+		{
+			Description: "'the kind of job: postsubmit or presubmit'",
+			Name:        "JOB_TYPE",
+			Type:        "string",
+		},
+		{
+			Description: "the base git reference of the pull request",
+			Name:        "PULL_BASE_REF",
+			Type:        "string",
+		},
+		{
+			Description: "the git sha of the base of the pull request",
+			Name:        "PULL_BASE_SHA",
+			Type:        "string",
+		},
+		{
+			Description: "git pull request number",
+			Name:        "PULL_NUMBER",
+			Type:        "string",
+		},
+		{
+			Description: "git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'",
+			Name:        "PULL_PULL_REF",
+			Type:        "string",
+		},
+		{
+			Description: "git revision to checkout (branch, tag, sha, ref…)",
+			Name:        "PULL_PULL_SHA",
+			Type:        "string",
+		},
+		{
+			Description: "git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'",
+			Name:        "PULL_REFS",
+			Type:        "string",
+		},
+		{
+			Description: "git repository name",
+			Name:        "REPO_NAME",
+			Type:        "string",
+		},
+		{
+			Description: "git repository owner (user or organisation)",
+			Name:        "REPO_OWNER",
+			Type:        "string",
+		},
+		{
+			Description: "git url to clone",
+			Name:        "REPO_URL",
+			Type:        "string",
+		},
+	}
+
+	defaultParameters = ToParams(defaultParameterSpecs)
+)
+
+// DefaultPipelineParameters defaults the parameter specs and parameter values from lighthouse onto
+// the PipelineRun and its nested PipelineSpec and Tasks
+func DefaultPipelineParameters(prs *v1beta1.PipelineRun) (*v1beta1.PipelineRun, error) {
+	ps := prs.Spec.PipelineSpec
+	if ps == nil {
+		return prs, nil
+	}
+
+	ps.Params = addDefaultParameterSpecs(ps.Params, defaultParameterSpecs)
+
+	for i := range ps.Tasks {
+		task := &ps.Tasks[i]
+		task.Params = addDefaultParameters(task.Params, defaultParameters)
+		if task.TaskSpec != nil {
+			// lets create a step template if its not already defined
+			if task.TaskSpec.StepTemplate == nil {
+				task.TaskSpec.StepTemplate = &corev1.Container{}
+			}
+			stepTemplate := task.TaskSpec.StepTemplate
+			stepTemplate.Env = addDefaultParameterEnvVars(stepTemplate.Env, defaultParameters)
+		}
+	}
+	return prs, nil
+}
+
+func addDefaultParameterSpecs(params []v1beta1.ParamSpec, defaults []v1beta1.ParamSpec) []v1beta1.ParamSpec {
+	for _, dp := range defaults {
+		found := false
+		for i := range params {
+			param := &params[i]
+			if param.Name == dp.Name {
+				found = true
+				if param.Description == "" {
+					param.Description = dp.Description
+				}
+				if param.Type == "" {
+					param.Type = dp.Type
+				}
+				break
+			}
+		}
+		if !found {
+			params = append(params, dp)
+		}
+	}
+	return params
+}
+
+func addDefaultParameters(params []v1beta1.Param, defaults []v1beta1.Param) []v1beta1.Param {
+	for _, dp := range defaults {
+		found := false
+		for i := range params {
+			p := &params[i]
+			if p.Name == dp.Name {
+				found = true
+				if p.Value.Type == dp.Value.Type {
+					switch p.Value.Type {
+					case v1beta1.ParamTypeString:
+						if p.Value.StringVal == "" {
+							p.Value.StringVal = dp.Value.StringVal
+						}
+					case v1beta1.ParamTypeArray:
+						if len(p.Value.ArrayVal) == 0 {
+							p.Value.ArrayVal = dp.Value.ArrayVal
+						}
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			params = append(params, dp)
+		}
+	}
+	return params
+}
+
+func addDefaultParameterEnvVars(env []corev1.EnvVar, defaults []v1beta1.Param) []corev1.EnvVar {
+	for _, dp := range defaults {
+		name := dp.Name
+		upperName := strings.ToUpper(name)
+		if upperName != name {
+			// ignore parameters which are not already suitable environment names being upper case
+			// with optional _ characters
+			continue
+		}
+		found := false
+		for i := range env {
+			p := &env[i]
+			if p.Name == name {
+				found = true
+				if p.Value == "" {
+					p.Value = dp.Value.StringVal
+				}
+				break
+			}
+		}
+		if !found {
+			env = append(env, corev1.EnvVar{
+				Name:  name,
+				Value: dp.Value.StringVal,
+			})
+		}
+	}
+	return env
+}

--- a/pkg/triggerconfig/inrepo/default_parameters.go
+++ b/pkg/triggerconfig/inrepo/default_parameters.go
@@ -95,6 +95,8 @@ func DefaultPipelineParameters(prs *v1beta1.PipelineRun) (*v1beta1.PipelineRun, 
 		task := &ps.Tasks[i]
 		task.Params = addDefaultParameters(task.Params, defaultParameters)
 		if task.TaskSpec != nil {
+			task.TaskSpec.Params = addDefaultParameterSpecs(task.TaskSpec.Params, defaultParameterSpecs)
+
 			// lets create a step template if its not already defined
 			if task.TaskSpec.StepTemplate == nil {
 				task.TaskSpec.StepTemplate = &corev1.Container{}

--- a/pkg/triggerconfig/inrepo/load_pipelinerun.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun.go
@@ -186,15 +186,19 @@ func loadPipelineRunRefs(prs *tektonv1beta1.PipelineRun, dir, message string, re
 			pipelinePath += ".yaml"
 		}
 		data, err := getData(pipelinePath)
-		if err == nil && len(data) > 0 {
-			p := &tektonv1beta1.Pipeline{}
-			err = yaml.Unmarshal(data, p)
-			if err != nil {
-				return prs, errors.Wrapf(err, "failed to unmarshal Pipeline YAML file %s %s", pipelinePath, message)
-			}
-			prs.Spec.PipelineSpec = &p.Spec
-			prs.Spec.PipelineRef = nil
+		if err != nil {
+			return prs, errors.Wrapf(err, "failed to find path %s in PipelineRun", pipelinePath)
 		}
+		if len(data) == 0 {
+			return prs, errors.Errorf("no YAML for path %s in PipelineRun", pipelinePath)
+		}
+		p := &tektonv1beta1.Pipeline{}
+		err = yaml.Unmarshal(data, p)
+		if err != nil {
+			return prs, errors.Wrapf(err, "failed to unmarshal Pipeline YAML file %s %s", pipelinePath, message)
+		}
+		prs.Spec.PipelineSpec = &p.Spec
+		prs.Spec.PipelineRef = nil
 	}
 
 	if prs.Spec.PipelineSpec != nil {
@@ -215,15 +219,19 @@ func loadTaskRefs(pipelineSpec *tektonv1beta1.PipelineSpec, dir, message string,
 				path += ".yaml"
 			}
 			data, err := getData(path)
-			if err == nil && len(data) > 0 {
-				t2 := &tektonv1beta1.Task{}
-				err = yaml.Unmarshal(data, t2)
-				if err != nil {
-					return errors.Wrapf(err, "failed to unmarshal Task YAML file %s %s", path, message)
-				}
-				t.TaskSpec = &t2.Spec
-				t.TaskRef = nil
+			if err != nil {
+				return errors.Wrapf(err, "failed to find path %s in PipelineSpec", path)
 			}
+			if len(data) == 0 {
+				return errors.Errorf("no YAML for path %s in PipelineSpec", path)
+			}
+			t2 := &tektonv1beta1.Task{}
+			err = yaml.Unmarshal(data, t2)
+			if err != nil {
+				return errors.Wrapf(err, "failed to unmarshal Task YAML file %s %s", path, message)
+			}
+			t.TaskSpec = &t2.Spec
+			t.TaskRef = nil
 		}
 	}
 	return nil

--- a/pkg/triggerconfig/inrepo/load_pipelinerun.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun.go
@@ -79,16 +79,20 @@ func LoadTektonResourceAsPipelineRun(data []byte, dir, message string, getData f
 			return nil, errors.Wrapf(err, "failed to unmarshal Pipeline YAML %s", message)
 		}
 		prs, err := ConvertPipelineToPipelineRun(pipeline, message, defaultValues)
-		if err == nil {
-			re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		if re != nil {
+			prs, err = loadPipelineRunRefs(prs, dir, message, re, getData)
 			if err != nil {
 				return prs, err
 			}
-			if re != nil {
-				return loadPipelineRunRefs(prs, dir, message, re, getData)
-			}
 		}
-		return prs, err
+		return DefaultPipelineParameters(prs)
 
 	case "PipelineRun":
 		prs := &tektonv1beta1.PipelineRun{}
@@ -96,15 +100,18 @@ func LoadTektonResourceAsPipelineRun(data []byte, dir, message string, getData f
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to unmarshal PipelineRun YAML %s", message)
 		}
-
 		re, err := loadTektonRefsFromFilesPattern(prs)
 		if err != nil {
 			return prs, err
 		}
 		if re != nil {
-			return loadPipelineRunRefs(prs, dir, message, re, getData)
+			prs, err = loadPipelineRunRefs(prs, dir, message, re, getData)
+			if err != nil {
+				return prs, err
+			}
 		}
-		return prs, err
+		return DefaultPipelineParameters(prs)
+
 	case "Task":
 		task := &tektonv1beta1.Task{}
 		err := yaml.Unmarshal(data, task)
@@ -112,16 +119,20 @@ func LoadTektonResourceAsPipelineRun(data []byte, dir, message string, getData f
 			return nil, errors.Wrapf(err, "failed to unmarshal Task YAML %s", message)
 		}
 		prs, err := ConvertTaskToPipelineRun(task, message, defaultValues)
-		if err == nil {
-			re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		if re != nil {
+			prs, err = loadPipelineRunRefs(prs, dir, message, re, getData)
 			if err != nil {
 				return prs, err
 			}
-			if re != nil {
-				return loadPipelineRunRefs(prs, dir, message, re, getData)
-			}
 		}
-		return prs, err
+		return DefaultPipelineParameters(prs)
 
 	case "TaskRun":
 		tr := &tektonv1beta1.TaskRun{}
@@ -130,16 +141,20 @@ func LoadTektonResourceAsPipelineRun(data []byte, dir, message string, getData f
 			return nil, errors.Wrapf(err, "failed to unmarshal TaskRun YAML %s", message)
 		}
 		prs, err := ConvertTaskRunToPipelineRun(tr, message, defaultValues)
-		if err == nil {
-			re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		re, err := loadTektonRefsFromFilesPattern(prs)
+		if err != nil {
+			return prs, err
+		}
+		if re != nil {
+			prs, err = loadPipelineRunRefs(prs, dir, message, re, getData)
 			if err != nil {
 				return prs, err
 			}
-			if re != nil {
-				return loadPipelineRunRefs(prs, dir, message, re, getData)
-			}
 		}
-		return prs, err
+		return DefaultPipelineParameters(prs)
 
 	default:
 		return nil, errors.Errorf("kind %s is not supported for %s", kind, message)

--- a/pkg/triggerconfig/inrepo/load_pipelinerun.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun.go
@@ -262,7 +262,6 @@ func ConvertTaskToPipelineRun(from *tektonv1beta1.Task, message string, defaultV
 		Finally: nil,
 	}
 	prs.Spec.PipelineSpec = pipelineSpec
-	prs.Spec.Params = ToParams(fs.Params)
 	//prs.Spec.Resources = fs.Resources
 	prs.Spec.Workspaces = ToWorkspaceBindings(fs.Workspaces)
 	defaultValues.Apply(prs)
@@ -312,7 +311,6 @@ func ConvertTaskRunToPipelineRun(from *tektonv1beta1.TaskRun, message string, de
 		Finally:    nil,
 	}
 	prs.Spec.PipelineSpec = pipelineSpec
-	prs.Spec.Params = params
 	prs.Spec.PodTemplate = fs.PodTemplate
 	//prs.Spec.Resources = fs.Resources
 	prs.Spec.ServiceAccountName = fs.ServiceAccountName
@@ -331,7 +329,7 @@ func (v *DefaultValues) Apply(prs *tektonv1beta1.PipelineRun) {
 	}
 }
 
-// ToParams convers the param specs to params
+// ToParams converts the param specs to params
 func ToParams(params []tektonv1beta1.ParamSpec) []tektonv1beta1.Param {
 	var answer []tektonv1beta1.Param
 	for _, p := range params {

--- a/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
@@ -41,6 +41,12 @@ func TestLoadPipelineRunTest(t *testing.T) {
 		require.NoError(t, err, "failed to load "+message)
 
 		pr, err := LoadTektonResourceAsPipelineRun(data, dir, message, getData, nil)
+		if strings.HasSuffix(name, "-fails") {
+			require.Errorf(t, err, "expected failure for test %s", name)
+			t.Logf("test %s generated expected error %s\n", name, err.Error())
+			continue
+		}
+
 		require.NoError(t, err, "failed to load PipelineRun for "+message)
 		require.NotNil(t, pr, "no PipelineRun for "+message)
 

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/demo-deploy-kubectl.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/demo-deploy-kubectl.yaml
@@ -1,0 +1,35 @@
+# This task deploys with kubectl apply -f <filename>
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: demo-deploy-kubectl
+spec:
+  params:
+  - name: path
+    description: Path to the manifest to apply
+  - name: yqArg
+    description: Okay this is a hack, but I didn't feel right hard-coding `-d1` down below
+  - name: yamlPathToImage
+    description: The path to the image to replace in the yaml manifest (arg to yq)
+  - name: imageURL
+    description: The URL of the image to deploy
+  workspaces:
+  - name: source
+  steps:
+  - name: replace-image
+    image: mikefarah/yq
+    command: ['yq']
+    args:
+    - "w"
+    - "-i"
+    - "$(params.yqArg)"
+    - "$(params.path)"
+    - "$(params.yamlPathToImage)"
+    - "$(params.imageURL)"
+  - name: run-kubectl
+    image: lachlanevenson/k8s-kubectl
+    command: ['kubectl']
+    args:
+    - 'apply'
+    - '-f'
+    - '$(params.path)'

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/expected.yaml
@@ -1,0 +1,960 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    lighthouse.jenkins-x.io/loadFileRefs: .*
+  creationTimestamp: null
+  name: demo-pipeline
+spec:
+  pipelineSpec:
+    params:
+    - default: gcr.io/christiewilson-catfactory
+      name: image-registry
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: fetch-from-git
+      params:
+      - name: url
+        value: https://github.com/GoogleContainerTools/skaffold
+      - name: revision
+        value: v0.32.0
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        params:
+        - description: git url to clone
+          name: url
+          type: string
+        - default: master
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: revision
+          type: string
+        - default: "true"
+          description: defines if the resource should initialize and fetch the submodules
+          name: submodules
+          type: string
+        - default: "1"
+          description: performs a shallow clone where only the most recent commit(s) will be fetched
+          name: depth
+          type: string
+        - default: "true"
+          description: defines if http.sslVerify should be set to true or false in the global git config
+          name: sslVerify
+          type: string
+        - default: ""
+          description: subdirectory inside the "output" workspace to clone the git repo into
+          name: subdirectory
+          type: string
+        - default: "false"
+          description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+          name: deleteExisting
+          type: string
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        results:
+        - description: The precise commit SHA that was fetched by this Task
+          name: commit
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - image: ko://github.com/tektoncd/pipeline/cmd/git-init
+          name: clone
+          resources: {}
+          script: |-
+            CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+            cleandir() {
+              # Delete any existing contents of the repo directory if it exists.
+              #
+              # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+              # or the root of a mounted volume.
+              if [[ -d "$CHECKOUT_DIR" ]] ; then
+                # Delete non-hidden files and directories
+                rm -rf "$CHECKOUT_DIR"/*
+                # Delete files and directories starting with . but excluding ..
+                rm -rf "$CHECKOUT_DIR"/.[!.]*
+                # Delete files and directories starting with .. plus any other character
+                rm -rf "$CHECKOUT_DIR"/..?*
+              fi
+            }
+            if [[ "$(params.deleteExisting)" == "true" ]] ; then
+              cleandir
+            fi
+            /ko-app/git-init \
+              -url "$(params.url)" \
+              -revision "$(params.revision)" \
+              -path "$CHECKOUT_DIR" \
+              -sslVerify="$(params.sslVerify)" \
+              -submodules="$(params.submodules)" \
+              -depth="$(params.depth)"
+            cd "$CHECKOUT_DIR"
+            RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
+            EXIT_CODE="$?"
+            if [ "$EXIT_CODE" != 0 ]
+            then
+              exit $EXIT_CODE
+            fi
+            # Make sure we don't add a trailing newline to the result!
+            echo -n "$RESULT_SHA" > $(results.commit.path)
+        workspaces:
+        - description: The git repo will be cloned onto the volume backing this workspace
+          name: output
+      workspaces:
+      - name: output
+        workspace: git-source
+    - name: skaffold-unit-tests
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      runAfter:
+      - fetch-from-git
+      taskSpec:
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - env:
+          - name: GOPATH
+            value: /workspace/go
+          image: golang
+          name: run-tests
+          resources: {}
+          script: |-
+            # The intention behind this example Task is to run unit test, however we
+            # currently do nothing to ensure that a unit test issue doesn't cause this example
+            # to fail unnecessarily. In the future we could re-introduce the unit tests (since
+            # we are now pinning the version of Skaffold we pull) or use Tekton Pipelines unit tests.
+            echo "pass"
+          workingDir: $(workspaces.source.path)
+        workspaces:
+        - mountPath: /workspace/source/go/src/github.com/GoogleContainerTools/skaffold
+          name: source
+      workspaces:
+      - name: source
+        workspace: git-source
+    - name: build-skaffold-web
+      params:
+      - name: IMAGE
+        value: $(params.image-registry)/leeroy-web
+      - name: CONTEXT
+        value: examples/microservices/leeroy-web
+      - name: DOCKERFILE
+        value: $(workspaces.source.path)/examples/microservices/leeroy-web/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      runAfter:
+      - skaffold-unit-tests
+      taskSpec:
+        params:
+        - description: Name (reference) of the image to build.
+          name: IMAGE
+        - default: ./Dockerfile
+          description: Path to the Dockerfile to build.
+          name: DOCKERFILE
+        - default: ./
+          description: The build context used by Kaniko.
+          name: CONTEXT
+        - default: ""
+          name: EXTRA_ARGS
+        - default: gcr.io/kaniko-project/executor:latest
+          description: The image on which builds will run
+          name: BUILDER_IMAGE
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        results:
+        - description: Digest of the image just built.
+          name: IMAGE_DIGEST
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - command:
+          - /kaniko/executor
+          - $(params.EXTRA_ARGS)
+          - --dockerfile=$(params.DOCKERFILE)
+          - --context=$(workspaces.source.path)/$(params.CONTEXT)
+          - --destination=$(params.IMAGE)
+          - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
+          env:
+          - name: DOCKER_CONFIG
+            value: /tekton/home/.docker
+          image: $(params.BUILDER_IMAGE)
+          name: build-and-push
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          workingDir: $(workspaces.source.path)
+        - args:
+          - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/$(params.CONTEXT)/image-digest"}]
+          - -terminationMessagePath=$(params.CONTEXT)/image-digested
+          command:
+          - /ko-app/imagedigestexporter
+          image: ko://github.com/tektoncd/pipeline/cmd/imagedigestexporter
+          name: write-digest
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          workingDir: $(workspaces.source.path)
+        - image: stedolan/jq
+          name: digest-to-results
+          resources: {}
+          script: cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE_DIGEST
+          workingDir: $(workspaces.source.path)
+        workspaces:
+        - name: source
+      workspaces:
+      - name: source
+        workspace: git-source
+    - name: build-skaffold-app
+      params:
+      - name: IMAGE
+        value: $(params.image-registry)/leeroy-app
+      - name: CONTEXT
+        value: examples/microservices/leeroy-app
+      - name: DOCKERFILE
+        value: $(workspaces.source.path)/examples/microservices/leeroy-app/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      runAfter:
+      - skaffold-unit-tests
+      taskSpec:
+        params:
+        - description: Name (reference) of the image to build.
+          name: IMAGE
+        - default: ./Dockerfile
+          description: Path to the Dockerfile to build.
+          name: DOCKERFILE
+        - default: ./
+          description: The build context used by Kaniko.
+          name: CONTEXT
+        - default: ""
+          name: EXTRA_ARGS
+        - default: gcr.io/kaniko-project/executor:latest
+          description: The image on which builds will run
+          name: BUILDER_IMAGE
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        results:
+        - description: Digest of the image just built.
+          name: IMAGE_DIGEST
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - command:
+          - /kaniko/executor
+          - $(params.EXTRA_ARGS)
+          - --dockerfile=$(params.DOCKERFILE)
+          - --context=$(workspaces.source.path)/$(params.CONTEXT)
+          - --destination=$(params.IMAGE)
+          - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
+          env:
+          - name: DOCKER_CONFIG
+            value: /tekton/home/.docker
+          image: $(params.BUILDER_IMAGE)
+          name: build-and-push
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          workingDir: $(workspaces.source.path)
+        - args:
+          - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/$(params.CONTEXT)/image-digest"}]
+          - -terminationMessagePath=$(params.CONTEXT)/image-digested
+          command:
+          - /ko-app/imagedigestexporter
+          image: ko://github.com/tektoncd/pipeline/cmd/imagedigestexporter
+          name: write-digest
+          resources: {}
+          securityContext:
+            runAsUser: 0
+          workingDir: $(workspaces.source.path)
+        - image: stedolan/jq
+          name: digest-to-results
+          resources: {}
+          script: cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE_DIGEST
+          workingDir: $(workspaces.source.path)
+        workspaces:
+        - name: source
+      workspaces:
+      - name: source
+        workspace: git-source
+    - name: deploy-app
+      params:
+      - name: imageURL
+        value: $(params.image-registry)/leeroy-app@$(tasks.build-skaffold-app.results.IMAGE_DIGEST)
+      - name: path
+        value: $(workspaces.source.path)/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+      - name: yqArg
+        value: -d1
+      - name: yamlPathToImage
+        value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        params:
+        - description: Path to the manifest to apply
+          name: path
+        - description: Okay this is a hack, but I didn't feel right hard-coding `-d1` down below
+          name: yqArg
+        - description: The path to the image to replace in the yaml manifest (arg to yq)
+          name: yamlPathToImage
+        - description: The URL of the image to deploy
+          name: imageURL
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - args:
+          - w
+          - -i
+          - $(params.yqArg)
+          - $(params.path)
+          - $(params.yamlPathToImage)
+          - $(params.imageURL)
+          command:
+          - yq
+          image: mikefarah/yq
+          name: replace-image
+          resources: {}
+        - args:
+          - apply
+          - -f
+          - $(params.path)
+          command:
+          - kubectl
+          image: lachlanevenson/k8s-kubectl
+          name: run-kubectl
+          resources: {}
+        workspaces:
+        - name: source
+      workspaces:
+      - name: source
+        workspace: git-source
+    - name: deploy-web
+      params:
+      - name: imageURL
+        value: $(params.image-registry)/leeroy-web@$(tasks.build-skaffold-web.results.IMAGE_DIGEST)
+      - name: path
+        value: $(workspaces.source.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+      - name: yqArg
+        value: -d1
+      - name: yamlPathToImage
+        value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        params:
+        - description: Path to the manifest to apply
+          name: path
+        - description: Okay this is a hack, but I didn't feel right hard-coding `-d1` down below
+          name: yqArg
+        - description: The path to the image to replace in the yaml manifest (arg to yq)
+          name: yamlPathToImage
+        - description: The URL of the image to deploy
+          name: imageURL
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - args:
+          - w
+          - -i
+          - $(params.yqArg)
+          - $(params.path)
+          - $(params.yamlPathToImage)
+          - $(params.imageURL)
+          command:
+          - yq
+          image: mikefarah/yq
+          name: replace-image
+          resources: {}
+        - args:
+          - apply
+          - -f
+          - $(params.path)
+          command:
+          - kubectl
+          image: lachlanevenson/k8s-kubectl
+          name: run-kubectl
+          resources: {}
+        workspaces:
+        - name: source
+      workspaces:
+      - name: source
+        workspace: git-source
+    workspaces:
+    - name: git-source
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/kaniko.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/kaniko.yaml
@@ -1,0 +1,63 @@
+# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/kaniko/kaniko.yaml
+# with a few fixes that will be port over in https://github.com/tektoncd/catalog/pull/291
+# Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kaniko
+spec:
+  workspaces:
+  - name: source
+  params:
+  - name: IMAGE
+    description: Name (reference) of the image to build.
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: The build context used by Kaniko.
+    default: ./
+  - name: EXTRA_ARGS
+    default: ""
+  - name: BUILDER_IMAGE
+    description: The image on which builds will run
+    default: gcr.io/kaniko-project/executor:latest
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  steps:
+  - name: build-and-push
+    workingDir: $(workspaces.source.path)
+    image: $(params.BUILDER_IMAGE)
+    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+    # https://github.com/tektoncd/pipeline/pull/706
+    env:
+    - name: DOCKER_CONFIG
+      value: /tekton/home/.docker
+    command:
+    - /kaniko/executor
+    - $(params.EXTRA_ARGS)
+    - --dockerfile=$(params.DOCKERFILE)
+    - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
+    - --destination=$(params.IMAGE)
+    - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
+    # kaniko assumes it is running as root, which means this example fails on platforms
+    # that default to run containers as random uid (like OpenShift). Adding this securityContext
+    # makes it explicit that it needs to run as root.
+    securityContext:
+      runAsUser: 0
+  - name: write-digest
+    workingDir: $(workspaces.source.path)
+    image: ko://github.com/tektoncd/pipeline/cmd/imagedigestexporter
+    # output of imagedigestexport [{"name":"image","digest":"sha256:eed29..660"}]
+    command: ["/ko-app/imagedigestexporter"]
+    securityContext:
+      runAsUser: 0
+    args:
+    - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/$(params.CONTEXT)/image-digest"}]
+    - -terminationMessagePath=$(params.CONTEXT)/image-digested
+  - name: digest-to-results
+    workingDir: $(workspaces.source.path)
+    image: stedolan/jq
+    script: |
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE_DIGEST

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/mydir/git-clone.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/mydir/git-clone.yaml
@@ -1,0 +1,80 @@
+# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml
+# With a few fixes being ported over in https://github.com/tektoncd/catalog/pull/290
+# Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  workspaces:
+  - name: output
+    description: The git repo will be cloned onto the volume backing this workspace
+  params:
+  - name: url
+    description: git url to clone
+    type: string
+  - name: revision
+    description: git revision to checkout (branch, tag, sha, ref…)
+    type: string
+    default: master
+  - name: submodules
+    description: defines if the resource should initialize and fetch the submodules
+    type: string
+    default: "true"
+  - name: depth
+    description: performs a shallow clone where only the most recent commit(s) will be fetched
+    type: string
+    default: "1"
+  - name: sslVerify
+    description: defines if http.sslVerify should be set to true or false in the global git config
+    type: string
+    default: "true"
+  - name: subdirectory
+    description: subdirectory inside the "output" workspace to clone the git repo into
+    type: string
+    default: ""
+  - name: deleteExisting
+    description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+    type: string
+    default: "false"
+  results:
+  - name: commit
+    description: The precise commit SHA that was fetched by this Task
+  steps:
+  - name: clone
+    image: ko://github.com/tektoncd/pipeline/cmd/git-init
+    script: |
+      CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+      cleandir() {
+        # Delete any existing contents of the repo directory if it exists.
+        #
+        # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+        # or the root of a mounted volume.
+        if [[ -d "$CHECKOUT_DIR" ]] ; then
+          # Delete non-hidden files and directories
+          rm -rf "$CHECKOUT_DIR"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "$CHECKOUT_DIR"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "$CHECKOUT_DIR"/..?*
+        fi
+      }
+      if [[ "$(params.deleteExisting)" == "true" ]] ; then
+        cleandir
+      fi
+      /ko-app/git-init \
+        -url "$(params.url)" \
+        -revision "$(params.revision)" \
+        -path "$CHECKOUT_DIR" \
+        -sslVerify="$(params.sslVerify)" \
+        -submodules="$(params.submodules)" \
+        -depth="$(params.depth)"
+      cd "$CHECKOUT_DIR"
+      RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
+      EXIT_CODE="$?"
+      if [ "$EXIT_CODE" != 0 ]
+      then
+        exit $EXIT_CODE
+      fi
+      # Make sure we don't add a trailing newline to the result!
+      echo -n "$RESULT_SHA" > $(results.commit.path)

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/source.yaml
@@ -1,0 +1,91 @@
+# This Pipeline Builds two microservice images(https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices)
+# from the Skaffold repo (https://github.com/GoogleContainerTools/skaffold) and deploys them to the repo currently running Tekton Pipelines.
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+  annotations:
+    lighthouse.jenkins-x.io/loadFileRefs: ".*"
+spec:
+  params:
+  - name: image-registry
+    default: gcr.io/christiewilson-catfactory
+  workspaces:
+  - name: git-source
+  tasks:
+  - name: fetch-from-git
+    taskRef:
+      name: mydir/git-clone
+    params:
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold
+    - name: revision
+      value: v0.32.0
+    workspaces:
+    - name: output
+      workspace: git-source
+  - name: skaffold-unit-tests
+    runAfter: [fetch-from-git]
+    taskRef:
+      name: unit-tests
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: build-skaffold-web
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: kaniko
+    params:
+    - name: IMAGE
+      value: $(params.image-registry)/leeroy-web
+    - name: CONTEXT
+      value: examples/microservices/leeroy-web
+    - name: DOCKERFILE
+      value: $(workspaces.source.path)/examples/microservices/leeroy-web/Dockerfile
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: build-skaffold-app
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: kaniko
+    params:
+    - name: IMAGE
+      value: $(params.image-registry)/leeroy-app
+    - name: CONTEXT
+      value: examples/microservices/leeroy-app
+    - name: DOCKERFILE
+      value: $(workspaces.source.path)/examples/microservices/leeroy-app/Dockerfile
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: deploy-app
+    taskRef:
+      name: demo-deploy-kubectl
+    params:
+    - name: imageURL
+      value: $(params.image-registry)/leeroy-app@$(tasks.build-skaffold-app.results.IMAGE_DIGEST)
+    - name: path
+      value: $(workspaces.source.path)/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: deploy-web
+    taskRef:
+      name: demo-deploy-kubectl
+    params:
+    - name: imageURL
+      value: $(params.image-registry)/leeroy-web@$(tasks.build-skaffold-web.results.IMAGE_DIGEST)
+    - name: path
+      value: $(workspaces.source.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+    workspaces:
+    - name: source
+      workspace: git-source

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/unit-tests.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs-sub-dir/unit-tests.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: unit-tests
+spec:
+  workspaces:
+  - name: source
+    mountPath: /workspace/source/go/src/github.com/GoogleContainerTools/skaffold
+  steps:
+  - name: run-tests
+    image: golang
+    env:
+    - name: GOPATH
+      value: /workspace/go
+    workingDir: $(workspaces.source.path)
+    script: |
+      # The intention behind this example Task is to run unit test, however we
+      # currently do nothing to ensure that a unit test issue doesn't cause this example
+      # to fail unnecessarily. In the future we could re-introduce the unit tests (since
+      # we are now pinning the version of Skaffold we pull) or use Tekton Pipelines unit tests.
+      echo "pass"

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs/expected.yaml
@@ -10,6 +10,45 @@ spec:
     params:
     - default: gcr.io/christiewilson-catfactory
       name: image-registry
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
     tasks:
     - name: fetch-from-git
       params:
@@ -17,6 +56,32 @@ spec:
         value: https://github.com/GoogleContainerTools/skaffold
       - name: revision
         value: v0.32.0
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskSpec:
         params:
         - description: git url to clone
@@ -49,6 +114,36 @@ spec:
         results:
         - description: The precise commit SHA that was fetched by this Task
           name: commit
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - image: ko://github.com/tektoncd/pipeline/cmd/git-init
           name: clone
@@ -95,9 +190,66 @@ spec:
       - name: output
         workspace: git-source
     - name: skaffold-unit-tests
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - fetch-from-git
       taskSpec:
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - env:
           - name: GOPATH
@@ -126,6 +278,32 @@ spec:
         value: examples/microservices/leeroy-web
       - name: DOCKERFILE
         value: $(workspaces.source.path)/examples/microservices/leeroy-web/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - skaffold-unit-tests
       taskSpec:
@@ -146,6 +324,36 @@ spec:
         results:
         - description: Digest of the image just built.
           name: IMAGE_DIGEST
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - command:
           - /kaniko/executor
@@ -192,6 +400,32 @@ spec:
         value: examples/microservices/leeroy-app
       - name: DOCKERFILE
         value: $(workspaces.source.path)/examples/microservices/leeroy-app/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - skaffold-unit-tests
       taskSpec:
@@ -212,6 +446,36 @@ spec:
         results:
         - description: Digest of the image just built.
           name: IMAGE_DIGEST
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - command:
           - /kaniko/executor
@@ -260,6 +524,32 @@ spec:
         value: -d1
       - name: yamlPathToImage
         value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskSpec:
         params:
         - description: Path to the manifest to apply
@@ -270,6 +560,36 @@ spec:
           name: yamlPathToImage
         - description: The URL of the image to deploy
           name: imageURL
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - args:
           - w
@@ -307,6 +627,32 @@ spec:
         value: -d1
       - name: yamlPathToImage
         value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskSpec:
         params:
         - description: Path to the manifest to apply
@@ -317,6 +663,36 @@ spec:
           name: yamlPathToImage
         - description: The URL of the image to deploy
           name: imageURL
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - args:
           - w

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-load-refs/expected.yaml
@@ -111,6 +111,45 @@ spec:
           description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
           name: deleteExisting
           type: string
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         results:
         - description: The precise commit SHA that was fetched by this Task
           name: commit
@@ -220,6 +259,46 @@ spec:
       runAfter:
       - fetch-from-git
       taskSpec:
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         stepTemplate:
           env:
           - name: BUILD_ID
@@ -321,6 +400,45 @@ spec:
         - default: gcr.io/kaniko-project/executor:latest
           description: The image on which builds will run
           name: BUILDER_IMAGE
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         results:
         - description: Digest of the image just built.
           name: IMAGE_DIGEST
@@ -443,6 +561,45 @@ spec:
         - default: gcr.io/kaniko-project/executor:latest
           description: The image on which builds will run
           name: BUILDER_IMAGE
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         results:
         - description: Digest of the image just built.
           name: IMAGE_DIGEST
@@ -560,6 +717,45 @@ spec:
           name: yamlPathToImage
         - description: The URL of the image to deploy
           name: imageURL
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         stepTemplate:
           env:
           - name: BUILD_ID
@@ -663,6 +859,45 @@ spec:
           name: yamlPathToImage
         - description: The URL of the image to deploy
           name: imageURL
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         stepTemplate:
           env:
           - name: BUILD_ID

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-missing-refs-fails/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-missing-refs-fails/source.yaml
@@ -1,0 +1,91 @@
+# This Pipeline Builds two microservice images(https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices)
+# from the Skaffold repo (https://github.com/GoogleContainerTools/skaffold) and deploys them to the repo currently running Tekton Pipelines.
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+  annotations:
+    lighthouse.jenkins-x.io/loadFileRefs: ".*"
+spec:
+  params:
+  - name: image-registry
+    default: gcr.io/christiewilson-catfactory
+  workspaces:
+  - name: git-source
+  tasks:
+  - name: fetch-from-git
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/GoogleContainerTools/skaffold
+    - name: revision
+      value: v0.32.0
+    workspaces:
+    - name: output
+      workspace: git-source
+  - name: skaffold-unit-tests
+    runAfter: [fetch-from-git]
+    taskRef:
+      name: unit-tests
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: build-skaffold-web
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: kaniko
+    params:
+    - name: IMAGE
+      value: $(params.image-registry)/leeroy-web
+    - name: CONTEXT
+      value: examples/microservices/leeroy-web
+    - name: DOCKERFILE
+      value: $(workspaces.source.path)/examples/microservices/leeroy-web/Dockerfile
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: build-skaffold-app
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: kaniko
+    params:
+    - name: IMAGE
+      value: $(params.image-registry)/leeroy-app
+    - name: CONTEXT
+      value: examples/microservices/leeroy-app
+    - name: DOCKERFILE
+      value: $(workspaces.source.path)/examples/microservices/leeroy-app/Dockerfile
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: deploy-app
+    taskRef:
+      name: demo-deploy-kubectl
+    params:
+    - name: imageURL
+      value: $(params.image-registry)/leeroy-app@$(tasks.build-skaffold-app.results.IMAGE_DIGEST)
+    - name: path
+      value: $(workspaces.source.path)/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+    workspaces:
+    - name: source
+      workspace: git-source
+  - name: deploy-web
+    taskRef:
+      name: demo-deploy-kubectl
+    params:
+    - name: imageURL
+      value: $(params.image-registry)/leeroy-web@$(tasks.build-skaffold-web.results.IMAGE_DIGEST)
+    - name: path
+      value: $(workspaces.source.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+    workspaces:
+    - name: source
+      workspace: git-source

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline/expected.yaml
@@ -8,6 +8,45 @@ spec:
     params:
     - default: gcr.io/christiewilson-catfactory
       name: image-registry
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
     tasks:
     - name: fetch-from-git
       params:
@@ -15,12 +54,65 @@ spec:
         value: https://github.com/GoogleContainerTools/skaffold
       - name: revision
         value: v0.32.0
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskRef:
         name: git-clone
       workspaces:
       - name: output
         workspace: git-source
     - name: skaffold-unit-tests
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - fetch-from-git
       taskRef:
@@ -36,6 +128,32 @@ spec:
         value: examples/microservices/leeroy-web
       - name: DOCKERFILE
         value: $(workspaces.source.path)/examples/microservices/leeroy-web/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - skaffold-unit-tests
       taskRef:
@@ -51,6 +169,32 @@ spec:
         value: examples/microservices/leeroy-app
       - name: DOCKERFILE
         value: $(workspaces.source.path)/examples/microservices/leeroy-app/Dockerfile
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       runAfter:
       - skaffold-unit-tests
       taskRef:
@@ -68,6 +212,32 @@ spec:
         value: -d1
       - name: yamlPathToImage
         value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskRef:
         name: demo-deploy-kubectl
       workspaces:
@@ -83,6 +253,32 @@ spec:
         value: -d1
       - name: yamlPathToImage
         value: spec.template.spec.containers[0].image
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskRef:
         name: demo-deploy-kubectl
       workspaces:

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pr-load-refs/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pr-load-refs/expected.yaml
@@ -19,6 +19,45 @@ spec:
       type: string
     - name: pl-param-y
       type: string
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
     tasks:
     - name: add-params
       params:
@@ -26,6 +65,32 @@ spec:
         value: $(params.pl-param-x)
       - name: b
         value: $(params.pl-param-y)
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskSpec:
         params:
         - description: The first integer
@@ -34,6 +99,36 @@ spec:
         - description: The second integer
           name: b
           type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - image: bash:latest
           name: sum

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pr-load-refs/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pr-load-refs/expected.yaml
@@ -99,6 +99,45 @@ spec:
         - description: The second integer
           name: b
           type: string
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
         stepTemplate:
           env:
           - name: BUILD_ID

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-append-steps/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-append-steps/expected.yaml
@@ -1,0 +1,170 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    lighthouse.jenkins-x.io/appendStepsURL: https://gist.githubusercontent.com/jstrachan/1937a809fd4223f3588db32cbb3a034f/raw/3bb56dd20cae2795e0ec4788d79e18d9486da9d9/sample-git-clone-task.yaml
+  creationTimestamp: null
+  name: cheese
+spec:
+  pipelineSpec:
+    params:
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: cheese
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - image: some/linter:1.2.3
+          name: lint
+          resources: {}
+          workingDir: /workspace/source
+        - image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+          name: git-clone
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            export SUBDIR="source"
+            echo "git cloning url: $REPO_URL version $PULL_PULL_SHA to dir: $SUBDIR"
+            git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+            git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
+            git config --global credential.helper store
+            git clone $REPO_URL $SUBDIR
+            cd $SUBDIR
+            git checkout $PULL_PULL_SHA
+            echo "checked out revision: $PULL_PULL_SHA to dir: $SUBDIR"
+          workingDir: /workspace
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-append-steps/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-append-steps/source.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cheese
+  annotations:
+    "lighthouse.jenkins-x.io/appendStepsURL": "https://gist.githubusercontent.com/jstrachan/1937a809fd4223f3588db32cbb3a034f/raw/3bb56dd20cae2795e0ec4788d79e18d9486da9d9/sample-git-clone-task.yaml"
+spec:
+  steps:
+    - image: some/linter:1.2.3
+      name: lint
+      workingDir: /workspace/source

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-prepend-steps/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-prepend-steps/expected.yaml
@@ -1,0 +1,170 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    lighthouse.jenkins-x.io/prependStepsURL: https://gist.githubusercontent.com/jstrachan/1937a809fd4223f3588db32cbb3a034f/raw/3bb56dd20cae2795e0ec4788d79e18d9486da9d9/sample-git-clone-task.yaml
+  creationTimestamp: null
+  name: cheese
+spec:
+  pipelineSpec:
+    params:
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: cheese
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+          name: git-clone
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            export SUBDIR="source"
+            echo "git cloning url: $REPO_URL version $PULL_PULL_SHA to dir: $SUBDIR"
+            git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+            git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
+            git config --global credential.helper store
+            git clone $REPO_URL $SUBDIR
+            cd $SUBDIR
+            git checkout $PULL_PULL_SHA
+            echo "checked out revision: $PULL_PULL_SHA to dir: $SUBDIR"
+          workingDir: /workspace
+        - image: some/linter:1.2.3
+          name: lint
+          resources: {}
+          workingDir: /workspace/source
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-prepend-steps/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-prepend-steps/source.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cheese
+  annotations:
+    "lighthouse.jenkins-x.io/prependStepsURL": "https://gist.githubusercontent.com/jstrachan/1937a809fd4223f3588db32cbb3a034f/raw/3bb56dd20cae2795e0ec4788d79e18d9486da9d9/sample-git-clone-task.yaml"
+spec:
+  steps:
+    - image: some/linter:1.2.3
+      name: lint
+      workingDir: /workspace/source

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-without-params/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-without-params/expected.yaml
@@ -2,11 +2,10 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   creationTimestamp: null
+  name: cheese
 spec:
   pipelineSpec:
     params:
-    - default: param-value
-      name: PARAM
     - description: the unique build number
       name: BUILD_ID
       type: string
@@ -47,9 +46,8 @@ spec:
       name: REPO_URL
       type: string
     tasks:
-    - params:
-      - name: PARAM
-        value: $(params.PARAM)
+    - name: cheese
+      params:
       - name: BUILD_ID
         value: $(params.BUILD_ID)
       - name: JOB_NAME
@@ -78,8 +76,6 @@ spec:
         value: $(params.REPO_URL)
       taskSpec:
         params:
-        - default: param-value
-          name: PARAM
         - description: the unique build number
           name: BUILD_ID
           type: string
@@ -148,86 +144,118 @@ spec:
           - name: REPO_URL
             value: $(params.REPO_URL)
           name: ""
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          volumeMounts:
+          - mountPath: /home/jenkins
+            name: workspace-volume
+          - mountPath: /etc/podinfo
+            name: podinfo
+            readOnly: true
+          workingDir: /workspace/source
         steps:
-        - image: ubuntu
-          name: noshebang
-          resources: {}
-          script: echo "no shebang"
-        - env:
-          - name: FOO
-            value: foooooooo
-          image: ubuntu
-          name: bash
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            set -euxo pipefail
-            echo "Hello from Bash!"
-            echo FOO is ${FOO}
-            echo substring is ${FOO:2:4}
-            for i in {1..10}; do
-              echo line $i
-            done
-        - image: ubuntu
-          name: place-file
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            echo "echo Hello from script file" > /workspace/hello
-            chmod +x /workspace/hello
-        - image: ubuntu
-          name: run-file
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            /workspace/hello
-        - image: ubuntu
-          name: contains-eof
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            cat > file << EOF
-            this file has some contents
-            EOF
-            cat file
-        - image: node
-          name: node
-          resources: {}
-          script: |
-            #!/usr/bin/env node
-            console.log("Hello from Node!")
-        - image: python
-          name: python
-          resources: {}
-          script: |
-            #!/usr/bin/env python3
-            print("Hello from Python!")
-        - image: perl
-          name: perl
-          resources: {}
-          script: |
-            #!/usr/bin/perl
-            print "Hello from Perl!"
-        - image: python
-          name: params-applied
-          resources: {}
-          script: |
-            #!/usr/bin/env python3
-            v = '$(params.PARAM)'
-            if v != 'param-value':
-              print('Param values not applied')
-              print('Got: ', v)
-              exit(1)
         - args:
-          - hello
-          - world
-          image: ubuntu
-          name: args-allowed
+          - -c
+          - 'mkdir -p $HOME; git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}; git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}; git config --global credential.helper store; git clone $(params.REPO_URL) $(params.subdirectory); echo cloned url: $(params.REPO_URL) to dir: $(params.subdirectory); cd $(params.subdirectory); git checkout $(params.PULL_PULL_SHA); echo checked out revision: $(params.PULL_PULL_SHA) to dir: $(params.subdirectory)'
+          command:
+          - /bin/sh
+          image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+          name: git-clone
           resources: {}
-          script: |-
-            #!/usr/bin/env bash
-            [[ $# == 2 ]]
-            [[ $1 == "hello" ]]
-            [[ $2 == "world" ]]
+          workingDir: /workspace
+        - args:
+          - gitops
+          - git
+          - setup
+          - --namespace
+          - jx-git-operator
+          command:
+          - jx
+          image: gcr.io/jenkinsxio/jx-cli:latest
+          name: git-setup
+          resources: {}
+          workingDir: /workspace
+        - args:
+          - '[ -d /builder/home ] || mkdir -p /builder && ln -s /tekton/home /builder/home'
+          command:
+          - /bin/sh
+          - -c
+          image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+          name: setup-builder-home
+          resources: {}
+        - args:
+          - step
+          - git
+          - merge
+          - --verbose
+          - --baseSHA
+          - $(params.PULL_BASE_SHA)
+          - --sha
+          - $(params.PULL_PULL_SHA)
+          - --baseBranch
+          - $(params.PULL_BASE_REF)
+          command:
+          - jx
+          image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+          name: git-merge
+          resources: {}
+        - args:
+          - gitops
+          - variables
+          command:
+          - jx
+          image: gcr.io/jenkinsxio/jx-cli:latest
+          name: jx-variables
+          resources: {}
+        - args:
+          - jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
+          command:
+          - /bin/sh
+          - -c
+          image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+          name: build-npmrc
+          resources: {}
+        - args:
+          - npm install
+          command:
+          - /bin/sh
+          - -c
+          image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+          name: build-npm-install
+          resources: {}
+        - args:
+          - CI=true DISPLAY=:99 npm test
+          command:
+          - /bin/sh
+          - -c
+          image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+          name: build-npm-test
+          resources: {}
+        - args:
+          - source .jx/variables.sh && cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json && /kaniko/executor $KANIKO_FLAGS --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION --cache-repo=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/cache
+          command:
+          - /busybox/sh
+          - -c
+          image: gcr.io/jenkinsxio/kaniko:0.0.5
+          name: build-container-build
+          resources: {}
+        - args:
+          - source /workspace/source/.jx/variables.sh && jx preview create
+          command:
+          - /bin/bash
+          - -c
+          image: gcr.io/jenkinsxio/jx-cli:latest
+          name: promote-jx-preview
+          resources: {}
+        volumes:
+        - emptyDir: {}
+          name: workspace-volume
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.labels
+              path: labels
+          name: podinfo
 status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-without-params/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task-without-params/source.yaml
@@ -1,0 +1,120 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cheese
+spec:
+  stepTemplate:
+    resources:
+      requests:
+        cpu: 400m
+        memory: 512Mi
+    volumeMounts:
+    - mountPath: /home/jenkins
+      name: workspace-volume
+    - mountPath: /etc/podinfo
+      name: podinfo
+      readOnly: true
+    workingDir: /workspace/source
+  steps:
+  - args:
+    - -c
+    - 'mkdir -p $HOME; git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}; git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}; git config --global credential.helper store; git clone $(params.REPO_URL) $(params.subdirectory); echo cloned url: $(params.REPO_URL) to dir: $(params.subdirectory); cd $(params.subdirectory); git checkout $(params.PULL_PULL_SHA); echo checked out revision: $(params.PULL_PULL_SHA) to dir: $(params.subdirectory)'
+    command:
+    - /bin/sh
+    image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+    name: git-clone
+    resources: {}
+    workingDir: /workspace
+  - args:
+    - gitops
+    - git
+    - setup
+    - --namespace
+    - jx-git-operator
+    command:
+    - jx
+    image: gcr.io/jenkinsxio/jx-cli:latest
+    name: git-setup
+    resources: {}
+    workingDir: /workspace
+  - args:
+    - '[ -d /builder/home ] || mkdir -p /builder && ln -s /tekton/home /builder/home'
+    command:
+    - /bin/sh
+    - -c
+    image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+    name: setup-builder-home
+    resources: {}
+  - args:
+    - step
+    - git
+    - merge
+    - --verbose
+    - --baseSHA
+    - $(params.PULL_BASE_SHA)
+    - --sha
+    - $(params.PULL_PULL_SHA)
+    - --baseBranch
+    - $(params.PULL_BASE_REF)
+    command:
+    - jx
+    image: gcr.io/jenkinsxio/builder-jx:2.1.142-761
+    name: git-merge
+    resources: {}
+  - args:
+    - gitops
+    - variables
+    command:
+    - jx
+    image: gcr.io/jenkinsxio/jx-cli:latest
+    name: jx-variables
+    resources: {}
+  - args:
+    - jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
+    command:
+    - /bin/sh
+    - -c
+    image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+    name: build-npmrc
+    resources: {}
+  - args:
+    - npm install
+    command:
+    - /bin/sh
+    - -c
+    image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+    name: build-npm-install
+    resources: {}
+  - args:
+    - CI=true DISPLAY=:99 npm test
+    command:
+    - /bin/sh
+    - -c
+    image: gcr.io/jenkinsxio/builder-nodejs:2.1.150-769
+    name: build-npm-test
+    resources: {}
+  - args:
+    - source .jx/variables.sh && cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json && /kaniko/executor $KANIKO_FLAGS --cache=true --cache-dir=/workspace --context=/workspace/source --dockerfile=/workspace/source/Dockerfile --destination=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION --cache-repo=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/cache
+    command:
+    - /busybox/sh
+    - -c
+    image: gcr.io/jenkinsxio/kaniko:0.0.5
+    name: build-container-build
+    resources: {}
+  - args:
+    - source /workspace/source/.jx/variables.sh && jx preview create
+    command:
+    - /bin/bash
+    - -c
+    image: gcr.io/jenkinsxio/jx-cli:latest
+    name: promote-jx-preview
+    resources: {}
+  volumes:
+  - emptyDir: {}
+    name: workspace-volume
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: podinfo

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/task/expected.yaml
@@ -4,35 +4,6 @@ metadata:
   creationTimestamp: null
   name: cheese
 spec:
-  params:
-  - name: REPO_URL
-    value: $(params.REPO_URL)
-  - name: PULL_PULL_SHA
-    value: $(params.PULL_PULL_SHA)
-  - name: subdirectory
-    value: $(params.subdirectory)
-  - name: BUILD_ID
-    value: $(params.BUILD_ID)
-  - name: JOB_NAME
-    value: $(params.JOB_NAME)
-  - name: JOB_SPEC
-    value: $(params.JOB_SPEC)
-  - name: JOB_TYPE
-    value: $(params.JOB_TYPE)
-  - name: PULL_BASE_REF
-    value: $(params.PULL_BASE_REF)
-  - name: PULL_BASE_SHA
-    value: $(params.PULL_BASE_SHA)
-  - name: PULL_NUMBER
-    value: $(params.PULL_NUMBER)
-  - name: PULL_PULL_REF
-    value: $(params.PULL_PULL_REF)
-  - name: PULL_REFS
-    value: $(params.PULL_REFS)
-  - name: REPO_NAME
-    value: $(params.REPO_NAME)
-  - name: REPO_OWNER
-    value: $(params.REPO_OWNER)
   pipelineSpec:
     params:
     - description: git url to clone

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/taskrun/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/taskrun/expected.yaml
@@ -7,14 +7,109 @@ spec:
     params:
     - default: param-value
       name: PARAM
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
     tasks:
     - params:
       - name: PARAM
         value: $(params.PARAM)
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
       taskSpec:
         params:
         - default: param-value
           name: PARAM
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
         steps:
         - image: ubuntu
           name: noshebang

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/taskrun/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/taskrun/expected.yaml
@@ -3,9 +3,6 @@ kind: PipelineRun
 metadata:
   creationTimestamp: null
 spec:
-  params:
-  - name: PARAM
-    value: $(params.PARAM)
   pipelineSpec:
     params:
     - default: param-value


### PR DESCRIPTION
we should not default `$(params.FOO)` values for `PipelineRun.Spec.Params` since those expressions only make sense inside a Pipeline/Task and the values are usually specified via `pipeline_run_params` or by Lighthouse when it defaults parameters like REPO_URL and so forth

fixes https://github.com/jenkins-x/lighthouse/issues/1122

there's really no need to copy/paste the 150 lines of YAML for all the common lighthouse based parameters that get injected...
https://github.com/jenkins-x/jx3-pipeline-catalog/blob/master/packs/go-plugin/.lighthouse/jenkins-x/release.yaml#L9-L159

we can just enrich the `PipelineRun` and add them in if they are not already there