### PR TITLE
fix: race condition that call reChanges with nil regex

### DIFF
--- a/pkg/config/job/regexpchangematcher.go
+++ b/pkg/config/job/regexpchangematcher.go
@@ -70,6 +70,7 @@ func (cm RegexpChangeMatcher) SetChangeRegexes() (RegexpChangeMatcher, error) {
 	return cm, nil
 }
 
+// GetRE lazily creates the regex
 func (cm RegexpChangeMatcher) GetRE() *regexp.Regexp {
 	if cm.reChanges == nil {
 		cm2, _ := cm.SetChangeRegexes()

--- a/pkg/config/job/regexpchangematcher.go
+++ b/pkg/config/job/regexpchangematcher.go
@@ -51,7 +51,7 @@ func (cm RegexpChangeMatcher) ShouldRun(changes ChangedFilesProvider) (determine
 // RunsAgainstChanges returns true if any of the changed input paths match the run_if_changed regex.
 func (cm RegexpChangeMatcher) RunsAgainstChanges(changes []string) bool {
 	for _, change := range changes {
-		if cm.reChanges.MatchString(change) {
+		if cm.GetRE().MatchString(change) {
 			return true
 		}
 	}
@@ -68,4 +68,12 @@ func (cm RegexpChangeMatcher) SetChangeRegexes() (RegexpChangeMatcher, error) {
 		cm.reChanges = re
 	}
 	return cm, nil
+}
+
+func (cm RegexpChangeMatcher) GetRE() *regexp.Regexp {
+	if cm.reChanges == nil {
+		cm2, _ := cm.SetChangeRegexes()
+		return cm2.reChanges
+	}
+	return cm.reChanges
 }


### PR DESCRIPTION
What:
when using `run_if_changed`  it always crashes
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x90 pc=0x758982]
[running]:
 regexp.(*Regexp).doExecute(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc000519c20, 0
x1d, 0x0, 0x0, ...)
         /usr/local/go/src/regexp/exec.go:527 +0x562
 regexp.(*Regexp).doMatch(...)
         /usr/local/go/src/regexp/exec.go:514
 regexp.(*Regexp).MatchString(...)
         /usr/local/go/src/regexp/regexp.go:507
 github.com/jenkins-x/lighthouse/pkg/config/job.RegexpChangeMatcher.RunsAgainstChanges(0xc0008641c0, 0x12, 0x0, 0xc000341680, 0x8, 0x8, 0x0)
```
How
adds function GetRE and call MatchString via it

Why 
to make sure that regex is not nil when calling MatchString