### PR TITLE
fix: include tags when fetching updates from the server

### DIFF
--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -281,7 +281,7 @@ func (i *interactor) Fetch() error {
 		return fmt.Errorf("could not resolve remote for fetching: %v", err)
 	}
 	i.logger.Debugf("Fetching from %s", remote)
-	if out, err := i.executor.Run("fetch", remote, "--tags"); err != nil {
+	if out, err := i.executor.Run("fetch", remote); err != nil {
 		return fmt.Errorf("error fetching: %v %v", err, string(out))
 	}
 	return nil
@@ -294,7 +294,7 @@ func (i *interactor) FetchRef(refspec string) error {
 		return fmt.Errorf("could not resolve remote for fetching: %v", err)
 	}
 	i.logger.Debugf("Fetching %q from %s", refspec, remote)
-	if out, err := i.executor.Run("fetch", remote, refspec, "--tags"); err != nil {
+	if out, err := i.executor.Run("fetch", "--tags", remote, refspec); err != nil {
 		return fmt.Errorf("error fetching %q: %v %v", refspec, err, string(out))
 	}
 	return nil

--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -281,7 +281,7 @@ func (i *interactor) Fetch() error {
 		return fmt.Errorf("could not resolve remote for fetching: %v", err)
 	}
 	i.logger.Debugf("Fetching from %s", remote)
-	if out, err := i.executor.Run("fetch", remote); err != nil {
+	if out, err := i.executor.Run("fetch", remote, "--tags"); err != nil {
 		return fmt.Errorf("error fetching: %v %v", err, string(out))
 	}
 	return nil
@@ -294,7 +294,7 @@ func (i *interactor) FetchRef(refspec string) error {
 		return fmt.Errorf("could not resolve remote for fetching: %v", err)
 	}
 	i.logger.Debugf("Fetching %q from %s", refspec, remote)
-	if out, err := i.executor.Run("fetch", remote, refspec); err != nil {
+	if out, err := i.executor.Run("fetch", remote, refspec, "--tags"); err != nil {
 		return fmt.Errorf("error fetching %q: %v %v", refspec, err, string(out))
 	}
 	return nil

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -1174,12 +1174,12 @@ func TestInteractor_FetchRef(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com shasum": {
+				"fetch --tags someone.com shasum": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "shasum"},
+				{"fetch", "--tags", "someone.com", "shasum"},
 			},
 			expectedErr: false,
 		},
@@ -1200,12 +1200,12 @@ func TestInteractor_FetchRef(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com shasum": {
+				"fetch --tags someone.com shasum": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "shasum"},
+				{"fetch", "--tags", "someone.com", "shasum"},
 			},
 			expectedErr: true,
 		},
@@ -1340,7 +1340,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com pull/1/head": {
+				"fetch --tags someone.com pull/1/head": {
 					out: []byte(`ok`),
 				},
 				"checkout FETCH_HEAD": {
@@ -1351,7 +1351,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "pull/1/head"},
+				{"fetch", "--tags", "someone.com", "pull/1/head"},
 				{"checkout", "FETCH_HEAD"},
 				{"checkout", "-b", "pull1"},
 			},
@@ -1374,12 +1374,12 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com pull/1/head": {
+				"fetch --tags someone.com pull/1/head": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "pull/1/head"},
+				{"fetch", "--tags", "someone.com", "pull/1/head"},
 			},
 			expectedErr: true,
 		},
@@ -1390,7 +1390,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com pull/1/head": {
+				"fetch --tags someone.com pull/1/head": {
 					out: []byte(`ok`),
 				},
 				"checkout FETCH_HEAD": {
@@ -1398,7 +1398,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "pull/1/head"},
+				{"fetch", "--tags", "someone.com", "pull/1/head"},
 				{"checkout", "FETCH_HEAD"},
 			},
 			expectedErr: true,
@@ -1410,7 +1410,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"fetch someone.com pull/1/head": {
+				"fetch --tags someone.com pull/1/head": {
 					out: []byte(`ok`),
 				},
 				"checkout FETCH_HEAD": {
@@ -1421,7 +1421,7 @@ func TestInteractor_CheckoutPullRequest(t *testing.T) {
 				},
 			},
 			expectedCalls: [][]string{
-				{"fetch", "someone.com", "pull/1/head"},
+				{"fetch", "--tags", "someone.com", "pull/1/head"},
 				{"checkout", "FETCH_HEAD"},
 				{"checkout", "-b", "pull1"},
 			},


### PR DESCRIPTION
If I run a pipeline that has a uses: line with an @version suffix, then change the pipeline to have a later @version suffix and re-trigger, I get this error

```
{"Branch":"master","Clone":"https://git.drivenow.com.au/drivenow/octane-staging.git","ID":"2206","Link":"https://git.drivenow.com.au/drivenow/octane-staging","Name":"octane-staging","Namespace":"drivenow","Webhook":"push","error":"failed to create agent: failed to calculate in repo config: failed to load trigger config for repository drivenow/octane-staging for ref ad417c592f9a80ca5c559d41885b3e96f07b3a6b: failed to load file .lighthouse/jenkins-x/triggers.yaml in drivenow/octane-staging with sha ad417c592f9a80ca5c559d41885b3e96f07b3a6b: failed to load source for presubmit pr: failed to unmarshal YAML file .lighthouse/jenkins-x/pullrequest.yaml in repo drivenow/octane-staging with sha ad417c592f9a80ca5c559d41885b3e96f07b3a6b: failed to inherit steps: failed to process uses steps: failed to resolve git URI lighthouse:drivenow/octane/.lighthouse/jenkins-x/site-import-octane.yaml@0.15.4 for step : failed to load URI lighthouse:drivenow/octane/.lighthouse/jenkins-x/site-import-octane.yaml@0.15.4: failed to find file .lighthouse/jenkins-x/site-import-octane.yaml in repo drivenow/octane with sha 0.15.4: failed to switch to ref 0.15.4: failed to fetch repository drivenow/octane: error fetching \"0.15.4\": exit status 128 fatal: couldn't find remote ref 0.15.4\n","head":"ad417c592f9a80ca5c559d41885b3e96f07b3a6b","level":"error","msg":"Error creating agent for PushEvent.","org":"drivenow","ref":"refs/heads/master","repo":"octane-staging","time":"2021-04-04T12:24:42Z"}
```

The only way to resolve it is to delete the pod

```
k --context live -n jx delete pod -l app=lighthouse-webhooks --wait=false
```

then re-trigger the same pipeline with a dummy commit

Even though it says `couldn't find remote ref 0.15.4` the remote ref **is** there since it was just created by a previous pipeline run
