### PR TITLE
fix: upgrade gitea client fix get combined status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ jenkins-values.yaml
 
 #OSX system files.
 **/.DS_Store
+.history

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/jenkins-x/lighthouse
 
 require (
+	code.gitea.io/sdk/gitea v0.13.1-0.20201217044651-7ddbf1a0151e // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/bwmarrin/snowflake v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.6.0 h1:UDpwYIwla4jHGzZJaEJYx1tOejbgSoNqsAfHAUYe2r
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 code.gitea.io/sdk/gitea v0.13.0 h1:iHognp8ZMhMFLooUUNZFpm8IHaC9qoHJDvAE5vTm5aw=
 code.gitea.io/sdk/gitea v0.13.0/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUrR6JDY=
+code.gitea.io/sdk/gitea v0.13.1-0.20201217044651-7ddbf1a0151e h1:b9kfpt/mPttLy1szZhI2ZqL6FV8DKTXtwHvjyydHQRs=
+code.gitea.io/sdk/gitea v0.13.1-0.20201217044651-7ddbf1a0151e/go.mod h1:89WiyOX1KEcvjP66sRHdu0RafojGo60bT9UqW17VbWs=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0/go.mod h1:ImxhfLRpxoYiSq891pBrLVhN+qmP8BTVvdH2YLs7Gl0=
@@ -571,6 +573,8 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=


### PR DESCRIPTION
The gitea client prior to this upgrade uses `/repos/%s/%s/commits/%s/status` which results in an error in lighthouse keeper

```
lighthouse-keeper-69969c4cff-98j8v lighthouse-keeper {"component":"keeper","controller":"status-update","error":"failed to get the combined status: unexpected end of JSON input","file":"/workspace/source/pkg/keeper/status.go:326","func":"github.com/jenkins-x/lighthouse/pkg/keeper.(*statusController).setStatuses.func1","level":"error","msg":"Getting head commit status contexts, skipping...","org":"coders","pr":1,"repo":"jx3-cluster-repo","sha":"83ab6c85f6953abb9995cc09c0081b46ad007e93","time":"2020-12-30T11:10:39Z"}
```

This is because the server is expecting the url to be `/repos/%s/%s/commits/%s/statuses` 

