### PR TITLE
fix: add a new require_run property

### DIFF
--- a/pkg/config/job/presubmit.go
+++ b/pkg/config/job/presubmit.go
@@ -31,6 +31,8 @@ type Presubmit struct {
 	Reporter
 	// AlwaysRun automatically for every PR, or only when a comment triggers it.
 	AlwaysRun bool `json:"always_run"`
+	// RequireRun if this value is true and AlwaysRun is false then we need to manually trigger this context for the PR to be allowed to auto merge.
+	RequireRun bool `json:"require_run,omitempty"`
 	// Optional indicates that the job's status context should not be required for merge.
 	Optional bool `json:"optional,omitempty"`
 	// Trigger is the regular expression to trigger the job.
@@ -106,7 +108,7 @@ func (p Presubmit) ShouldRun(baseRef string, changes ChangedFilesProvider, force
 	if !p.CouldRun(baseRef) {
 		return false, nil
 	}
-	if p.AlwaysRun {
+	if p.AlwaysRun || p.RequireRun {
 		return true, nil
 	}
 	if forced {

--- a/pkg/triggerconfig/inrepo/load_triggers_test.go
+++ b/pkg/triggerconfig/inrepo/load_triggers_test.go
@@ -36,6 +36,11 @@ func TestMergeConfig(t *testing.T) {
 	r := owner + "/" + repo
 	assert.Len(t, cfg.Presubmits[r], 2, "presubmits for repo %s", r)
 	assert.Len(t, cfg.Postsubmits[r], 1, "postsubmits for repo %s", r)
+
+	presubmit := cfg.Presubmits[r][0]
+	assert.False(t, presubmit.Optional, "Optional for presubmit %s", presubmit.Context)
+	assert.False(t, presubmit.SkipReport, "SkipReport for presubmit %s", presubmit.Context)
+	assert.True(t, presubmit.ContextRequired(), "ContextRequired() for presubmit %s", presubmit.Context)
 }
 
 func TestInvalidConfigs(t *testing.T) {


### PR DESCRIPTION
so that we can prevent auto merge on a PR for any contexts with `always_run: false` if they have `require_run: true`