### PR TITLE
fix: file browser couldn't read serverUrl

### DIFF
--- a/pkg/triggerconfig/inrepo/calculate.go
+++ b/pkg/triggerconfig/inrepo/calculate.go
@@ -38,11 +38,7 @@ func Generate(fileBrowser filebrowser.Interface, sharedConfig *config.Config, sh
 	}
 
 	for _, ref := range refs {
-		repoConfig, err := LoadTriggerConfig(fileBrowser, owner, repo, ref)
-		if err != nil {
-			return sharedConfig, sharedPlugins, errors.Wrapf(err, "failed to create trigger config from local source for repo %s/%s ref %s", owner, repo, ref)
-		}
-
+		repoConfig, _ := LoadTriggerConfig(fileBrowser, owner, repo, ref)
 		if repoConfig != nil {
 			err = merge.ConfigMerge(&cfg, &pluginCfg, repoConfig, owner, repo)
 			if err != nil {
@@ -50,5 +46,5 @@ func Generate(fileBrowser filebrowser.Interface, sharedConfig *config.Config, sh
 			}
 		}
 	}
-	return &cfg, &pluginCfg, nil
+	return &cfg, &pluginCfg, errors.Wrapf(err, "failed to create trigger config from local source for repo %s/%s ref %s", owner, repo, eventRef)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -58,7 +58,6 @@ func NewWebhooksController(path, namespace, botName, pluginFilename, configFilen
 	}
 
 	cfg := o.server.ConfigAgent.Config
-	o.gitServerURL = util.GetGitServer(cfg)
 	gitClient, err := git.NewClient(o.gitServerURL, util.GitKind(cfg))
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting git client.")
@@ -423,6 +422,7 @@ func (o *WebhooksController) createHookServer() (*Server, error) {
 		logrus.Warn("no configAgent configuration")
 	}
 
+	o.gitServerURL = util.GetGitServer(configAgent.Config)
 	serverURL, err := url.Parse(o.gitServerURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse server URL %s", o.gitServerURL)


### PR DESCRIPTION
file browser couldn't read serverUrl
allow fallback to current ref when main branch doesn't have triggers