### PR TITLE
fix: Typo fixed '7Path' to 'Path' in cli args help

### DIFF
--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -44,7 +44,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.path, "path", "/hook",
 		"The path to listen on for requests to trigger a pipeline run.")
 	fs.StringVar(&o.pluginFilename, "plugin-file", "", "Path to the plugins.yaml file. If not specified it is loaded from the 'plugins' ConfigMap")
-	fs.StringVar(&o.configFilename, "config-file", "", "7Path to the config.yaml file. If not specified it is loaded from the 'config' ConfigMap")
+	fs.StringVar(&o.configFilename, "config-file", "", "Path to the config.yaml file. If not specified it is loaded from the 'config' ConfigMap")
 	fs.StringVar(&o.botName, "bot-name", "", "The name of the bot user to run as. Defaults to $GIT_USER if not specified.")
 	fs.StringVar(&o.namespace, "namespace", "", "The namespace to listen in")
 


### PR DESCRIPTION
Typo fixed '7Path' to 'Path'