### PR TITLE
fix: fix for OpenShift 4.x

### DIFF
--- a/pkg/engines/tekton/controller.go
+++ b/pkg/engines/tekton/controller.go
@@ -115,6 +115,15 @@ func (r *LighthouseJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 				r.logger.Errorf("Failed to set owner reference: %s", err)
 				return ctrl.Result{}, err
 			}
+
+			// lets disable the blockOwnerDeletion as it fails on OpenShift
+			for i := range pipelineRun.OwnerReferences {
+				ref := &pipelineRun.OwnerReferences[i]
+				if ref.Kind == "LighthouseJob" && ref.BlockOwnerDeletion != nil {
+					ref.BlockOwnerDeletion = nil
+				}
+			}
+
 			// TODO: changing the status should be a consequence of a pipeline run being created
 			// update status
 			job.Status = lighthousev1alpha1.LighthouseJobStatus{

--- a/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-batch-pullrequest/expected-pr.yml
@@ -23,7 +23,6 @@ metadata:
       kind: LighthouseJob
       name: f46327af-b47e-11ea-b797-9256b7b8d9b0
       Controller: true
-      BlockOwnerDeletion: true
 spec:
   params:
     - name: BUILD_ID

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
@@ -23,7 +23,6 @@ metadata:
       kind: LighthouseJob
       name: f46327af-b47e-11ea-b797-9256b7b8d9b0
       Controller: true
-      BlockOwnerDeletion: true
 spec:
   params:
     - name: BUILD_ID

--- a/pkg/engines/tekton/test_data/controller/start-push/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-push/expected-pr.yml
@@ -22,7 +22,6 @@ metadata:
       kind: LighthouseJob
       name: f46327af-b47e-11ea-b797-9256b7b8d9b0
       Controller: true
-      BlockOwnerDeletion: true
 spec:
   params:
     - name: BUILD_ID


### PR DESCRIPTION
avoid setting `blockOwnerDeletion: true` on the `PipelineRun` to avoid failing on OpenShift 4.x

fixes #1143