### PR TITLE
fix: add support multiple git servers in uses:sourceURI

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -50,10 +50,11 @@ That is a good approach for referencing a versioned `Task` / `Pipeline` / `Pipel
 
 The source URI syntax we use is:
         
-* treat it as a URL if it can be parsed as a URL (e.g. it contains `https://` or `http://`)
+* treat it as a URL if it contains `://` 
 * if the string contains `@` then it's a git URI of the form: `owner/repository/pathToFile@versionBranchOrSha`
+  * the repository is assumed to live on `github.com` like GitHub Actions. If you wish to use your local repository prefix the sourceURI with the server name. e.g.  `lighthouse:owner/repository/pathToFile@versionBranchOrSha` will reference a git repository in the current lighthouse git repository instead of github.com
   * you can use `@HEAD` to mean the latest version from the main branch
-  * you can use `@versionStream` to mean the git SHA of this git repository configured inside your version stream if available; otherwise it defaults to `@HEAD`  
+  * you can use `@versionStream` to mean the git SHA of this git repository configured inside your version stream if available; otherwise it defaults to `@HEAD`
 * otherwise assume the path is a local relative file in git
 
 

--- a/pkg/filebrowser/file_browsers.go
+++ b/pkg/filebrowser/file_browsers.go
@@ -1,0 +1,90 @@
+package filebrowser
+
+import (
+	"github.com/jenkins-x/lighthouse/pkg/git/v2"
+	"github.com/pkg/errors"
+	"os"
+	"strings"
+)
+
+const (
+	// GitHub the name used in a Uses Git URI to reference a git server
+	GitHub = "github"
+
+	// Lighthouse the name used in a Uses Git URI to reference the git server lighthouse is configured to run against
+	Lighthouse = "lighthouse"
+
+	// GitHubURL the github server URL
+	GitHubURL = "https://github.com"
+)
+
+// FileBrowsers contains the file browsers for the supported git servers
+type FileBrowsers struct {
+	cache map[string]Interface
+}
+
+// NewFileBrowsers creates a new file browsers service for the lighthouse git server URL and file browser
+// if the current server URL is not github.com then creates a second file browser so that we can use the uses: Git URI
+// syntax for accessing github resources as well as to access the lighthouse git server too
+func NewFileBrowsers(serverURL string, fb Interface) (*FileBrowsers, error) {
+	if serverURL == "" {
+		serverURL = GitHubURL
+	}
+	isGitHub := strings.TrimSuffix(serverURL, "/") == GitHubURL
+
+	answer := &FileBrowsers{
+		cache: map[string]Interface{
+			Lighthouse: fb,
+		},
+	}
+
+	// lets see if we have a custom server name we want to support
+	serverName := os.Getenv("GIT_NAME")
+	if serverName != "" && serverName != GitHub {
+		answer.cache[serverName] = fb
+	}
+	var githubBrowser Interface
+	if isGitHub {
+		githubBrowser = fb
+	} else {
+		// lets create a github browser\
+		configureOpts := func(opts *git.ClientFactoryOpts) {
+			opts.Token = func() []byte {
+				return []byte(os.Getenv("GITHUB_TOKEN"))
+			}
+			opts.GitUser = func() (name, email string, err error) {
+				name = os.Getenv("GITHUB_USER_NAME")
+				email = os.Getenv("GITHUB_USER_EMAIL")
+				return
+			}
+			opts.Username = func() (login string, err error) {
+				login = os.Getenv("GITHUB_USER")
+				return
+			}
+			opts.Host = "github.com"
+			opts.Scheme = "https"
+		}
+		githubFactory, err := git.NewClientFactory(configureOpts)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create git client factory for github")
+		}
+		githubBrowser = NewFileBrowserFromGitClient(githubFactory)
+	}
+	answer.cache[GitHub] = githubBrowser
+	return answer, nil
+}
+
+// GitHubFileBrowser returns a git file browser for github.com
+func (f *FileBrowsers) GitHubFileBrowser() Interface {
+	return f.GetFileBrowser(GitHub)
+}
+
+// LighthouseGitFileBrowser returns the git file browser for the git server that lighthouse is configured against
+func (f *FileBrowsers) LighthouseGitFileBrowser() Interface {
+	return f.GetFileBrowser(Lighthouse)
+}
+
+// GetFileBrowser returns the file browser for the given git server name.
+func (f *FileBrowsers) GetFileBrowser(name string) Interface {
+	return f.cache[name]
+}

