### PR TITLE
fix: build pull request broken when run_if_changed is set

### DIFF
--- a/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/master/.lighthouse/triggers/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/master/.lighthouse/triggers/triggers.yaml
@@ -4,10 +4,10 @@ spec:
   presubmits:
   - name: lint
     context: "lint"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/lint"
-    rerunCommand: "/relint"
+    trigger: "(?:/lint|/relint)"
+    rerun_command: "/relint"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/mybranch/.lighthouse/triggers/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/branchtest/refs/mybranch/.lighthouse/triggers/triggers.yaml
@@ -4,17 +4,17 @@ spec:
   presubmits:
   - name: lint
     context: "lint"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/lint"
-    rerunCommand: "/relint"
+    trigger: "(?:/lint|/relint)"
+    rerun_command: "/relint"
     agent: tekton-pipeline
   - name: newthingy
     context: "newthingy"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/newthingy"
-    rerunCommand: "/renewthingy"
+    trigger: "(?:/newthingy|/renewthingy)"
+    rerun_command: "/renewthingy"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-postsubmit/.lighthouse/duplicate-lint/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-postsubmit/.lighthouse/duplicate-lint/triggers.yaml
@@ -4,10 +4,10 @@ spec:
   presubmits:
   - name: lint
     context: "test"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/test"
-    rerunCommand: "/retest"
+    trigger: "(?:/test|/retest)"
+    rerun_command: "/retest"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-postsubmit/.lighthouse/linter/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-postsubmit/.lighthouse/linter/triggers.yaml
@@ -4,10 +4,10 @@ spec:
   presubmits:
   - name: test
     context: "test"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/test"
-    rerunCommand: "/retest"
+    trigger: "(?:/test|/retest)"
+    rerun_command: "/retest"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-presubmit/.lighthouse/duplicate-lint/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-presubmit/.lighthouse/duplicate-lint/triggers.yaml
@@ -4,10 +4,10 @@ spec:
   presubmits:
   - name: lint
     context: "test"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/test"
-    rerunCommand: "/retest"
+    trigger: "(?:/test|/retest)"
+    rerun_command: "/retest"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-presubmit/.lighthouse/linter/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/duplicate-presubmit/.lighthouse/linter/triggers.yaml
@@ -4,9 +4,9 @@ spec:
   presubmits:
   - name: lint
     context: "lint"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/lint"
-    rerunCommand: "/relint"
+    trigger: "(?:/lint|/relint)"
+    rerun_command: "/relint"
     agent: tekton-pipeline
 

--- a/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/jenkins-x/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/jenkins-x/triggers.yaml
@@ -4,10 +4,10 @@ spec:
   presubmits:
   - name: test
     context: "test"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/test"
-    rerunCommand: "/retest"
+    trigger: "(?:/test|/retest)"
+    rerun_command: "/retest"
     agent: tekton-pipeline
   postsubmits:
   - name: release

--- a/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/linter/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/linter/triggers.yaml
@@ -4,9 +4,9 @@ spec:
   presubmits:
   - name: lint
     context: "lint"
-    alwaysRun: true
+    always_run: true
     optional: false
-    trigger: "/lint"
-    rerunCommand: "/relint"
+    trigger: "(?:/lint|/relint)"
+    rerun_command: "/relint"
     agent: tekton-pipeline
 

--- a/pkg/triggerconfig/inrepo/test_data/myorg/myrepo/.lighthouse/jenkins-x/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/myrepo/.lighthouse/jenkins-x/triggers.yaml
@@ -6,7 +6,7 @@ spec:
     context: "test"
     always_run: true
     optional: false
-    trigger: "/test"
+    trigger: "(?:/test|/retest)"
     rerun_command: "/retest"
     source: "test.yaml"
     pipeline_run_params:

--- a/pkg/triggerconfig/inrepo/test_data/myorg/myrepo/.lighthouse/linter/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/myrepo/.lighthouse/linter/triggers.yaml
@@ -6,7 +6,7 @@ spec:
     context: "lint"
     always_run: true
     optional: false
-    trigger: "/lint"
+    trigger: "(?:/lint|/relint)"
     rerun_command: "/relint"
     source: "lint.yaml"
   branchProtection:

--- a/pkg/triggerconfig/merge/merge.go
+++ b/pkg/triggerconfig/merge/merge.go
@@ -80,6 +80,10 @@ func ConfigMerge(cfg *config.Config, pluginsCfg *plugins.Configuration, repoConf
 	if err != nil {
 		return errors.Wrapf(err, "failed to validate plugins")
 	}
+	err = cfg.Init(cfg.ProwConfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize config")
+	}
 	err = cfg.Validate(cfg.ProwConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to validate config")

--- a/pkg/triggerconfig/merge/merge_test.go
+++ b/pkg/triggerconfig/merge/merge_test.go
@@ -36,7 +36,7 @@ func TestMergeTriggerConfig(t *testing.T) {
 							},
 							AlwaysRun:    true,
 							Optional:     false,
-							Trigger:      "/lint",
+							Trigger:      "(?:/lint|/relint)",
 							RerunCommand: "/relint",
 							Reporter: job.Reporter{
 								Context: "lint",

--- a/pkg/triggerconfig/merge/test_data/simple/expected-config.yaml
+++ b/pkg/triggerconfig/merge/test_data/simple/expected-config.yaml
@@ -6,16 +6,20 @@ plank: {}
 postsubmits:
   myorg/myowner:
   - agent: tekton-pipeline
+    cluster: default
     context: release
     name: release
+    namespace: ""
 presubmits:
   myorg/myowner:
   - agent: tekton-pipeline
     always_run: true
+    cluster: default
     context: lint
     name: lint
+    namespace: ""
     rerun_command: /relint
-    trigger: /lint
+    trigger: (?:/lint|/relint)
 push_gateway:
   serve_metrics: false
 tide:

--- a/pkg/triggerconfig/merge/test_data/simple/triggers.yaml
+++ b/pkg/triggerconfig/merge/test_data/simple/triggers.yaml
@@ -6,7 +6,7 @@ spec:
     context: "lint"
     always_run: true
     optional: false
-    trigger: "/lint"
+    trigger: "(?:/lint|/relint)"
     rerun_command: "/relint"
     agent: tekton-pipeline
   postsubmits:


### PR DESCRIPTION
The problem found when user specified `run_if_changed` in triggers.yaml. It can make lighthouse crash with nil pointer dereference panic because `run_if_changed` required to compile regular expression before use it. The workaround for this problem fixed in https://github.com/jenkins-x/lighthouse/commit/ff0c2cb55ba0b184a4059fe5f0877a2a33f2f3de. After dig down into the problem, I found that configuration doesn't initialize before validate (ref this function call https://github.com/wingyplus/lighthouse/blob/25e654ab141d8280b97c4aa9c7e9279a0d35fe12/pkg/triggerconfig/merge/merge.go#L87). So try fix it by add `cfg.Init` before `cfg.Validate` calls. 

After adding Init function calls. I found that tests was fail due to `rerun_command` doesn't be the subset of `trigger` and field name is incorrect, such as `rerunCommand` (should be `rerun_command`) or `alwaysRun`( should be `always_run`). This changes correct the field name and add `retest` rerun_command to be the subset of `trigger` to make tests pass.