### PR TITLE
fix: get annotations as from jobutil.LabelsAndAnnotations

### DIFF
--- a/pkg/jobutil/jobutil.go
+++ b/pkg/jobutil/jobutil.go
@@ -298,7 +298,12 @@ func LabelsAndAnnotationsForJob(lj v1alpha1.LighthouseJob, buildID string) (map[
 	if buildID != "" {
 		extraLabels[util.BuildNumLabel] = buildID
 	}
-	return LabelsAndAnnotationsForSpec(lj.Spec, extraLabels, nil)
+
+	var extraAnnotations map[string]string
+	if extraAnnotations = lj.ObjectMeta.Annotations; extraAnnotations == nil {
+		extraAnnotations = map[string]string{}
+	}
+	return LabelsAndAnnotationsForSpec(lj.Spec, extraLabels, extraAnnotations)
 }
 
 // PartitionActive separates the provided prowjobs into pending and triggered


### PR DESCRIPTION
Trying to fix #1210

Not sure if this is all that's needed. Oddly there already seems to be tests that check for extra annotations. I'm guessing because this is a util function that isn't used in the test, but I'm not familiar enough with go to know how to check the coverage.

Signed-off-by: Patrick Lee Scott <pat@patscott.io>