### PR TITLE
feat: add multi-prepend/append for task

### DIFF
--- a/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
@@ -67,3 +67,46 @@ func TestLoadPipelineRunTest(t *testing.T) {
 		assert.Equal(t, expectedText, text, "PipelineRun loaded for "+message)
 	}
 }
+
+func TestGetAnnotationsSortedSimple(t *testing.T) {
+	m := map[string]string{"lighthouse.jenkins-x.io/prependStepsURL": "a"}
+	res := getAnnotationsSorted(PrependStepURL, m)
+
+	assert.Equal(t, res, []string{"a"})
+}
+
+func TestGetAnnotationsSortedNumbered(t *testing.T) {
+	m := map[string]string{
+		"lighthouse.jenkins-x.io/prependStepsURL-1": "1",
+		"lighthouse.jenkins-x.io/prependStepsURL-2": "2",
+		"lighthouse.jenkins-x.io/prependStepsURL-3": "3",
+		"other-ano": "ano",
+	}
+	res := getAnnotationsSorted(PrependStepURL, m)
+
+	assert.Equal(t, res, []string{"3", "2", "1"})
+}
+
+func TestGetAnnotationsSortedMixed(t *testing.T) {
+	m := map[string]string{
+		"lighthouse.jenkins-x.io/prependStepsURL-a": "a",
+		"lighthouse.jenkins-x.io/prependStepsURL-1": "1",
+		"lighthouse.jenkins-x.io/prependStepsURL":   "",
+		"other-ano": "ano",
+	}
+	res := getAnnotationsSorted(PrependStepURL, m)
+
+	assert.Equal(t, res, []string{"a", "1", ""})
+}
+
+func TestGetAnnotationsSortedMixedStable(t *testing.T) {
+	m := map[string]string{
+		"lighthouse.jenkins-x.io/prependStepsURL":   "",
+		"lighthouse.jenkins-x.io/prependStepsURL-a": "a",
+		"lighthouse.jenkins-x.io/prependStepsURL-1": "1",
+		"other-ano": "ano",
+	}
+	res := getAnnotationsSorted(PrependStepURL, m)
+
+	assert.Equal(t, res, []string{"a", "1", ""})
+}


### PR DESCRIPTION
This PR expands functionality of prepend/appends tasks by allowing to add suffix to the prependsteps suffixes are then prepended in lexicographical order:
```yaml
annotations:
  lighthouse.jenkins-x.io/prependStepsURL-1: "url-1"
  lighthouse.jenkins-x.io/prependStepsURL-2: "url-2"
spec:
  taskA
```
Will result in appending multiple steps to the task:
```
url-1
url-2
taskA
```

This can be used to combine multiple steps e.g git-clone, test, build, push chart.
The changes keeps support of the current format