### PR TITLE
fix: log at warning level when external plugin failed

### DIFF
--- a/pkg/util/externalplugins.go
+++ b/pkg/util/externalplugins.go
@@ -181,7 +181,7 @@ func callExternalPlugins(l *logrus.Entry, externalPlugins []plugins.ExternalPlug
 		go func(p plugins.ExternalPlugin) {
 			defer wg.Done()
 			if err := dispatch(p.Endpoint, payload, headers); err != nil {
-				l.WithError(err).WithField("external-plugin", p.Name).Error("Error dispatching event to external plugin.")
+				l.WithError(err).WithField("external-plugin", p.Name).Warning("Error dispatching event to external plugin.")
 			} else {
 				l.WithField("external-plugin", p.Name).Info("Dispatched event to external plugin")
 			}


### PR DESCRIPTION
related to https://github.com/jenkins-x/jx3-versions/pull/2307

if we have external plugins that can't be reached, let's just log this as a warning, because it's not impacting the behaviour of lighthouse in itself.