### PR TITLE
fix: add missing PipelineRunParams when creating LighthouseJobSpec from job.Base

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -69,7 +69,7 @@ spec:
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
         - name: chart-docs
           resources: {}
-        - image: gcr.io/jenkinsxio/jx-changelog:0.0.34
+        - image: gcr.io/jenkinsxio/jx-changelog:0.0.35
           name: changelog
           resources: {}
           script: |
@@ -79,7 +79,7 @@ spec:
             sed -i -e "s/^version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
             sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
 
-            jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=false
+            jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --prerelease
         - name: release-chart
           resources: {}
         - name: upload-binaries

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-lhjob.yml
@@ -34,6 +34,8 @@ spec:
       value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
     - name: repo-url
       value_template: '{{ .Refs.CloneURI }}'
+    - name: foo-param
+      value_template: bar-value
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/expected-pr.yml
@@ -52,6 +52,8 @@ spec:
       value: https://github.com/jenkins-x/lighthouse.git
     - name: branch-name
       value: dd64c739442d505cf5381e2a14b60968e8a0d86e
+    - name: foo-param
+      value: bar-value
     - name: repo-url
       value: https://github.com/jenkins-x/lighthouse.git
   pipelineRef:

--- a/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
+++ b/pkg/engines/tekton/test_data/controller/start-pullrequest/observed-lhjob.yml
@@ -31,6 +31,8 @@ spec:
       value_template: '{{ range $i, $v := .Refs.Pulls }}{{if $i}} {{end}}{{ $v.SHA }}{{ end }}'
     - name: repo-url
       value_template: '{{ .Refs.CloneURI }}'
+    - name: foo-param
+      value_template: bar-value
   refs:
     base_link: https://github.com/jenkins-x/lighthouse/commit/e8d56b5ee9671599c75644af574a251dd3b94a5c
     base_ref: master

--- a/pkg/jobutil/jobutil.go
+++ b/pkg/jobutil/jobutil.go
@@ -163,12 +163,13 @@ func specFromJobBase(jb job.Base) v1alpha1.LighthouseJobSpec {
 		namespace = *jb.Namespace
 	}
 	return v1alpha1.LighthouseJobSpec{
-		Agent:           jb.Agent,
-		Job:             jb.Name,
-		Namespace:       namespace,
-		MaxConcurrency:  jb.MaxConcurrency,
-		PodSpec:         jb.Spec,
-		PipelineRunSpec: jb.PipelineRunSpec,
+		Agent:             jb.Agent,
+		Job:               jb.Name,
+		Namespace:         namespace,
+		MaxConcurrency:    jb.MaxConcurrency,
+		PodSpec:           jb.Spec,
+		PipelineRunSpec:   jb.PipelineRunSpec,
+		PipelineRunParams: jb.PipelineRunParams,
 	}
 }
 

--- a/pkg/jobutil/jobutil_test.go
+++ b/pkg/jobutil/jobutil_test.go
@@ -163,6 +163,36 @@ func TestPresubmitSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pipeline_run_params are added to lighthouseJobSpec",
+			p: job.Presubmit{
+				Base: job.Base{
+					PipelineRunParams: []job.PipelineRunParam{
+						{
+							Name:          "FOO_PARAM",
+							ValueTemplate: "BAR_VALUE",
+						},
+					},
+				},
+			},
+			refs: v1alpha1.Refs{
+				PathAlias: "fancy",
+				CloneURI:  "cats",
+			},
+			expected: v1alpha1.LighthouseJobSpec{
+				Type: job.PresubmitJob,
+				Refs: &v1alpha1.Refs{
+					PathAlias: "fancy",
+					CloneURI:  "cats",
+				},
+				PipelineRunParams: []job.PipelineRunParam{
+					{
+						Name:          "FOO_PARAM",
+						ValueTemplate: "BAR_VALUE",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -526,7 +556,7 @@ func TestSpecFromJobBase(t *testing.T) {
 		verify  func(v1alpha1.LighthouseJobSpec) error
 	}{
 		{
-			name:    "Verify reporter config gets copied",
+			name: "Verify reporter config gets copied",
 			jobBase: job.Base{
 				/*				ReporterConfig: &v1alpha1.ReporterConfig{
 									Slack: &v1alpha1.SlackReporterConfig{

--- a/pkg/jobutil/jobutil_test.go
+++ b/pkg/jobutil/jobutil_test.go
@@ -556,7 +556,7 @@ func TestSpecFromJobBase(t *testing.T) {
 		verify  func(v1alpha1.LighthouseJobSpec) error
 	}{
 		{
-			name: "Verify reporter config gets copied",
+			name:    "Verify reporter config gets copied",
 			jobBase: job.Base{
 				/*				ReporterConfig: &v1alpha1.ReporterConfig{
 									Slack: &v1alpha1.SlackReporterConfig{


### PR DESCRIPTION
lets add a rebased version of this PR https://github.com/jenkins-x/lighthouse/pull/1156 to get it past the new CI setup

fixes #1155

add missing PipelineRunParams in specFromJobBase add corresponding test