### PR TITLE
docs: Docs update

### DIFF
--- a/charts/lighthouse/Makefile
+++ b/charts/lighthouse/Makefile
@@ -6,7 +6,7 @@ OS := $(shell uname)
 
 HELMDOCS := $(GOPATH)/bin/helm-docs
 $(HELMDOCS):
-	pushd /tmp; $(GO_MOD) get -u github.com/norwoodj/helm-docs/cmd/helm-docs@v0.15.0; popd
+	pushd /tmp; $(GO_MOD) get -u github.com/norwoodj/helm-docs/cmd/helm-docs@v1.5.0; popd
 
 build: clean $(HELMDOCS)
 	rm -rf requirements.lock

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -74,7 +74,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `git.kind` | string | Git SCM provider (`github`, `gitlab`, `stash`) | `"github"` |
 | `git.server` | string | Git server URL | `""` |
 | `githubApp.enabled` | bool | Enables GitHub app authentication | `false` |
-| `githubApp.username` | string | GitHub app user name  | `"jenkins-x[bot]"` |
+| `githubApp.username` | string | GitHub app user name | `"jenkins-x[bot]"` |
 | `hmacToken` | string | Secret used for webhooks | `""` |
 | `hmacTokenEnabled` | bool | Enables the use of a hmac token. This should always be enabled if possible - though some git providers don't support it such as bitbucket cloud | `true` |
 | `image.parentRepository` | string | Docker registry to pull images from | `"gcr.io/jenkinsxio"` |

--- a/charts/lighthouse/README.md.gotmpl
+++ b/charts/lighthouse/README.md.gotmpl
@@ -44,7 +44,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | Key | Type | Description | Default |
 |-----|------|-------------|---------|
 {{- range .Values }}
-| `{{ .Key }}` | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+| `{{ .Key }}` | {{ .Type }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
 {{- end }}
 {{ end }}
 

--- a/charts/lighthouse/templates/webhooks-ingress.yaml
+++ b/charts/lighthouse/templates/webhooks-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml .Values.webhooks.ingress.annotations | nindent 4 }}
 spec:
   rules:
-  {{- range .Values.webhooks.ingress.hosts }}
+  {{- range (required "A valid ingress host is required when ingress enabled!" .Values.webhooks.ingress.hosts) }}
   - host: {{ . | quote }}
     http:
       paths:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -1,109 +1,108 @@
 git:
-  # git.kind -- Git SCM provider (`github`, `gitlab`, `stash`)
+  # -- Git SCM provider (`github`, `gitlab`, `stash`)
   kind: github
 
-  # git.server -- Git server URL
+  # -- Git server URL
   server: ""
 
-# lighthouseJobNamespace -- Namespace where `LighthouseJob`s and `Pod`s are created
+# -- Namespace where `LighthouseJob`s and `Pod`s are created
 # @default -- Deployment namespace
 lighthouseJobNamespace: ""
 
 githubApp:
-  # githubApp.enabled -- Enables GitHub app authentication
+  # -- Enables GitHub app authentication
   enabled: false
 
-  # githubApp.username -- GitHub app user name 
-  username:  "jenkins-x[bot]"
+  # -- GitHub app user name
+  username: "jenkins-x[bot]"
 
-# user -- Git user name (used when GitHub app authentication is not enabled)
+# -- Git user name (used when GitHub app authentication is not enabled)
 user: ""
 
-# oauthToken -- Git token (used when GitHub app authentication is not enabled)
+# -- Git token (used when GitHub app authentication is not enabled)
 oauthToken: ""
 
-# hmacToken -- Secret used for webhooks
+# -- Secret used for webhooks
 hmacToken: ""
 
-# hmacTokenEnabled -- Enables the use of a hmac token. This should always be enabled if possible - though some git providers don't support it such as bitbucket cloud
+# -- Enables the use of a hmac token. This should always be enabled if possible - though some git providers don't support it such as bitbucket cloud
 hmacTokenEnabled: true
 