--- a/pkg/filebrowser/file_browsers.go
+++ b/pkg/filebrowser/file_browsers.go
@@ -1,10 +1,11 @@
 package filebrowser
 
 import (
-	"github.com/jenkins-x/lighthouse/pkg/git/v2"
-	"github.com/pkg/errors"
 	"os"
 	"strings"
+
+	"github.com/jenkins-x/lighthouse/pkg/git/v2"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/filebrowser/file_browsers_test.go
+++ b/pkg/filebrowser/file_browsers_test.go
@@ -1,0 +1,38 @@
+package filebrowser_test
+
+import (
+	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
+	"github.com/jenkins-x/lighthouse/pkg/git/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFileBrowsers(t *testing.T) {
+	cf, err := git.NewClientFactory()
+	require.NoError(t, err, "failed to create git client factory")
+
+	testCases := []struct {
+		serverURL string
+	}{
+		{
+			serverURL: "https://something.com",
+		},
+		{
+			serverURL: "https://github.com",
+		},
+		{
+			serverURL: "http://gitlab.something.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		fb, err := filebrowser.NewFileBrowsers(tc.serverURL, filebrowser.NewFileBrowserFromGitClient(cf))
+		require.NoError(t, err, "failed to create file browser for  %s", tc.serverURL)
+		require.NotNil(t, fb.LighthouseGitFileBrowser(), "failed to get default file browser for server %s", tc.serverURL)
+
+		names := []string{filebrowser.Lighthouse, filebrowser.GitHub}
+		for _, name := range names {
+			require.NotNil(t, fb.GetFileBrowser(name), "failed to get file browser for server name %s", name)
+		}
+	}
+}

--- a/pkg/filebrowser/file_browsers_test.go
+++ b/pkg/filebrowser/file_browsers_test.go
@@ -1,10 +1,11 @@
 package filebrowser_test
 
 import (
+	"testing"
+
 	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
 	"github.com/jenkins-x/lighthouse/pkg/git/v2"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestFileBrowsers(t *testing.T) {

--- a/pkg/keeper/githubapp/github_app_ctrl.go
+++ b/pkg/keeper/githubapp/github_app_ctrl.go
@@ -174,7 +174,7 @@ func (g *gitHubAppKeeperController) createOwnerController(owner string, configGe
 		return nil, errors.Wrap(err, "Error creating kubernetes resource clients.")
 	}
 	launcherClient := launcher.NewLauncher(lhClient, g.ns)
-	c, err := keeper.NewController(gitproviderClient, gitproviderClient, launcherClient, tektonClient, lhClient, g.ns, configGetter, gitClient, g.maxRecordsPerPool, g.historyURI, g.statusURI, nil)
+	c, err := keeper.NewController(gitproviderClient, gitproviderClient, nil, launcherClient, tektonClient, lhClient, g.ns, configGetter, gitClient, g.maxRecordsPerPool, g.historyURI, g.statusURI, nil)
 	return c, err
 }
 

--- a/pkg/keeper/keeper.go
+++ b/pkg/keeper/keeper.go
@@ -1350,7 +1350,8 @@ func (c *DefaultController) presubmitsByPull(sp *subpool) (map[int][]job.Presubm
 	owner := sp.org
 	repo := sp.repo
 	sharedConfig := c.config()
-	cfg, _, err := inrepo.Generate(c.fileBrowsers, sharedConfig, nil, owner, repo, "")
+	cache := inrepo.NewResolverCache()
+	cfg, _, err := inrepo.Generate(c.fileBrowsers, cache, sharedConfig, nil, owner, repo, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to calculate in repo config")
 	}

--- a/pkg/triggerconfig/inrepo/calculate.go
+++ b/pkg/triggerconfig/inrepo/calculate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Generate generates the in repository config if enabled for this repository otherwise return the shared config
-func Generate(fileBrowser filebrowser.Interface, sharedConfig *config.Config, sharedPlugins *plugins.Configuration, owner, repo, eventRef string) (*config.Config, *plugins.Configuration, error) {
+func Generate(fileBrowsers *filebrowser.FileBrowsers, sharedConfig *config.Config, sharedPlugins *plugins.Configuration, owner, repo, eventRef string) (*config.Config, *plugins.Configuration, error) {
 	fullName := scm.Join(owner, repo)
 	if !sharedConfig.InRepoConfigEnabled(fullName) {
 		return sharedConfig, sharedPlugins, nil
@@ -32,13 +32,13 @@ func Generate(fileBrowser filebrowser.Interface, sharedConfig *config.Config, sh
 	}
 
 	// lets load the main branch first then merge in any changes from this PR/branch
-	refs, err := fileBrowser.GetMainAndCurrentBranchRefs(owner, repo, eventRef)
+	refs, err := fileBrowsers.LighthouseGitFileBrowser().GetMainAndCurrentBranchRefs(owner, repo, eventRef)
 	if err != nil {
 		return sharedConfig, sharedPlugins, errors.Wrapf(err, "failed to find main branch %s", fullName)
 	}
 
 	for _, ref := range refs {
-		repoConfig, _ := LoadTriggerConfig(fileBrowser, owner, repo, ref)
+		repoConfig, _ := LoadTriggerConfig(fileBrowsers, owner, repo, ref)
 		if repoConfig != nil {
 			err = merge.ConfigMerge(&cfg, &pluginCfg, repoConfig, owner, repo)
 			if err != nil {

--- a/pkg/triggerconfig/inrepo/calculate.go
+++ b/pkg/triggerconfig/inrepo/calculate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Generate generates the in repository config if enabled for this repository otherwise return the shared config
-func Generate(fileBrowsers *filebrowser.FileBrowsers, sharedConfig *config.Config, sharedPlugins *plugins.Configuration, owner, repo, eventRef string) (*config.Config, *plugins.Configuration, error) {
+func Generate(fileBrowsers *filebrowser.FileBrowsers, cache *ResolverCache, sharedConfig *config.Config, sharedPlugins *plugins.Configuration, owner, repo, eventRef string) (*config.Config, *plugins.Configuration, error) {
 	fullName := scm.Join(owner, repo)
 	if !sharedConfig.InRepoConfigEnabled(fullName) {
 		return sharedConfig, sharedPlugins, nil
@@ -38,7 +38,7 @@ func Generate(fileBrowsers *filebrowser.FileBrowsers, sharedConfig *config.Confi
 	}
 
 	for _, ref := range refs {
-		repoConfig, _ := LoadTriggerConfig(fileBrowsers, owner, repo, ref)
+		repoConfig, _ := LoadTriggerConfig(fileBrowsers, cache, owner, repo, ref)
 		if repoConfig != nil {
 			err = merge.ConfigMerge(&cfg, &pluginCfg, repoConfig, owner, repo)
 			if err != nil {

--- a/pkg/triggerconfig/inrepo/calculate_test.go
+++ b/pkg/triggerconfig/inrepo/calculate_test.go
@@ -48,7 +48,7 @@ func TestCalculate(t *testing.T) {
 	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
 	require.NoError(t, err, "failed to create filebrowsers")
 
-	cfg, pluginsCfg, err := inrepo.Generate(fileBrowsers, sharedConfig, sharedPluginConfig, owner, repo, ref)
+	cfg, pluginsCfg, err := inrepo.Generate(fileBrowsers, inrepo.NewResolverCache(), sharedConfig, sharedPluginConfig, owner, repo, ref)
 	require.NoError(t, err, "failed to calculate in repo config")
 
 	require.NoError(t, err, "failed to invoke getClientAndTrigger")
@@ -128,7 +128,7 @@ func TestTriggersInBranchMergeToMaster(t *testing.T) {
 	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
 	require.NoError(t, err, "failed to create filebrowsers")
 
-	cfg, _, err := inrepo.Generate(fileBrowsers, sharedConfig, sharedPluginConfig, owner, repo, ref)
+	cfg, _, err := inrepo.Generate(fileBrowsers, inrepo.NewResolverCache(), sharedConfig, sharedPluginConfig, owner, repo, ref)
 	require.NoError(t, err, "failed to calculate in repo config")
 
 	presubmits := cfg.Presubmits[fullName]

--- a/pkg/triggerconfig/inrepo/calculate_test.go
+++ b/pkg/triggerconfig/inrepo/calculate_test.go
@@ -45,9 +45,10 @@ func TestCalculate(t *testing.T) {
 	}
 	sharedPluginConfig := &plugins.Configuration{}
 
-	fileBrowser := filebrowser.NewFileBrowserFromScmClient(scmProvider)
+	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
+	require.NoError(t, err, "failed to create filebrowsers")
 
-	cfg, pluginsCfg, err := inrepo.Generate(fileBrowser, sharedConfig, sharedPluginConfig, owner, repo, ref)
+	cfg, pluginsCfg, err := inrepo.Generate(fileBrowsers, sharedConfig, sharedPluginConfig, owner, repo, ref)
 	require.NoError(t, err, "failed to calculate in repo config")
 
 	require.NoError(t, err, "failed to invoke getClientAndTrigger")
@@ -124,8 +125,10 @@ func TestTriggersInBranchMergeToMaster(t *testing.T) {
 	}
 	sharedPluginConfig := &plugins.Configuration{}
 
-	fileBrowser := filebrowser.NewFileBrowserFromScmClient(scmProvider)
-	cfg, _, err := inrepo.Generate(fileBrowser, sharedConfig, sharedPluginConfig, owner, repo, ref)
+	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
+	require.NoError(t, err, "failed to create filebrowsers")
+
+	cfg, _, err := inrepo.Generate(fileBrowsers, sharedConfig, sharedPluginConfig, owner, repo, ref)
 	require.NoError(t, err, "failed to calculate in repo config")
 
 	presubmits := cfg.Presubmits[fullName]

--- a/pkg/triggerconfig/inrepo/git_uri.go
+++ b/pkg/triggerconfig/inrepo/git_uri.go
@@ -1,6 +1,7 @@
 package inrepo
 
 import (
+	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
 	"strings"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -10,6 +11,7 @@ import (
 
 // GitURI the output of parsing Git URIs
 type GitURI struct {
+	Server     string
 	Owner      string
 	Repository string
 	Path       string
@@ -40,8 +42,17 @@ func ParseGitURI(text string) (*GitURI, error) {
 	case 3:
 		path = parts[2]
 	}
+	owner := parts[0]
+
+	server := filebrowser.GitHub
+	serverOwner := strings.SplitN(owner, ":", 2)
+	if len(serverOwner) > 1 {
+		server = serverOwner[0]
+		owner = serverOwner[1]
+	}
 	return &GitURI{
-		Owner:      parts[0],
+		Server:     server,
+		Owner:      owner,
 		Repository: parts[1],
 		Path:       path,
 		SHA:        sha,
@@ -62,5 +73,9 @@ func (u *GitURI) String() string {
 	if sha == "" {
 		sha = "head"
 	}
-	return path + "@" + sha
+	prefix := ""
+	if u.Server != "" && u.Server != filebrowser.GitHub {
+		prefix = u.Server + ":"
+	}
+	return prefix + path + "@" + sha
 }

--- a/pkg/triggerconfig/inrepo/git_uri.go
+++ b/pkg/triggerconfig/inrepo/git_uri.go
@@ -1,8 +1,9 @@
 package inrepo
 
 import (
-	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
 	"strings"
+
+	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
 
 	"github.com/jenkins-x/go-scm/scm"
 

--- a/pkg/triggerconfig/inrepo/git_uri_test.go
+++ b/pkg/triggerconfig/inrepo/git_uri_test.go
@@ -19,6 +19,7 @@ func TestParseGitURI(t *testing.T) {
 		{
 			text: "myowner/myrepo@v1",
 			expected: &inrepo.GitURI{
+				Server:     "github",
 				Owner:      "myowner",
 				Repository: "myrepo",
 				Path:       "",
@@ -28,6 +29,7 @@ func TestParseGitURI(t *testing.T) {
 		{
 			text: "myowner/myrepo/@v1",
 			expected: &inrepo.GitURI{
+				Server:     "github",
 				Owner:      "myowner",
 				Repository: "myrepo",
 				Path:       "",
@@ -38,6 +40,7 @@ func TestParseGitURI(t *testing.T) {
 		{
 			text: "myowner/myrepo/myfile.yaml@v1",
 			expected: &inrepo.GitURI{
+				Server:     "github",
 				Owner:      "myowner",
 				Repository: "myrepo",
 				Path:       "myfile.yaml",
@@ -47,6 +50,17 @@ func TestParseGitURI(t *testing.T) {
 		{
 			text: "myowner/myrepo/javascript/pullrequest.yaml@v1",
 			expected: &inrepo.GitURI{
+				Server:     "github",
+				Owner:      "myowner",
+				Repository: "myrepo",
+				Path:       "javascript/pullrequest.yaml",
+				SHA:        "v1",
+			},
+		},
+		{
+			text: "myserver:myowner/myrepo/javascript/pullrequest.yaml@v1",
+			expected: &inrepo.GitURI{
+				Server:     "myserver",
 				Owner:      "myowner",
 				Repository: "myrepo",
 				Path:       "javascript/pullrequest.yaml",

--- a/pkg/triggerconfig/inrepo/load_integration_test.go
+++ b/pkg/triggerconfig/inrepo/load_integration_test.go
@@ -29,8 +29,10 @@ func TestMergeConfigIntegration(t *testing.T) {
 	cfg := &config.Config{}
 	pluginCfg := &plugins.Configuration{}
 
-	fileBrowser := filebrowser.NewFileBrowserFromScmClient(scmProvider)
-	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowser, repoOwner, repoName, sha)
+	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
+	require.NoError(t, err, "failed to create filebrowsers")
+
+	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, repoOwner, repoName, sha)
 	require.NoError(t, err, "failed to merge configs")
 	assert.True(t, flag, "did not return merge flag")
 

--- a/pkg/triggerconfig/inrepo/load_integration_test.go
+++ b/pkg/triggerconfig/inrepo/load_integration_test.go
@@ -32,7 +32,7 @@ func TestMergeConfigIntegration(t *testing.T) {
 	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
 	require.NoError(t, err, "failed to create filebrowsers")
 
-	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, repoOwner, repoName, sha)
+	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, NewResolverCache(), repoOwner, repoName, sha)
 	require.NoError(t, err, "failed to merge configs")
 	assert.True(t, flag, "did not return merge flag")
 

--- a/pkg/triggerconfig/inrepo/load_triggers_test.go
+++ b/pkg/triggerconfig/inrepo/load_triggers_test.go
@@ -35,10 +35,12 @@ func TestMergeConfig(t *testing.T) {
 		},
 	}
 
+	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
+	require.NoError(t, err, "failed to create filebrowsers")
+
 	cfg := &config.Config{}
 	pluginCfg := &plugins.Configuration{}
-	fileBrowser := filebrowser.NewFileBrowserFromScmClient(scmProvider)
-	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowser, owner, repo, ref)
+	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, owner, repo, ref)
 	require.NoError(t, err, "failed to merge configs")
 	assert.True(t, flag, "did not return merge flag")
 
@@ -52,13 +54,15 @@ func TestMergeConfig(t *testing.T) {
 func TestInvalidConfigs(t *testing.T) {
 	scmClient, _ := fake.NewDefault()
 	scmProvider := scmprovider.ToClient(scmClient, "my-bot")
-	fileBrowser := filebrowser.NewFileBrowserFromScmClient(scmProvider)
+
+	fileBrowsers, err := filebrowser.NewFileBrowsers(filebrowser.GitHubURL, filebrowser.NewFileBrowserFromScmClient(scmProvider))
+	require.NoError(t, err, "failed to create filebrowsers")
 
 	invalidRepos := []string{"duplicate-presubmit", "duplicate-postsubmit"}
 	for _, repo := range invalidRepos {
 		owner := "myorg"
 		ref := "master"
-		_, err := LoadTriggerConfig(fileBrowser, owner, repo, ref)
+		_, err := LoadTriggerConfig(fileBrowsers, owner, repo, ref)
 		require.Errorf(t, err, "should have failed to load triggers from repo %s/%s with ref %s", owner, repo, ref)
 
 		t.Logf("got expected error loading invalid configuration on repo %s of: %s", repo, err.Error())

--- a/pkg/triggerconfig/inrepo/load_triggers_test.go
+++ b/pkg/triggerconfig/inrepo/load_triggers_test.go
@@ -40,7 +40,7 @@ func TestMergeConfig(t *testing.T) {
 
 	cfg := &config.Config{}
 	pluginCfg := &plugins.Configuration{}
-	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, owner, repo, ref)
+	flag, err := MergeTriggers(cfg, pluginCfg, fileBrowsers, NewResolverCache(), owner, repo, ref)
 	require.NoError(t, err, "failed to merge configs")
 	assert.True(t, flag, "did not return merge flag")
 
@@ -62,7 +62,7 @@ func TestInvalidConfigs(t *testing.T) {
 	for _, repo := range invalidRepos {
 		owner := "myorg"
 		ref := "master"
-		_, err := LoadTriggerConfig(fileBrowsers, owner, repo, ref)
+		_, err := LoadTriggerConfig(fileBrowsers, NewResolverCache(), owner, repo, ref)
 		require.Errorf(t, err, "should have failed to load triggers from repo %s/%s with ref %s", owner, repo, ref)
 
 		t.Logf("got expected error loading invalid configuration on repo %s of: %s", repo, err.Error())
@@ -79,7 +79,7 @@ func TestLoadJobFromURL(t *testing.T) {
 		File("test_data/load_url/foo.yaml")
 
 	j := &job.Base{}
-	err := loadJobBaseFromSourcePath(nil, j, "", "", "https://raw.githubusercontent.com/rawlingsj/test/master/foo.yaml", "")
+	err := loadJobBaseFromSourcePath(nil, NewResolverCache(), j, "", "", "https://raw.githubusercontent.com/rawlingsj/test/master/foo.yaml", "")
 	assert.NoError(t, err, "should not have an error returned")
 	assert.Equal(t, "jenkinsxio/chuck:0.0.1", j.PipelineRunSpec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].Image, "image name for task is not correct")
 }

--- a/pkg/triggerconfig/inrepo/resolver_cache.go
+++ b/pkg/triggerconfig/inrepo/resolver_cache.go
@@ -1,0 +1,67 @@
+package inrepo
+
+import (
+	"sync"
+
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+// ResolverCache a cache of data and pipelines to minimise
+// the git cloning with in repo configurations
+type ResolverCache struct {
+	lock          sync.RWMutex
+	pipelineCache map[string]*tektonv1beta1.PipelineRun
+	dataCache     map[string][]byte
+}
+
+// NewResolverCache creates a new resolver cache
+func NewResolverCache() *ResolverCache {
+	return &ResolverCache{
+		pipelineCache: map[string]*tektonv1beta1.PipelineRun{},
+		dataCache:     map[string][]byte{},
+	}
+}
+
+// GetData gets data from the cache if available or returns nil
+func (c *ResolverCache) GetData(sourceURI string) []byte {
+	if c == nil || sourceURI == "" {
+		return nil
+	}
+	var answer []byte
+	c.lock.Lock()
+	answer = c.dataCache[sourceURI]
+	c.lock.Unlock()
+	return answer
+}
+
+// SetData updates the cache
+func (c *ResolverCache) SetData(sourceURI string, value []byte) {
+	if c == nil || len(value) == 0 {
+		return
+	}
+	c.lock.Lock()
+	c.dataCache[sourceURI] = value
+	c.lock.Unlock()
+}
+
+// GetPipelineRun gets the PipelineRun from the cache if available or returns nil
+func (c *ResolverCache) GetPipelineRun(sourceURI string) *tektonv1beta1.PipelineRun {
+	if c == nil || sourceURI == "" {
+		return nil
+	}
+	var answer *tektonv1beta1.PipelineRun
+	c.lock.Lock()
+	answer = c.pipelineCache[sourceURI]
+	c.lock.Unlock()
+	return answer
+}
+
+// SetPipelineRun updates the cache
+func (c *ResolverCache) SetPipelineRun(sourceURI string, value *tektonv1beta1.PipelineRun) {
+	if c == nil || value == nil {
+		return
+	}
+	c.lock.Lock()
+	c.pipelineCache[sourceURI] = value
+	c.lock.Unlock()
+}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/README.md
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/README.md
@@ -1,0 +1,3 @@
+## Reuse steps in a task 
+
+This example shows how we can use `image: uses:sourceURI` and a `name: mystep` to include individual the steps in task using both both github repository and the local lighthouse git server

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/expected.yaml
@@ -1,0 +1,241 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+spec:
+  pipelineSpec:
+    params:
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - default: ""
+      description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - default: ""
+      description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - default: ""
+      description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: from-build-pack
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        metadata: {}
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - default: ""
+          description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - default: ""
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - image: $(params.gitInitImage)
+          name: clone
+          resources: {}
+          script: |
+            #!/bin/sh
+            set -eu -o pipefail
+
+            if [[ "$(params.verbose)" == "true" ]] ; then
+              set -x
+            fi
+
+            CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+
+            cleandir() {
+              # Delete any existing contents of the repo directory if it exists.
+              #
+              # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+              # or the root of a mounted volume.
+              if [[ -d "$CHECKOUT_DIR" ]] ; then
+                # Delete non-hidden files and directories
+                rm -rf "$CHECKOUT_DIR"/*
+                # Delete files and directories starting with . but excluding ..
+                rm -rf "$CHECKOUT_DIR"/.[!.]*
+                # Delete files and directories starting with .. plus any other character
+                rm -rf "$CHECKOUT_DIR"/..?*
+              fi
+            }
+
+            if [[ "$(params.deleteExisting)" == "true" ]] ; then
+              cleandir
+            fi
+
+            test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
+            test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
+            test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+
+            /ko-app/git-init \
+              -url "$(params.url)" \
+              -revision "$(params.revision)" \
+              -refspec "$(params.refspec)" \
+              -path "$CHECKOUT_DIR" \
+              -sslVerify="$(params.sslVerify)" \
+              -submodules="$(params.submodules)" \
+              -depth "$(params.depth)"
+            cd "$CHECKOUT_DIR"
+            RESULT_SHA="$(git rev-parse HEAD)"
+            EXIT_CODE="$?"
+            if [ "$EXIT_CODE" != 0 ] ; then
+              exit $EXIT_CODE
+            fi
+            # ensure we don't add a trailing newline to the result
+            echo -n "$RESULT_SHA" > $(results.commit.path)
+            echo -n "$(params.url)" > $(results.url.path)
+        - image: gcr.io/jenkinsxio/jx-boot:3.1.155
+          name: jx-variables
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+        - image: node:12-slim
+          name: build-npm-install
+          resources: {}
+          script: |
+            #!/bin/sh
+            npm install
+        - image: node:12-slim
+          name: build-npm-test
+          resources: {}
+          script: |
+            #!/bin/sh
+            CI=true DISPLAY=:99 npm test
+        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+          name: build-container-build
+          resources: {}
+          script: |
+            #!/busybox/sh
+            source .jx/variables.sh
+            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=Dockerfile --destination=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
+        - image: gcr.io/jenkinsxio/jx-preview:0.0.143
+          name: promote-jx-preview
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx preview create
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-steps-custom-git/source.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      taskSpec:
+        stepTemplate:
+          image: uses:lighthouse:jenkins-x/jx3-pipeline-catalog/packs/javascript/.lighthouse/jenkins-x/pullrequest.yaml@1d39235ee9235d7d52d4025a8e59cb8bda04306a
+        steps:
+        - name: clone
+          image: uses:tektoncd/catalog/task/git-clone/0.2/git-clone.yaml@HEAD
+        - name: jx-variables
+        - name: build-npm-install
+        - name: build-npm-test
+        - name: build-container-build
+        - name: promote-jx-preview

--- a/pkg/triggerconfig/inrepo/uses_resolver.go
+++ b/pkg/triggerconfig/inrepo/uses_resolver.go
@@ -20,6 +20,7 @@ import (
 // UsesResolver resolves the `uses:` URI syntax
 type UsesResolver struct {
 	FileBrowsers     *filebrowser.FileBrowsers
+	Cache            *ResolverCache
 	OwnerName        string
 	RepoName         string
 	SHA              string
@@ -27,8 +28,6 @@ type UsesResolver struct {
 	Message          string
 	DefaultValues    *DefaultValues
 	LocalFileResolve bool
-
-	cache map[string]*tektonv1beta1.PipelineRun
 }
 
 var (
@@ -40,10 +39,7 @@ var (
 // UsesSteps lets resolve the sourceURI to a PipelineRun and find the step or steps
 // for the given task name and/or step name then lets apply any overrides from the step
 func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv1beta1.Step) ([]tektonv1beta1.Step, error) {
-	if r.cache == nil {
-		r.cache = map[string]*tektonv1beta1.PipelineRun{}
-	}
-	pr := r.cache[sourceURI]
+	pr := r.Cache.GetPipelineRun(sourceURI)
 	if pr == nil {
 		data, err := r.GetData(sourceURI, false)
 		if err != nil {
@@ -60,7 +56,7 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 		if pr == nil {
 			return nil, errors.Errorf("no PipelineRun for URI %s", sourceURI)
 		}
-		r.cache[sourceURI] = pr
+		r.Cache.SetPipelineRun(sourceURI, pr)
 	}
 
 	return r.findSteps(sourceURI, pr, taskName, step)
@@ -68,7 +64,11 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 
 // GetData gets the data from the given source URI
 func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error) {
-	var data []byte
+	data := r.Cache.GetData(path)
+	if len(data) > 0 {
+		return data, nil
+	}
+
 	if strings.Contains(path, "://") {
 		data, err := getPipelineFromURL(path)
 		if err != nil {
@@ -104,6 +104,11 @@ func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error)
 	}
 	fb := r.FileBrowsers.LighthouseGitFileBrowser()
 	if gitURI != nil {
+		data := r.lookupDataCache(path)
+		if len(data) > 0 {
+			return data, nil
+		}
+
 		owner = gitURI.Owner
 		repo = gitURI.Repository
 		path = gitURI.Path
@@ -120,6 +125,9 @@ func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error)
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find file %s in repo %s/%s with sha %s", path, owner, repo, sha)
+	}
+	if gitURI != nil {
+		r.Cache.SetData(path, data)
 	}
 	return data, nil
 }
@@ -204,6 +212,14 @@ func (r *UsesResolver) findTaskStep(sourceURI string, task tektonv1beta1.Pipelin
 		}
 	}
 	return nil, errors.Errorf("source URI %s task %s has no step named %s", sourceURI, task.Name, name)
+}
+
+func (r *UsesResolver) lookupDataCache(path string) []byte {
+	return nil
+}
+
+func (r *UsesResolver) updateDataCache(path string, data []byte) {
+
 }
 
 // OverrideStep overrides the step with the given overrides

--- a/pkg/webhook/create_agent.go
+++ b/pkg/webhook/create_agent.go
@@ -62,7 +62,7 @@ func (s *Server) CreateAgent(l *logrus.Entry, owner, repo, ref string) (plugins.
 
 func (s *Server) createAgent(pc *plugins.Agent, owner, repo, ref string) error {
 	var err error
-	pc.Config, pc.PluginConfig, err = inrepo.Generate(s.FileBrowser, pc.Config, pc.PluginConfig, owner, repo, ref)
+	pc.Config, pc.PluginConfig, err = inrepo.Generate(s.FileBrowsers, pc.Config, pc.PluginConfig, owner, repo, ref)
 	if err != nil {
 		return errors.Wrapf(err, "failed to calculate in repo config")
 	}

--- a/pkg/webhook/create_agent.go
+++ b/pkg/webhook/create_agent.go
@@ -62,7 +62,8 @@ func (s *Server) CreateAgent(l *logrus.Entry, owner, repo, ref string) (plugins.
 
 func (s *Server) createAgent(pc *plugins.Agent, owner, repo, ref string) error {
 	var err error
-	pc.Config, pc.PluginConfig, err = inrepo.Generate(s.FileBrowsers, pc.Config, pc.PluginConfig, owner, repo, ref)
+	cache := inrepo.NewResolverCache()
+	pc.Config, pc.PluginConfig, err = inrepo.Generate(s.FileBrowsers, cache, pc.Config, pc.PluginConfig, owner, repo, ref)
 	if err != nil {
 		return errors.Wrapf(err, "failed to calculate in repo config")
 	}

--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -41,7 +41,7 @@ type Server struct {
 	ServerURL      *url.URL
 	TokenGenerator func() []byte
 	Metrics        *Metrics
-	FileBrowser    filebrowser.Interface
+	FileBrowsers   *filebrowser.FileBrowsers
 	InRepoCache    *lru.Cache
 
 	// Tracks running handlers for graceful shutdown


### PR DESCRIPTION
folks may want to reuse from github.com for things like tekton catalog: `uses:tektoncd/catalog/task/git-clone/0.2/git-clone.yaml@HEAD` while also using files from the current git server (if not using github.com as the git server)

so lets add an optional `uses:(lighthouse:)owner/repository/path@version` syntax to reference the lighthouse git server instead of github.com