### PR TITLE
chore: bump the image tag from 0.0.750 to 1.1.0

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -31,42 +31,42 @@ spec:
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-webhooks:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/webhooks/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-webhooks:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-webhooks:latest --build-arg=VERSION=$VERSION
         - name: build-and-push-image:keeper
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-keeper:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/keeper/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-keeper:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-keeper:latest --build-arg=VERSION=$VERSION
         - name: build-and-push-image:foghorn
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-foghorn:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/foghorn/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-foghorn:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-foghorn:latest --build-arg=VERSION=$VERSION
         - name: build-and-push-image:tekton
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-tekton-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/tekton/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-tekton-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-tekton-controller:latest --build-arg=VERSION=$VERSION
         - name: build-and-push-image:jenkins
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-jenkins-controller:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/jenkins/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-jenkins-controller:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-jenkins-controller:latest --build-arg=VERSION=$VERSION
         - name: build-and-push-image:gc-jobs
           resources: {}
           script: |
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-gc-jobs:$VERSION --build-arg=VERSION=$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-gc-jobs:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-gc-jobs:latest --build-arg=VERSION=$VERSION
         - name: chart-docs
           resources: {}
         - image: ghcr.io/jenkins-x/jx-changelog:0.0.43

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -50,7 +50,7 @@ image:
   parentRepository: ghcr.io/jenkins-x
 
   # image.tag -- Docker images tag
-  tag: 0.0.750
+  tag: 1.1.0
 
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -50,7 +50,8 @@ image:
   parentRepository: ghcr.io/jenkins-x
 
   # image.tag -- Docker images tag
-  tag: 1.1.0
+  # the following tag is latest on the main branch, it's a specific version on a git tag
+  tag: latest
 
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent


### PR DESCRIPTION
ghcr.io/jenkins-x/xxx:0.0.750 does not exist