### PR TITLE
fix: expose prometheus metrics

### DIFF
--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -17,6 +17,8 @@ const (
 	HealthPath = "/Health"
 	// ReadyPath URL path for the HTTP endpoint that returns Ready status.
 	ReadyPath = "/Ready"
+	// MetricsPath URL path for the HTTP endpoint that returns Prometheus metrics.
+	MetricsPath = "/Metrics"
 )
 
 type options struct {
@@ -81,6 +83,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle(HealthPath, http.HandlerFunc(controller.Health))
 	mux.Handle(ReadyPath, http.HandlerFunc(controller.Ready))
+	mux.Handle(MetricsPath, http.HandlerFunc(controller.Metrics))
 
 	mux.Handle("/", http.HandlerFunc(controller.DefaultHandler))
 	mux.Handle(o.path, http.HandlerFunc(controller.HandleWebhookRequests))

--- a/pkg/webhook/metrics.go
+++ b/pkg/webhook/metrics.go
@@ -25,7 +25,7 @@ var (
 	// Define all metrics for webhooks here.
 	webhookCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "lighthouse_webhook_counter",
-		Help: "A counter of the webhooks made to prow.",
+		Help: "A counter of the webhooks made to lighthouse.",
 	}, []string{"event_type"})
 	responseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "lighthouse_webhook_response_codes",

--- a/pkg/webhook/metrics.go
+++ b/pkg/webhook/metrics.go
@@ -18,24 +18,20 @@ package webhook
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
 	// Define all metrics for webhooks here.
-	webhookCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "prow_webhook_counter",
+	webhookCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "lighthouse_webhook_counter",
 		Help: "A counter of the webhooks made to prow.",
 	}, []string{"event_type"})
-	responseCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "prow_webhook_response_codes",
+	responseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "lighthouse_webhook_response_codes",
 		Help: "A counter of the different responses hook has responded to webhooks with.",
 	}, []string{"response_code"})
 )
-
-func init() {
-	prometheus.MustRegister(webhookCounter)
-	prometheus.MustRegister(responseCounter)
-}
 
 // Metrics is a set of metrics gathered by hook.
 type Metrics struct {


### PR DESCRIPTION
for webhook counts per event kind so its easier to know if lighthouse has been setup correctly and webhooks are being received

I've used`/Metrics` as the endpoint to follow the naming convention with `/Health` and `/Ready`