-# logFormat -- Log format
+# -- Log format
 logFormat: "json"
 
 cluster:
   crds:
-    # cluster.crds.create -- Create custom resource definitions
+    # -- Create custom resource definitions
     create: true
 
 image:
-  # image.parentRepository -- Docker registry to pull images from
+  # -- Docker registry to pull images from
   parentRepository: gcr.io/jenkinsxio
 
-  # image.tag -- Docker images tag
+  # -- Docker images tag
   tag: 0.0.750
 
-  # image.pullPolicy -- Image pull policy
+  # -- Image pull policy
   pullPolicy: IfNotPresent
 
-# env -- Environment variables
+# -- Environment variables
 env:
   JX_DEFAULT_IMAGE: ""
 
 gcJobs:
-  # gcJobs.maxAge -- Max age from which `LighthouseJob`s will be deleted
+  # -- Max age from which `LighthouseJob`s will be deleted
   maxAge: 168h
 
-  # gcJobs.schedule -- Cron expression to periodically delete `LighthouseJob`s
+  # -- Cron expression to periodically delete `LighthouseJob`s
   schedule: "0/30 * * * *"
 
-  # gcJobs.failedJobsHistoryLimit -- Drives the failed jobs history limit
+  # -- Drives the failed jobs history limit
   failedJobsHistoryLimit: 1
 
-  # gcJobs.successfulJobsHistoryLimit -- Drives the successful jobs history limit
+  #  -- Drives the successful jobs history limit
   successfulJobsHistoryLimit: 3
 
-  # gcJobs.concurrencyPolicy -- Drives the job's concurrency policy
+  # -- Drives the job's concurrency policy
   concurrencyPolicy: Forbid
 
   image:
-    # gcJobs.image.repository -- Template for computing the gc job docker image repository
+    # -- Template for computing the gc job docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-gc-jobs"
 
-    # gcJobs.image.tag -- Template for computing the gc job docker image tag
+    # -- Template for computing the gc job docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # gcJobs.image.pullPolicy -- Template for computing the gc job docker image pull policy
+    # -- Template for computing the gc job docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
 webhooks:
-  # webhooks.replicaCount -- Number of replicas
+  # -- Number of replicas
   replicaCount: 1
 
-  # webhooks.terminationGracePeriodSeconds -- Termination grace period for webhooks pods
+  # -- Termination grace period for webhooks pods
   terminationGracePeriodSeconds: 180
 
   image:
-    # webhooks.image.repository -- Template for computing the webhooks controller docker image repository
+    # -- Template for computing the webhooks controller docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-webhooks"
 
-    # webhooks.image.tag -- Template for computing the webhooks controller docker image tag
+    # -- Template for computing the webhooks controller docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # webhooks.image.pullPolicy -- Template for computing the webhooks controller docker image pull policy
+    # -- Template for computing the webhooks controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
-
-  # webhooks.labels -- allow optional labels to be added to the webhook deployment
+  # -- allow optional labels to be added to the webhook deployment
   labels: {}
 
-  # webhooks.podAnnotations -- Annotations applied to the webhooks pods
+  # -- Annotations applied to the webhooks pods
   podAnnotations: {}
 
-  # webhooks.serviceName -- Allows overriding the service name, this is here for compatibility reasons, regular users should clear this out
+  # -- Allows overriding the service name, this is here for compatibility reasons, regular users should clear this out
   serviceName: hook
 
-  # webhooks.service -- Service settings for the webhooks controller
+  # -- Service settings for the webhooks controller
   service:
     type: ClusterIP
     externalPort: 80
@@ -111,289 +110,288 @@ webhooks:
     annotations: {}
 
   resources:
-    # webhooks.resources.limits -- Resource limits applied to the webhooks pods
+    # -- Resource limits applied to the webhooks pods
     limits:
       cpu: 100m
       # may require more memory to perform the initial 'git clone' cmd for big repositories
       memory: 512Mi
 
