### PR TITLE
fix: add retry handler to updating lighthousejobs

### DIFF
--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -37,8 +37,8 @@ func (s *seededRandIDGenerator) GenerateBuildID() string {
 }
 func TestReconcile(t *testing.T) {
 	testCases := []string{
-		"start-pullrequest",
 		"update-job",
+		"start-pullrequest",
 		"start-batch-pullrequest",
 		"start-push",
 	}

--- a/pkg/engines/tekton/test_data/controller/update-job/observed-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/update-job/observed-lhjob.yml
@@ -16,7 +16,7 @@ metadata:
     lighthouse.jenkins-x.io/type: presubmit
   name: f46327af-b47e-11ea-b797-9256b7b8d9b0
   namespace: jx
-  resourceVersion: "2"
+  resourceVersion: "3"
 spec:
   agent: tekton-pipeline
   context: github


### PR DESCRIPTION
we've seen some failures + some pipelines not started due to update errors so lets add a retry loop