### PR TITLE
chore: ensure opentelemetry annotations are not copied

### DIFF
--- a/pkg/jobutil/jobutil.go
+++ b/pkg/jobutil/jobutil.go
@@ -304,6 +304,10 @@ func LabelsAndAnnotationsForJob(lj v1alpha1.LighthouseJob, buildID string) (map[
 	if extraAnnotations = lj.ObjectMeta.Annotations; extraAnnotations == nil {
 		extraAnnotations = map[string]string{}
 	}
+	// ensure the opentelemetry annotations holding trace context
+	// won't be copied to other resources
+	delete(extraAnnotations, "lighthouse.jenkins-x.io/traceparent")
+	delete(extraAnnotations, "lighthouse.jenkins-x.io/tracestate")
 	return LabelsAndAnnotationsForSpec(lj.Spec, extraLabels, extraAnnotations)
 }
 


### PR DESCRIPTION
when copying lhjob annotations to other resources, we need to ensure that some of them won't be copied:
the annotations holding the opentelemetry trace context

these are used by https://github.com/jenkins-x/lighthouse-telemetry-plugin to propagate the trace context between different resources (lhjob, pipelinerun, pipelinetask, pod, activity, ...) and should be unique for each resource