-    # webhooks.resources.requests -- Resource requests applied to the webhooks pods
+    # -- Resource requests applied to the webhooks pods
     requests:
       cpu: 80m
       memory: 128Mi
 
-  # webhooks.probe -- Liveness and readiness probes settings
+  # -- Liveness and readiness probes settings
   probe:
     path: /
 
-  # webhooks.livenessProbe -- Liveness probe configuration
+  # -- Liveness probe configuration
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
 
-  # webhooks.readinessProbe -- Readiness probe configuration
+  # -- Readiness probe configuration
   readinessProbe:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
 
-  # webhooks.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the webhooks pods
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the webhooks pods
   nodeSelector: {}
 
-  # webhooks.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the webhooks pods
+  # -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the webhooks pods
   affinity: {}
 
-  # webhooks.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the webhooks pods
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the webhooks pods
   tolerations: []
 
   ingress:
-    # webhooks.ingress.enabled -- Enable webhooks ingress
+    # -- Enable webhooks ingress
     enabled: false
 
-    # webhooks.ingress.annotations -- Webhooks ingress annotations
+    # -- Webhooks ingress annotations
     annotations: {}
 
-    # webhooks.ingress.hosts -- Webhooks ingress host names
+    # -- Webhooks ingress host names
     hosts: []
 
-  # webhooks.customDeploymentTriggerCommand -- deployments can configure the ability to allow custom lighthouse triggers
+  # -- deployments can configure the ability to allow custom lighthouse triggers
   # using their own unique chat prefix, for example extending the default `/test` trigger prefix let them specify
   # `customDeploymentTriggerPrefix: foo` which means they can also use their own custom trigger /foo mycoolthing
   customDeploymentTriggerCommand: ""
 
 foghorn:
-  # foghorn.replicaCount -- Number of replicas
+  # -- Number of replicas
   replicaCount: 1
-  
-  # foghorn.terminationGracePeriodSeconds -- Termination grace period for foghorn pods
+
+  # -- Termination grace period for foghorn pods
   terminationGracePeriodSeconds: 180
 
   image:
-    # foghorn.image.repository -- Template for computing the foghorn controller docker image repository
+    # -- Template for computing the foghorn controller docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-foghorn"
 
-    # foghorn.image.tag -- Template for computing the foghorn controller docker image tag
+    # -- Template for computing the foghorn controller docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # foghorn.image.pullPolicy -- Template for computing the foghorn controller docker image pull policy
+    # -- Template for computing the foghorn controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
   resources:
-    # foghorn.resources.limits -- Resource limits applied to the foghorn pods
+    # -- Resource limits applied to the foghorn pods
     limits:
       cpu: 100m
       memory: 256Mi
 
-    # foghorn.resources.requests -- Resource requests applied to the foghorn pods
+    # -- Resource requests applied to the foghorn pods
     requests:
       cpu: 80m
       memory: 128Mi
 
-  # foghorn.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the foghorn pods
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the foghorn pods
   nodeSelector: {}
 
-  # foghorn.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the foghorn pods
+  # -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the foghorn pods
   affinity: {}
 
-  # foghorn.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the foghorn pods
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the foghorn pods
   tolerations: []
 
-
 tektoncontroller:
-  # tektoncontroller.dashboardURL -- the dashboard URL (e.g. Tekton dashboard)
-  dashboardURL: ''
-  # tektoncontroller.dashboardTemplate -- Go template expression for URLs in the dashboard if not using Tekton dashboard
-  dashboardTemplate: ''
+  # -- the dashboard URL (e.g. Tekton dashboard)
+  dashboardURL: ""
+  # -- Go template expression for URLs in the dashboard if not using Tekton dashboard
+  dashboardTemplate: ""
 
-  # tektoncontroller.replicaCount -- Number of replicas
+  # -- Number of replicas
   replicaCount: 1
 
