### PR TITLE
fix(keeper): use the target URL when updating status

### DIFF
--- a/pkg/keeper/status.go
+++ b/pkg/keeper/status.go
@@ -345,9 +345,9 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]prWit
 			}
 		}
 		if wantState != strings.ToLower(string(actualState)) || wantDesc != actualDesc {
-			reportURL := ""
+			reportURL := targetURL(sc.config, pr, log)
 			// BitBucket Server requires a valid URL in all status reports
-			if sc.spc.ProviderType() == "stash" {
+			if sc.spc.ProviderType() == "stash" && reportURL == "" {
 				reportURL = "https://github.com/jenkins-x/lighthouse"
 			}
 			if _, err := sc.spc.CreateGraphQLStatus(


### PR DESCRIPTION
the `TargetURL` defined in the keeper config was not used when pushing status update to the git provider, but now that we have a lighthouse web UI at https://github.com/jenkins-x-plugins/lighthouse-webui-plugin we should use it

I'll also update the versions stream to use the new LH webui instead of the pipelines visualizer