### PR TITLE
fix: in uses resolver, clone pipelinerun when returning from the cache to avoid changes persistng between evaluations

### DIFF
--- a/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
@@ -1,6 +1,7 @@
 package inrepo
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/jenkins-x/lighthouse/pkg/filebrowser"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
+	"github.com/jenkins-x/lighthouse/pkg/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,8 @@ func TestLoadPipelineRunTest(t *testing.T) {
 
 	// lets use a custom version stream sha
 	os.Setenv("LIGHTHOUSE_VERSIONSTREAM_JENKINS_X_JX3_PIPELINE_CATALOG", "myversionstreamref")
+
+	require.NoError(t, err, "failed to get cwd")
 
 	// make it easy to run a specific test only
 	runTestName := os.Getenv("TEST_NAME")
@@ -65,37 +69,55 @@ func TestLoadPipelineRunTest(t *testing.T) {
 		dir := filepath.Join(sourceDir, name)
 		resolver.Dir = dir
 
-		path := filepath.Join(dir, "source.yaml")
-		expectedPath := filepath.Join(dir, "expected.yaml")
+		i := 0
+		for i <= 10 {
+			i++
 
-		message := "load file " + path
-		data, err := ioutil.ReadFile(path)
-		require.NoError(t, err, "failed to load "+message)
+			suffix := ""
+			if i > 1 {
+				suffix = fmt.Sprintf("%v", i)
+			}
+			path := filepath.Join(dir, fmt.Sprintf("source%s.yaml", suffix))
 
-		pr, err := LoadTektonResourceAsPipelineRun(resolver, data)
-		if strings.HasSuffix(name, "-fails") {
-			require.Errorf(t, err, "expected failure for test %s", name)
-			t.Logf("test %s generated expected error %s\n", name, err.Error())
-			continue
+			exists, err := util.FileExists(path)
+			require.NoError(t, err, "failed to check for file exists source "+path)
+
+			if !exists && i > 1 {
+				break
+			}
+
+			expectedPath := filepath.Join(dir, fmt.Sprintf("expected%s.yaml", suffix))
+
+			message := "load file " + path
+			data, err := ioutil.ReadFile(path)
+			require.NoError(t, err, "failed to load "+message)
+
+			pr, err := LoadTektonResourceAsPipelineRun(resolver, data)
+
+			if strings.HasSuffix(name, "-fails") {
+				require.Errorf(t, err, "expected failure for test %s", name)
+				t.Logf("test %s generated expected error %s\n", name, err.Error())
+				continue
+			}
+
+			require.NoError(t, err, "failed to load PipelineRun for "+message)
+			require.NotNil(t, pr, "no PipelineRun for "+message)
+
+			data, err = yaml.Marshal(pr)
+			require.NoError(t, err, "failed to marshal generated PipelineRun for "+message)
+
+			if generateTestOutput {
+				err = ioutil.WriteFile(expectedPath, data, 0666)
+				require.NoError(t, err, "failed to save file %s", expectedPath)
+				continue
+			}
+			expectedData, err := ioutil.ReadFile(expectedPath)
+			require.NoError(t, err, "failed to load file "+expectedPath)
+
+			text := strings.TrimSpace(string(data))
+			expectedText := strings.TrimSpace(string(expectedData))
+
+			assert.Equal(t, expectedText, text, "PipelineRun loaded for "+message)
 		}
-
-		require.NoError(t, err, "failed to load PipelineRun for "+message)
-		require.NotNil(t, pr, "no PipelineRun for "+message)
-
-		data, err = yaml.Marshal(pr)
-		require.NoError(t, err, "failed to marshal generated PipelineRun for "+message)
-
-		if generateTestOutput {
-			err = ioutil.WriteFile(expectedPath, data, 0666)
-			require.NoError(t, err, "failed to save file %s", expectedPath)
-			continue
-		}
-		expectedData, err := ioutil.ReadFile(expectedPath)
-		require.NoError(t, err, "failed to load file "+expectedPath)
-
-		text := strings.TrimSpace(string(data))
-		expectedText := strings.TrimSpace(string(expectedData))
-
-		assert.Equal(t, expectedText, text, "PipelineRun loaded for "+message)
 	}
 }

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/README.md
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/README.md
@@ -1,0 +1,3 @@
+## Replication of a issue 1234
+
+https://github.com/jenkins-x/lighthouse/issues/1234

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/common.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/common.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+spec:
+  pipelineSpec:
+    tasks:
+    - name: common
+      taskSpec:
+        steps:
+        - image: common-image
+          name: common-build
+          env:
+          - name: FOO
+            value: foo

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/expected.yaml
@@ -1,0 +1,161 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+spec:
+  pipelineSpec:
+    params:
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - default: ""
+      description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - default: ""
+      description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - default: ""
+      description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: from-build-pack
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        metadata: {}
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - default: ""
+          description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - default: ""
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - env:
+          - name: FOO
+            value: one
+          image: common-image
+          name: common-build
+          resources: {}
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/expected2.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/expected2.yaml
@@ -1,0 +1,161 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+spec:
+  pipelineSpec:
+    params:
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - default: ""
+      description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - default: ""
+      description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - default: ""
+      description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    tasks:
+    - name: from-build-pack
+      params:
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        metadata: {}
+        params:
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - default: ""
+          description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - default: ""
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          resources: {}
+        steps:
+        - env:
+          - name: FOO
+            value: foo
+          image: common-image
+          name: common-build
+          resources: {}
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/source.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      taskSpec:
+        steps:
+        - image: uses:./test_data/load_pipelinerun/uses-ussue-1234/common.yaml
+          name: common-build
+          env:
+          - name: FOO
+            value: one

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/source2.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/uses-ussue-1234/source2.yaml
@@ -1,0 +1,10 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      taskSpec:
+        steps:
+        - image: uses:./test_data/load_pipelinerun/uses-ussue-1234/common.yaml
+          name: common-build

--- a/pkg/triggerconfig/inrepo/uses_resolver.go
+++ b/pkg/triggerconfig/inrepo/uses_resolver.go
@@ -59,7 +59,7 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 		r.Cache.SetPipelineRun(sourceURI, pr)
 	}
 
-	return r.findSteps(sourceURI, pr, taskName, step)
+	return r.findSteps(sourceURI, pr.DeepCopy(), taskName, step)
 }
 
 // GetData gets the data from the given source URI


### PR DESCRIPTION
The test runner was changed to evaluate multiple source/expected runs

e.g. 
source.yaml compared to expected.yaml
source2.yaml compared to expected2.yaml

Fix was a `pr.DeepClone()`

Fixes https://github.com/jenkins-x/lighthouse/issues/1234