### PR TITLE
fix: handling draft PRs without errors

### DIFF
--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -350,6 +350,8 @@ func actionRelatesToPullRequestComment(action scm.Action, l *logrus.Entry) bool 
 		scm.ActionUnassigned,
 		scm.ActionReviewRequested,
 		scm.ActionReviewRequestRemoved,
+		scm.ActionReadyForReview,
+		scm.ActionConvertedToDraft,
 		scm.ActionLabel,
 		scm.ActionUnlabel,
 		scm.ActionClose,


### PR DESCRIPTION
ensure we won't log the following error when handling draft PRs switching to the "ready for review" state:

    Could not coerce pull_request event to a GenericCommentEvent. Unknown 'action': "ready_for_review".

by adding the missing actions to the list of actions that are not related to a PR comment