### PR TITLE
fix: convert old incorrect configuration

### DIFF
--- a/pkg/triggerconfig/inrepo/load_integration_test.go
+++ b/pkg/triggerconfig/inrepo/load_integration_test.go
@@ -49,7 +49,7 @@ func LogConfig(t *testing.T, cfg *config.Config) {
 		t.Logf("presubmits for repository %s\n", k)
 
 		for _, r := range v {
-			t.Logf("  presubmit %s\n", r.Name)
+			t.Logf("  presubmit %s trigger: %s rerun_command: %s\n", r.Name, r.Trigger, r.RerunCommand)
 		}
 	}
 	for k, v := range cfg.Postsubmits {

--- a/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/jenkins-x/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/jenkins-x/triggers.yaml
@@ -6,7 +6,7 @@ spec:
     context: "test"
     always_run: true
     optional: false
-    trigger: "(?:/test|/retest)"
+    trigger: "/test"
     rerun_command: "/retest"
     agent: tekton-pipeline
   postsubmits:

--- a/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/linter/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/loadtest/.lighthouse/linter/triggers.yaml
@@ -6,7 +6,7 @@ spec:
     context: "lint"
     always_run: true
     optional: false
-    trigger: "(?:/lint|/relint)"
+    trigger: "/lint"
     rerun_command: "/relint"
     agent: tekton-pipeline
 


### PR DESCRIPTION
lots of in-repo triggers have incorrectly used `/test` and `/retest` and `/lint` and `/relint` for `trigger` and `rerun_command` due to the bug where we didn't used to properly validate JobConfig for in repo.

to make it easy to transition to the latest lighthouse lets add a little migrator function to switch those bad configurations to their correct values so that lighthouse still works if its upgraded for existing triggers in Jenkins X