### PR TITLE
feat: add 'team' label to labels plugin

### DIFF
--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -40,7 +40,7 @@ var (
 		ConfigHelpProvider: configHelp,
 		Commands: []plugins.Command{{
 			Prefix: "remove-",
-			Name:   "area|committee|kind|language|priority|sig|triage|wg|label",
+			Name:   "area|committee|kind|language|priority|sig|team|triage|wg|label",
 			Arg: &plugins.CommandArg{
 				Pattern: ".*",
 			},

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -124,6 +124,15 @@ func TestLabel(t *testing.T) {
 			commenter:             orgMember,
 		},
 		{
+			name:                  "Add Single Team Label",
+			body:                  "/team ops",
+			repoLabels:            []string{"area/infra", "team/ops"},
+			issueLabels:           []string{"area/infra"},
+			expectedNewLabels:     formatLabels("team/ops"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+		},
+		{
 			name:                  "Add Single Triage Label",
 			body:                  "/triage needs-information",
 			repoLabels:            []string{"area/infra", "triage/needs-information"},
@@ -339,6 +348,15 @@ func TestLabel(t *testing.T) {
 			issueLabels:           []string{"area/infra", "wg/policy"},
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("wg/policy"),
+			commenter:             orgMember,
+		},
+		{
+			name:                  "Remove Team Label",
+			body:                  "/remove-team ops",
+			repoLabels:            []string{"area/infra", "team/ops"},
+			issueLabels:           []string{"area/infra", "team/ops"},
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: formatLabels("team/ops"),
 			commenter:             orgMember,
 		},
 		{


### PR DESCRIPTION
We are using a general term of 'team' so we would like to leverage the team label in the label plugin

Signed-off-by: Brian Davis <dbrian@vmware.com>