### PR TITLE
fix: handle v1 CRDs

### DIFF
--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -96,6 +96,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `jenkinscontroller.tolerations` | list | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods | `[]` |
 | `keeper.affinity` | object | [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the keeper pods | `{}` |
 | `keeper.datadog.enabled` | string | Enables datadog | `"true"` |
+| `keeper.env` | object | Lets you define keeper specific environment variables | `{}` |
 | `keeper.image.pullPolicy` | string | Template for computing the keeper controller docker image pull policy | `"{{ .Values.image.pullPolicy }}"` |
 | `keeper.image.repository` | string | Template for computing the keeper controller docker image repository | `"{{ .Values.image.parentRepository }}/lighthouse-keeper"` |
 | `keeper.image.tag` | string | Template for computing the keeper controller docker image tag | `"{{ .Values.image.tag }}"` |

--- a/charts/lighthouse/config/lighthousejobs.lighthouse.jenkins.io-v1.yaml
+++ b/charts/lighthouse/config/lighthousejobs.lighthouse.jenkins.io-v1.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: lighthousejobs.lighthouse.jenkins.io
+spec:
+  group: lighthouse.jenkins.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: LighthouseJob
+    singular: lighthousejob
+    plural: lighthousejobs
+    shortNames:
+      - lhjob
+  scope: Namespaced
+

--- a/charts/lighthouse/templates/lighthousejobs-crd.yaml
+++ b/charts/lighthouse/templates/lighthousejobs-crd.yaml
@@ -1,3 +1,8 @@
 {{- if .Values.cluster.crds.create }}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+{{ .Files.Get "config/lighthousejobs.lighthouse.jenkins.io-v1.yaml" }}
+{{- else }}
 {{ .Files.Get "config/lighthousejobs.lighthouse.jenkins.io.yaml" }}
+{{- end }}
+
 {{- end -}}


### PR DESCRIPTION
lets allow v1 of CRDs to be used in more recent k8s installs