### PR TITLE
fix: prometheus support for keeper

### DIFF
--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -100,6 +100,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `keeper.image.tag` | string | Template for computing the keeper controller docker image tag | `"{{ .Values.image.tag }}"` |
 | `keeper.livenessProbe` | object | Liveness probe configuration | `{"initialDelaySeconds":120,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `keeper.nodeSelector` | object | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the keeper pods | `{}` |
+| `keeper.podAnnotations` | object | Annotations applied to the keeper pods | `{}` |
 | `keeper.probe` | object | Liveness and readiness probes settings | `{"path":"/"}` |
 | `keeper.readinessProbe` | object | Readiness probe configuration | `{"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `keeper.replicaCount` | int | Number of replicas | `1` |
@@ -137,6 +138,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `webhooks.ingress.hosts` | list | Webhooks ingress host names | `[]` |
 | `webhooks.livenessProbe` | object | Liveness probe configuration | `{"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `webhooks.nodeSelector` | object | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the webhooks pods | `{}` |
+| `webhooks.podAnnotations` | object | Annotations applied to the webhooks pods | `{}` |
 | `webhooks.probe` | object | Liveness and readiness probes settings | `{"path":"/"}` |
 | `webhooks.readinessProbe` | object | Readiness probe configuration | `{"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` |
 | `webhooks.replicaCount` | int | Number of replicas | `1` |

--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -19,9 +19,14 @@ spec:
       app: {{ template "keeper.name" . }}
   template:
     metadata:
-{{- if .Values.keeper.datadog.enabled }}
+{{- if or .Values.keeper.datadog.enabled .Values.keeper.podAnnotations }}
       annotations:
+{{- if .Values.keeper.datadog.enabled }}
         ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
+{{- end }}
+{{- if .Values.keeper.podAnnotations }}
+{{ toYaml .Values.keeper.podAnnotations | indent 8 }}
+{{- end }}
 {{- end }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -19,8 +19,9 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "webhooks.name" . }}
-{{- if .Values.podAnnotations }}
+{{- if or .Values.webhooks.podAnnotations .Values.podAnnotations }}
       annotations:
+{{ toYaml .Values.webhooks.podAnnotations | indent 8 }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -90,6 +90,9 @@ webhooks:
     # webhooks.image.pullPolicy -- Template for computing the webhooks controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
+  # webhooks.podAnnotations -- Annotations applied to the webhooks pods
+  podAnnotations: {}
+
   # webhooks.serviceName -- Allows overriding the service name, this is here for compatibility reasons, regular users should clear this out
   serviceName: hook
 
@@ -309,6 +312,9 @@ keeper:
 
     # keeper.image.pullPolicy -- Template for computing the keeper controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
+
+  # keeper.podAnnotations -- Annotations applied to the keeper pods
+  podAnnotations: {}
 
   # keeper.service -- Service settings for the webhooks controller
   service:

--- a/cmd/keeper/main.go
+++ b/cmd/keeper/main.go
@@ -161,20 +161,13 @@ func main() {
 	})
 
 	// Push metrics to the configured prometheus pushgateway endpoint or serve them
-	gateway := cfg().PushGateway
-	if gateway.Endpoint != "" {
-		logrus.WithField("gateway", gateway.Endpoint).Infof("using push gateway")
-		go metrics.ExposeMetrics("keeper", gateway)
+	metrics.ExposeMetrics("keeper", cfg().PushGateway)
 
-		// serve data
-		interrupts.ListenAndServe(server, 10*time.Second)
-	} else {
-		logrus.Warn("not pushing metrics as there is no push_gateway defined in the config.yaml")
+	// serve data
+	logrus.WithField("port", o.port).Info("Starting HTTP server")
+	interrupts.ListenAndServe(server, 10*time.Second)
 
-		// serve data
-		err := server.ListenAndServe()
-		logrus.WithError(err).Errorf("failed to server HTTP")
-	}
+	interrupts.WaitForGracefulShutdown()
 }
 
 func sync(c keeper.Controller) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,11 +37,11 @@ const metricsPort = 9090
 // ExposeMetrics chooses whether to serve or push metrics for the service
 func ExposeMetrics(component string, pushGateway lighthouse.PushGateway) {
 	if pushGateway.Endpoint != "" {
+		logrus.WithField("gateway", pushGateway.Endpoint).Info("using push gateway")
 		pushMetrics(component, pushGateway.Endpoint, pushGateway.Interval)
-		if pushGateway.ServeMetrics {
-			serveMetrics()
-		}
-	} else {
+	}
+	if pushGateway.ServeMetrics {
+		logrus.WithField("port", metricsPort).Info("exposing metrics server")
 		serveMetrics()
 	}
 }


### PR DESCRIPTION
- ensure prometheus metrics are exposed if required
- fix chart to allow users to add the prometheus scrape annotations on the pods