### PR TITLE
feat: push images to an alternative image registry ghcr.io

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -34,42 +34,42 @@ spec:
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-webhooks:$VERSION --build-arg=VERSION=$VERSION
         - name: build-container-build:keeper
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-keeper:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-keeper:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-keeper:$VERSION --build-arg=VERSION=$VERSION
         - name: build-container-build:foghorn
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-foghorn:$VERSION --build-arg=VERSION=$VERSION
         - name: build-container-build:tekton
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-tekton-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-tekton-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-tekton-controller:$VERSION --build-arg=VERSION=$VERSION
         - name: build-container-build:jenkins
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-jenkins-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-jenkins-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-jenkins-controller:$VERSION --build-arg=VERSION=$VERSION
         - name: build-container-build:gc-jobs
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 240h0m0s

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -31,42 +31,42 @@ spec:
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-webhooks:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-webhooks:$VERSION --build-arg=VERSION=$VERSION
         - name: build-and-push-image:keeper
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-keeper:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-keeper:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-keeper:$VERSION --build-arg=VERSION=$VERSION
         - name: build-and-push-image:foghorn
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-foghorn:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-foghorn:$VERSION --build-arg=VERSION=$VERSION
         - name: build-and-push-image:tekton
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-tekton-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-tekton-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-tekton-controller:$VERSION --build-arg=VERSION=$VERSION
         - name: build-and-push-image:jenkins
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-jenkins-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-jenkins-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-jenkins-controller:$VERSION --build-arg=VERSION=$VERSION
         - name: build-and-push-image:gc-jobs
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=gcr.io/jenkinsxio/lighthouse-gc-jobs:$VERSION --destination=ghcr.io/jenkins-x/lighthouse/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
         - name: chart-docs
           resources: {}
         - image: gcr.io/jenkinsxio/jx-changelog:0.0.35


### PR DESCRIPTION
ghcr.io can be accessed from most places, this is super friendly especially for China

## TODO
I'm not able to provide the secret for ghcr.io/jenkins-x/lighthouse. I'm requesting a maintainer of this project to help with that.

This visibility of this image package is private by default. So in order to make it be available for most users. We need to do one more job. Please access the following address, and turn it to be public:

https://github.com/orgs/jenkins-x/packages/container/lighthouse%2Flighthouse-webhooks/settings

![image](https://user-images.githubusercontent.com/1450685/116200845-6901d880-a76b-11eb-858e-d3f87549d3f2.png)
