### PR TITLE
fix: config-updater not work with gitlab

### DIFF
--- a/pkg/plugins/updateconfig/updateconfig.go
+++ b/pkg/plugins/updateconfig/updateconfig.go
@@ -266,7 +266,7 @@ func handle(spc scmProviderClient, kc corev1.ConfigMapsGetter, cp commentPruner,
 	isUpdate := false
 
 	switch pre.Action {
-	case scm.ActionClose:
+	case scm.ActionClose, scm.ActionMerge:
 		isMerge = true
 	case scm.ActionOpen, scm.ActionReopen, scm.ActionSync:
 		isUpdate = true

--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -355,6 +355,7 @@ func actionRelatesToPullRequestComment(action scm.Action, l *logrus.Entry) bool 
 		scm.ActionLabel,
 		scm.ActionUnlabel,
 		scm.ActionClose,
+		scm.ActionMerge,
 		scm.ActionReopen,
 		scm.ActionSync:
 		return false


### PR DESCRIPTION
fix that config-updater not work with gitlab, because of not dealing with ActionMerge event