-  # tektoncontroller.terminationGracePeriodSeconds -- Termination grace period for tekton controller pods
+  # -- Termination grace period for tekton controller pods
   terminationGracePeriodSeconds: 180
 
   image:
-    # tektoncontroller.image.repository -- Template for computing the tekton controller docker image repository
+    # -- Template for computing the tekton controller docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-tekton-controller"
 
-    # tektoncontroller.image.tag -- Template for computing the tekton controller docker image tag
+    # -- Template for computing the tekton controller docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # tektoncontroller.image.pullPolicy -- Template for computing the tekton controller docker image pull policy
+    # -- Template for computing the tekton controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
-  # tektoncontroller.podAnnotations -- Annotations applied to the tekton controller pods
+  # -- Annotations applied to the tekton controller pods
   podAnnotations: {}
 
-  # tektoncontroller.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods
   nodeSelector: {}
 
-  # tektoncontroller.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods
+  # -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods
   affinity: {}
 
-  # tektoncontroller.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods
   tolerations: []
 
   resources:
-    # tektoncontroller.resources.limits -- Resource limits applied to the tekton controller pods
+    # -- Resource limits applied to the tekton controller pods
     limits:
       cpu: 100m
       memory: 256Mi
 
-    # tektoncontroller.resources.requests -- Resource requests applied to the tekton controller pods
+    # -- Resource requests applied to the tekton controller pods
     requests:
       cpu: 80m
       memory: 128Mi
 
-  # tektoncontroller.service -- Service settings for the tekton controller
+  # -- Service settings for the tekton controller
   service:
     annotations: {}
 
 jenkinscontroller:
-  # jenkinscontroller.jenkinsURL -- The URL of the Jenkins instance
+  # -- The URL of the Jenkins instance
   jenkinsURL:
 
-  # jenkinscontroller.jenkinsUser -- The username for the Jenkins user
+  # -- The username for the Jenkins user
   jenkinsUser:
 
-  # jenkinscontroller.jenkinsToken -- The token for authenticating the Jenkins user
+  # -- The token for authenticating the Jenkins user
   jenkinsToken:
 
-  # jenkinscontroller.terminationGracePeriodSeconds -- Termination grace period for tekton controller pods
+  # -- Termination grace period for tekton controller pods
   terminationGracePeriodSeconds: 180
 
   image:
-    # jenkinscontroller.image.repository -- Template for computing the Jenkins controller docker image repository
+    # -- Template for computing the Jenkins controller docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-jenkins-controller"
 
-    # jenkinscontroller.image.tag -- Template for computing the tekton controller docker image tag
+    # -- Template for computing the tekton controller docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # jenkinscontroller.image.pullPolicy -- Template for computing the tekton controller docker image pull policy
+    # -- Template for computing the tekton controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
-  # jenkinscontroller.podAnnotations -- Annotations applied to the tekton controller pods
+  # -- Annotations applied to the tekton controller pods
   podAnnotations: {}
 
-  # jenkinscontroller.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the tekton controller pods
   nodeSelector: {}
 
-  # jenkinscontroller.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods
+  # -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the tekton controller pods
   affinity: {}
 
-  # jenkinscontroller.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the tekton controller pods
   tolerations: []
 
   resources:
-    # jenkinscontroller.resources.limits -- Resource limits applied to the tekton controller pods
+    # -- Resource limits applied to the tekton controller pods
     limits:
       cpu: 100m
       memory: 256Mi
 
-    # jenkinscontroller.resources.requests -- Resource requests applied to the tekton controller pods
+    # -- Resource requests applied to the tekton controller pods
     requests:
       cpu: 80m
       memory: 128Mi
 
-  # jenkinscontroller.service -- Service settings for the tekton controller
+  # -- Service settings for the tekton controller
   service:
     annotations: {}
 
 keeper:
