### PR TITLE
chore: lets only create the jenkins controller secret when the jenkins engine is enabled like the other jenkins specific k8s resources

### DIFF
--- a/charts/lighthouse/templates/jenkins-controller-secret.yaml
+++ b/charts/lighthouse/templates/jenkins-controller-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.engines.jenkins }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:  
   token: {{ default "" .Values.jenkinscontroller.jenkinsToken | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
fixes https://github.com/jenkins-x/lighthouse/issues/1150