### PR TITLE
feat: Invalidate failed polls

### DIFF
--- a/pkg/poller/pollstate/interface.go
+++ b/pkg/poller/pollstate/interface.go
@@ -2,4 +2,5 @@ package pollstate
 
 type Interface interface {
 	IsNew(repository, operation, values string) (bool, error)
+	Invalidate(repository, operation, invalidValue string)
 }

--- a/pkg/poller/pollstate/memory.go
+++ b/pkg/poller/pollstate/memory.go
@@ -25,3 +25,16 @@ func (p *memoryPollstate) IsNew(repository, operation, newValue string) (bool, e
 	p.lock.Unlock()
 	return old != newValue, nil
 }
+
+func (p *memoryPollstate) Invalidate(repository, operation, invalidValue string) {
+	key := repository + ":" + operation
+
+	p.lock.Lock()
+
+	currentValue := p.cache[key]
+	if currentValue == invalidValue {
+		delete(p.cache, key)
+	}
+
+	p.lock.Unlock()
+}


### PR DESCRIPTION
In the current poller implementation, if an event fails to be delivered (for example, if the Lighthouse hook is down), the poller does not retry. This PR invalidates the cache on error so that the poller will retry.