### PR TITLE
fix: fix uses resolver using incorrect version of uses:task.yaml

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -435,7 +435,6 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -465,8 +464,8 @@ github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mq
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
-github.com/jenkins-x/go-scm v1.7.2 h1:EWUHRFtJoLFInBMGkfceMqhrzIS8E+L2gKjJQCbnDgY=
-github.com/jenkins-x/go-scm v1.7.2/go.mod h1:z7xTO9/VzqW3xEbEMH2z5cpOGrZ8+nOHOWfU1ngFGxs=
+github.com/jenkins-x/go-scm v1.8.2 h1:GMEUz6ap0pAeyUkwWP3SQxJoz/qN+tJmCkr9sWvbXs4=
+github.com/jenkins-x/go-scm v1.8.2/go.mod h1:z7xTO9/VzqW3xEbEMH2z5cpOGrZ8+nOHOWfU1ngFGxs=
 github.com/jenkins-x/pipeline v0.3.2-0.20210223153617-0d1186b27496 h1:yN90dXuD7TkAkYwKr5h2fT7bjA7osK7tMhuz31qL7gE=
 github.com/jenkins-x/pipeline v0.3.2-0.20210223153617-0d1186b27496/go.mod h1:y1XwzBDu4EmOCfoeV2cUW2icCto/izTyjEKK5j0UmwA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/triggerconfig/inrepo/resolver_cache.go
+++ b/pkg/triggerconfig/inrepo/resolver_cache.go
@@ -6,6 +6,8 @@ import (
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
+const DELIMIER = "#"
+
 // ResolverCache a cache of data and pipelines to minimise
 // the git cloning with in repo configurations
 type ResolverCache struct {
@@ -23,45 +25,45 @@ func NewResolverCache() *ResolverCache {
 }
 
 // GetData gets data from the cache if available or returns nil
-func (c *ResolverCache) GetData(sourceURI string) []byte {
+func (c *ResolverCache) GetData(sourceURI, ref string) []byte {
 	if c == nil || sourceURI == "" {
 		return nil
 	}
 	var answer []byte
 	c.lock.Lock()
-	answer = c.dataCache[sourceURI]
+	answer = c.dataCache[sourceURI+DELIMIER+ref]
 	c.lock.Unlock()
 	return answer
 }
 
 // SetData updates the cache
-func (c *ResolverCache) SetData(sourceURI string, value []byte) {
+func (c *ResolverCache) SetData(sourceURI, ref string, value []byte) {
 	if c == nil || len(value) == 0 {
 		return
 	}
 	c.lock.Lock()
-	c.dataCache[sourceURI] = value
+	c.dataCache[sourceURI+DELIMIER+ref] = value
 	c.lock.Unlock()
 }
 
 // GetPipelineRun gets the PipelineRun from the cache if available or returns nil
-func (c *ResolverCache) GetPipelineRun(sourceURI string) *tektonv1beta1.PipelineRun {
+func (c *ResolverCache) GetPipelineRun(sourceURI, ref string) *tektonv1beta1.PipelineRun {
 	if c == nil || sourceURI == "" {
 		return nil
 	}
 	var answer *tektonv1beta1.PipelineRun
 	c.lock.Lock()
-	answer = c.pipelineCache[sourceURI]
+	answer = c.pipelineCache[sourceURI+DELIMIER+ref]
 	c.lock.Unlock()
 	return answer
 }
 
 // SetPipelineRun updates the cache
-func (c *ResolverCache) SetPipelineRun(sourceURI string, value *tektonv1beta1.PipelineRun) {
+func (c *ResolverCache) SetPipelineRun(sourceURI string, ref string, value *tektonv1beta1.PipelineRun) {
 	if c == nil || value == nil {
 		return
 	}
 	c.lock.Lock()
-	c.pipelineCache[sourceURI] = value
+	c.pipelineCache[sourceURI+DELIMIER+ref] = value
 	c.lock.Unlock()
 }

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: release
+      taskSpec:
+        steps:
+        - image: uses:.lighthouse/jenkins-x/shared-task.yaml

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/shared-task.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/shared-task.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: task1
+spec:
+  steps:
+  - name: step-1
+    image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      echo ubuntu-master

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/master/.lighthouse/jenkins-x/triggers.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
+kind: TriggerConfig
+spec:
+  presubmits:
+  - name: pullrequest
+    context: "pr"
+    always_run: true
+    optional: false
+    source: "pullrequest.yaml"

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: release
+      taskSpec:
+        steps:
+        - image: uses:.lighthouse/jenkins-x/shared-task.yaml

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/shared-task.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/shared-task.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: shared-task
+spec:
+  steps:
+  - name: step-1
+    image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      echo ubuntu-pr1

--- a/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/triggers.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/myorg/issue-1306/refs/pr1/.lighthouse/jenkins-x/triggers.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
+kind: TriggerConfig
+spec:
+  presubmits:
+  - name: pullrequest
+    context: "pr"
+    always_run: true
+    optional: false
+    source: "pullrequest.yaml"

--- a/pkg/triggerconfig/inrepo/uses_resolver.go
+++ b/pkg/triggerconfig/inrepo/uses_resolver.go
@@ -41,7 +41,7 @@ var (
 // UsesSteps lets resolve the sourceURI to a PipelineRun and find the step or steps
 // for the given task name and/or step name then lets apply any overrides from the step
 func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv1beta1.Step, ts *tektonv1beta1.TaskSpec, loc *UseLocation) ([]tektonv1beta1.Step, error) {
-	pr := r.Cache.GetPipelineRun(sourceURI)
+	pr := r.Cache.GetPipelineRun(sourceURI, r.SHA)
 	if pr == nil || ignoreUsesCache {
 		data, err := r.GetData(sourceURI, false)
 		if err != nil {
@@ -58,7 +58,7 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 		if pr == nil {
 			return nil, errors.Errorf("no PipelineRun for URI %s", sourceURI)
 		}
-		r.Cache.SetPipelineRun(sourceURI, pr)
+		r.Cache.SetPipelineRun(sourceURI, r.SHA, pr)
 	}
 
 	useTS, err := r.findSteps(sourceURI, pr.DeepCopy(), taskName, step)
@@ -88,7 +88,7 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 
 // GetData gets the data from the given source URI
 func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error) {
-	data := r.Cache.GetData(path)
+	data := r.Cache.GetData(path, r.SHA)
 	if len(data) > 0 {
 		return data, nil
 	}
@@ -151,7 +151,7 @@ func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error)
 		return nil, errors.Wrapf(err, "failed to find file %s in repo %s/%s with sha %s", path, owner, repo, sha)
 	}
 	if gitURI != nil {
-		r.Cache.SetData(path, data)
+		r.Cache.SetData(path, r.SHA, data)
 	}
 	return data, nil
 }


### PR DESCRIPTION
Test case in TestUsesInPRBranch, test data in pkg/triggerconfig/inrepo/test_data/myorg/uses-cache-issue

The fix was to include the SHA in the uses resolver cache key so that a different entry exists for master and the pr branch for a given path.