-  # keeper.statusContextLabel -- Label used to report status to git provider
+  # -- Label used to report status to git provider
   statusContextLabel: "Lighthouse Merge Status"
 
-  # keeper.replicaCount -- Number of replicas
+  # -- Number of replicas
   replicaCount: 1
 
-  # keeper.terminationGracePeriodSeconds -- Termination grace period for keeper pods
+  # -- Termination grace period for keeper pods
   terminationGracePeriodSeconds: 30
 
   image:
-    # keeper.image.repository -- Template for computing the keeper controller docker image repository
+    # -- Template for computing the keeper controller docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-keeper"
 
-    # keeper.image.tag -- Template for computing the keeper controller docker image tag
+    # -- Template for computing the keeper controller docker image tag
     tag: "{{ .Values.image.tag }}"
 
-    # keeper.image.pullPolicy -- Template for computing the keeper controller docker image pull policy
+    # -- Template for computing the keeper controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
-  # keeper.podAnnotations -- Annotations applied to the keeper pods
+  # -- Annotations applied to the keeper pods
   podAnnotations: {}
 
-  # keeper.env -- Lets you define keeper specific environment variables
+  # -- Lets you define keeper specific environment variables
   env: {}
 
-  # keeper.service -- Service settings for the webhooks controller
+  # -- Service settings for the webhooks controller
   service:
     type: ClusterIP
     externalPort: 80
     internalPort: 8888
 
   resources:
-    # keeper.resources.limits -- Resource limits applied to the keeper pods
+    # -- Resource limits applied to the keeper pods
     limits:
       cpu: 400m
       memory: 512Mi
 
-    # keeper.resources.requests -- Resource requests applied to the keeper pods
+    # -- Resource requests applied to the keeper pods
     requests:
       cpu: 100m
       memory: 128Mi
 
-  # keeper.probe -- Liveness and readiness probes settings
+  # -- Liveness and readiness probes settings
   probe:
     path: /
 
-  # keeper.livenessProbe -- Liveness probe configuration
+  # -- Liveness probe configuration
   livenessProbe:
     initialDelaySeconds: 120
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
 
-  # keeper.readinessProbe -- Readiness probe configuration
+  # -- Readiness probe configuration
   readinessProbe:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
 
   datadog:
-    # keeper.datadog.enabled -- Enables datadog
+    # -- Enables datadog
     enabled: "true"
 
-  # keeper.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the keeper pods
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the keeper pods
   nodeSelector: {}
 
-  # keeper.affinity -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the keeper pods
+  # -- [Affinity rules](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) applied to the keeper pods
   affinity: {}
 
-  # keeper.tolerations -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the keeper pods
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the keeper pods
   tolerations: []
 
 engines:
-  # engines.jx -- Enables the jx engine
+  # -- Enables the jx engine
   jx: true
 
-  # engines.tekton -- Enables the tekton engine
+  # -- Enables the tekton engine
   tekton: false
 
-  # engines.jenkins -- Enables the Jenkins engine
+  # -- Enables the Jenkins engine
   jenkins: false
 
 configMaps:
-  # configMaps.create -- Enables creation of `config.yaml` and `plugins.yaml` config maps
+  # -- Enables creation of `config.yaml` and `plugins.yaml` config maps
   create: false
 
-  # configMaps.config -- Raw `config.yaml` content
+  # -- Raw `config.yaml` content
   config: null
 
-  # configMaps.plugins -- Raw `plugins.yaml` content
+  # -- Raw `plugins.yaml` content
   plugins: null
 
-  # configMaps.configUpdater -- Settings used to configure the `config-updater` plugin
+  # -- Settings used to configure the `config-updater` plugin
   configUpdater:
     orgAndRepo: ""
     path: ""


### PR DESCRIPTION
- Documents that `webhooks.ingress.hosts` is required when ingress is enabled (otherwise chart fails to deploy)
- Updates helm-docs to 1.5.0
- Uses new, shorter helm-docs syntax in `values.yaml`