### PR TITLE
fix(chart): foghorn is missing the HMAC token

### DIFF
--- a/charts/lighthouse/templates/foghorn-deployment.yaml
+++ b/charts/lighthouse/templates/foghorn-deployment.yaml
@@ -46,6 +46,11 @@ spec:
                 name: lighthouse-oauth-token
                 key: oauth
 {{- end }}
+          - name: "HMAC_TOKEN"
+            valueFrom:
+              secretKeyRef:
+                name: "lighthouse-hmac-token"
+                key: hmac
           - name: "JX_LOG_FORMAT"
             value: "{{ .Values.logFormat }}"
           - name: "LOGRUS_FORMAT"


### PR DESCRIPTION
which results in activity records events sent to external plugin not being signed with the right token