### PR TITLE
feat: Support commit context match pattern

### DIFF
--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -38,8 +38,8 @@ spec:
         imagePullPolicy: {{ tpl .Values.poller.image.pullPolicy . }}
         args:
           - "--namespace={{ .Release.Namespace }}"
-          {{- if .Values.poller.commitStatusLabelPattern }}
-          - "--commit-status-label-pattern={{ .Values.poller.commitStatusLabelPattern }}"
+          {{- if .Values.poller.contextMatchPattern }}
+          - "--context-match-pattern={{ .Values.poller.contextMatchPattern }}"
           {{- end }}
         ports:
           - name: http

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         imagePullPolicy: {{ tpl .Values.poller.image.pullPolicy . }}
         args:
           - "--namespace={{ .Release.Namespace }}"
+          {{- if .Values.poller.commitStatusLabelPattern }}
+          - "--commit-status-label-pattern={{ .Values.poller.commitStatusLabelPattern }}"
+          {{- end }}
         ports:
           - name: http
             containerPort: {{ .Values.poller.internalPort }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -427,6 +427,7 @@ poller:
     # poller.env.POLL_HOOK_ENDPOINT the hook service endpoint to post webhooks to
     POLL_HOOK_ENDPOINT: http://hook/hook/poll
 
+  # poller.commitStatusLabelPattern -- Regex pattern to match commit status label/context
   commitStatusLabelPattern: ""
 
   resources:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -427,6 +427,8 @@ poller:
     # poller.env.POLL_HOOK_ENDPOINT the hook service endpoint to post webhooks to
     POLL_HOOK_ENDPOINT: http://hook/hook/poll
 
+  commitStatusLabelPattern: ""
+
   resources:
     # poller.resources.limits -- Resource limits applied to the poller pods
     limits:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -427,8 +427,8 @@ poller:
     # poller.env.POLL_HOOK_ENDPOINT the hook service endpoint to post webhooks to
     POLL_HOOK_ENDPOINT: http://hook/hook/poll
 
-  # poller.commitStatusLabelPattern -- Regex pattern to match commit status label/context
-  commitStatusLabelPattern: ""
+  # poller.contextMatchPattern -- Regex pattern to use to match commit status context
+  contextMatchPattern: ""
 
   resources:
     # poller.resources.limits -- Resource limits applied to the poller pods

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -87,6 +87,12 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	}
 	fs.DurationVar(&o.pollPeriod, "period", defaultPollPeriod, "The time period between polls")
 
+	err := fs.Parse(args)
+	if err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+	o.configPath = configutil.PathOrDefault(o.configPath)
+
 	if o.commitStatusLabelPattern != "" {
 		commitStatusLabelPatternCompiled, err := regexp.Compile(o.commitStatusLabelPattern)
 		if err != nil {
@@ -95,11 +101,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 		o.commitStatusLabelPatternCompiled = commitStatusLabelPatternCompiled
 	}
 
-	err := fs.Parse(args)
-	if err != nil {
-		logrus.WithError(err).Fatal("Invalid options")
-	}
-	o.configPath = configutil.PathOrDefault(o.configPath)
 	return o
 }
 

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -163,7 +163,6 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatalf("failed to compile context match pattern \"%s\"", o.contextMatchPattern)
 		}
-		contextMatchPatternCompiled = contextMatchPatternCompiled
 	}
 
 	configureOpts := func(opts *gitv2.ClientFactoryOpts) {

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -91,7 +91,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
 	o.configPath = configutil.PathOrDefault(o.configPath)
-
 	return o
 }
 

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -282,7 +282,7 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 	}
 
 	for _, s := range statuses {
-		if c.isValidStatus(s) {
+		if c.isMatchingStatus(s) {
 			l.WithField("Statuses", statuses).Info("the SHA has CI statuses so not triggering")
 			return true, nil
 		}
@@ -290,7 +290,7 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 	return false, nil
 }
 
-func (c *pollingController) isValidStatus(s *scm.Status) bool {
+func (c *pollingController) isMatchingStatus(s *scm.Status) bool {
 	if c.commitStatusLabelPatternCompiled != nil {
 		if c.commitStatusLabelPatternCompiled.MatchString(s.Label) {
 			return true

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -20,36 +20,36 @@ var (
 )
 
 type pollingController struct {
-	DisablePollRelease               bool
-	DisablePollPullRequest           bool
-	repositoryNames                  []string
-	gitServer                        string
-	scmClient                        *scm.Client
-	fb                               filebrowser.Interface
-	pollstate                        pollstate.Interface
-	logger                           *logrus.Entry
-	commitStatusLabelPatternCompiled *regexp.Regexp
-	notifier                         func(webhook *scm.WebhookWrapper) error
+	DisablePollRelease          bool
+	DisablePollPullRequest      bool
+	repositoryNames             []string
+	gitServer                   string
+	scmClient                   *scm.Client
+	fb                          filebrowser.Interface
+	pollstate                   pollstate.Interface
+	logger                      *logrus.Entry
+	contextMatchPatternCompiled *regexp.Regexp
+	notifier                    func(webhook *scm.WebhookWrapper) error
 }
 
 func (c *pollingController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("hello from lighthouse poller\n"))
 }
 
-func NewPollingController(repositoryNames []string, gitServer string, scmClient *scm.Client, commitStatusLabelPatternCompiled *regexp.Regexp, fb filebrowser.Interface, notifier func(webhook *scm.WebhookWrapper) error) (*pollingController, error) {
+func NewPollingController(repositoryNames []string, gitServer string, scmClient *scm.Client, contextMatchPatternCompiled *regexp.Regexp, fb filebrowser.Interface, notifier func(webhook *scm.WebhookWrapper) error) (*pollingController, error) {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	if gitServer == "" {
 		gitServer = "https://github.com"
 	}
 	return &pollingController{
-		repositoryNames:                  repositoryNames,
-		gitServer:                        gitServer,
-		logger:                           logger,
-		scmClient:                        scmClient,
-		fb:                               fb,
-		notifier:                         notifier,
-		commitStatusLabelPatternCompiled: commitStatusLabelPatternCompiled,
-		pollstate:                        pollstate.NewMemoryPollState(),
+		repositoryNames:             repositoryNames,
+		gitServer:                   gitServer,
+		logger:                      logger,
+		scmClient:                   scmClient,
+		fb:                          fb,
+		notifier:                    notifier,
+		contextMatchPatternCompiled: contextMatchPatternCompiled,
+		pollstate:                   pollstate.NewMemoryPollState(),
 	}, nil
 }
 
@@ -291,8 +291,8 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 }
 
 func (c *pollingController) isMatchingStatus(s *scm.Status) bool {
-	if c.commitStatusLabelPatternCompiled != nil {
-		if c.commitStatusLabelPatternCompiled.MatchString(s.Label) {
+	if c.contextMatchPatternCompiled != nil {
+		if c.contextMatchPatternCompiled.MatchString(s.Label) {
 			return true
 		}
 	} else if !strings.HasPrefix(s.Label, "Lighthouse") {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -20,36 +20,36 @@ var (
 )
 
 type pollingController struct {
-	DisablePollRelease     bool
-	DisablePollPullRequest bool
-	repositoryNames        []string
-	gitServer              string
-	scmClient              *scm.Client
-	fb                     filebrowser.Interface
-	pollstate              pollstate.Interface
-	logger                 *logrus.Entry
-	compiledPattern        *regexp.Regexp
-	notifier               func(webhook *scm.WebhookWrapper) error
+	DisablePollRelease               bool
+	DisablePollPullRequest           bool
+	repositoryNames                  []string
+	gitServer                        string
+	scmClient                        *scm.Client
+	fb                               filebrowser.Interface
+	pollstate                        pollstate.Interface
+	logger                           *logrus.Entry
+	commitStatusLabelPatternCompiled *regexp.Regexp
+	notifier                         func(webhook *scm.WebhookWrapper) error
 }
 
 func (c *pollingController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("hello from lighthouse poller\n"))
 }
 
-func NewPollingController(repositoryNames []string, gitServer string, scmClient *scm.Client, compiledPattern *regexp.Regexp, fb filebrowser.Interface, notifier func(webhook *scm.WebhookWrapper) error) (*pollingController, error) {
+func NewPollingController(repositoryNames []string, gitServer string, scmClient *scm.Client, commitStatusLabelPatternCompiled *regexp.Regexp, fb filebrowser.Interface, notifier func(webhook *scm.WebhookWrapper) error) (*pollingController, error) {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	if gitServer == "" {
 		gitServer = "https://github.com"
 	}
 	return &pollingController{
-		repositoryNames: repositoryNames,
-		gitServer:       gitServer,
-		logger:          logger,
-		scmClient:       scmClient,
-		fb:              fb,
-		notifier:        notifier,
-		compiledPattern: compiledPattern,
-		pollstate:       pollstate.NewMemoryPollState(),
+		repositoryNames:                  repositoryNames,
+		gitServer:                        gitServer,
+		logger:                           logger,
+		scmClient:                        scmClient,
+		fb:                               fb,
+		notifier:                         notifier,
+		commitStatusLabelPatternCompiled: commitStatusLabelPatternCompiled,
+		pollstate:                        pollstate.NewMemoryPollState(),
 	}, nil
 }
 
@@ -291,8 +291,8 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 }
 
 func (c *pollingController) isValidStatus(s *scm.Status) bool {
-	if c.compiledPattern != nil {
-		if c.compiledPattern.MatchString(s.Label) {
+	if c.commitStatusLabelPatternCompiled != nil {
+		if c.commitStatusLabelPatternCompiled.MatchString(s.Label) {
 			return true
 		}
 	} else if !strings.HasPrefix(s.Label, "Lighthouse") {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -280,7 +280,6 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to list status")
 	}
-
 	for _, s := range statuses {
 		if c.isMatchingStatus(s) {
 			l.WithField("Statuses", statuses).Info("the SHA has CI statuses so not triggering")

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -46,9 +46,9 @@ func NewPollingController(repositoryNames []string, gitServer string, scmClient 
 		gitServer:                   gitServer,
 		logger:                      logger,
 		scmClient:                   scmClient,
+		contextMatchPatternCompiled: contextMatchPatternCompiled,
 		fb:                          fb,
 		notifier:                    notifier,
-		contextMatchPatternCompiled: contextMatchPatternCompiled,
 		pollstate:                   pollstate.NewMemoryPollState(),
 	}, nil
 }

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -292,13 +292,9 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 
 func (c *pollingController) isMatchingStatus(s *scm.Status) bool {
 	if c.contextMatchPatternCompiled != nil {
-		if c.contextMatchPatternCompiled.MatchString(s.Label) {
-			return true
-		}
-	} else if !strings.HasPrefix(s.Label, "Lighthouse") {
-		return true
+		return c.contextMatchPatternCompiled.MatchString(s.Label)
 	}
-	return false
+	return !strings.HasPrefix(s.Label, "Lighthouse")
 }
 
 func (c *pollingController) createPushHook(fullName, owner, repo, before, after, branch, refBranch string) (*scm.PushHook, error) {

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -46,9 +46,7 @@ func TestPollerReleases(t *testing.T) {
 	out, err := c.CombinedOutput()
 	require.NoError(t, err, "failed to get latest git commit sha")
 	sha := strings.TrimSpace(string(out))
-	fakeData.Statuses = map[string][]*scm.Status{
-		sha: {{Label: "Jenkins"}},
-	}
+	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: "Jenkins"}}}
 
 	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
@@ -107,9 +105,8 @@ func TestPollerPullRequests(t *testing.T) {
 		Sha:    sha,
 	}
 	// Load fake status with label that doesn't match our context match pattern
-	fakeData.Statuses = map[string][]*scm.Status{
-		sha: {{Label: "Jenkins"}},
-	}
+	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: "Jenkins"}}}
+
 	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -40,7 +40,7 @@ func TestPollerReleases(t *testing.T) {
 	contextMatchPatternCompiled, err := regexp.Compile(contextMatchPattern)
 	require.NoErrorf(t, err, "failed to compile context match pattern \"%s\"", contextMatchPattern)
 
-	// Load fake statuses that don't match our context match pattern
+	// Load fake status with label that doesn't match our context match pattern
 	c := exec.Command("git", "rev-parse", "HEAD")
 	c.Dir = testDataDir
 	out, err := c.CombinedOutput()
@@ -106,7 +106,7 @@ func TestPollerPullRequests(t *testing.T) {
 		State:  "open",
 		Sha:    sha,
 	}
-	// Load fake statuses that don't match our context match pattern
+	// Load fake status with label that doesn't match our context match pattern
 	fakeData.Statuses = map[string][]*scm.Status{
 		sha: {{Label: "Jenkins"}},
 	}

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -17,9 +17,11 @@ import (
 )
 
 var (
-	repoNames   = []string{"myorg/myrepo"}
-	gitServer   = "https://github.com"
-	testDataDir = "test_data"
+	repoNames           = []string{"myorg/myrepo"}
+	gitServer           = "https://github.com"
+	testDataDir         = "test_data"
+	contextMatchPattern = "^Lighthouse$"
+	statusLabel         = "Jenkins"
 )
 
 func TestPollerReleases(t *testing.T) {
@@ -36,7 +38,6 @@ func TestPollerReleases(t *testing.T) {
 	scmClient, fakeData := scmfake.NewDefault()
 	fb := fbfake.NewFakeFileBrowser(testDataDir, true)
 
-	contextMatchPattern := "^Lighthouse$"
 	contextMatchPatternCompiled, err := regexp.Compile(contextMatchPattern)
 	require.NoErrorf(t, err, "failed to compile context match pattern \"%s\"", contextMatchPattern)
 
@@ -46,7 +47,7 @@ func TestPollerReleases(t *testing.T) {
 	out, err := c.CombinedOutput()
 	require.NoError(t, err, "failed to get latest git commit sha")
 	sha := strings.TrimSpace(string(out))
-	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: "Jenkins"}}}
+	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
 	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
@@ -77,7 +78,6 @@ func TestPollerPullRequests(t *testing.T) {
 	scmClient, fakeData := scmfake.NewDefault()
 	fb := fbfake.NewFakeFileBrowser("test_data", true)
 
-	contextMatchPattern := "^Lighthouse$"
 	contextMatchPatternCompiled, err := regexp.Compile(contextMatchPattern)
 	require.NoErrorf(t, err, "failed to compile context match pattern \"%s\"", contextMatchPattern)
 
@@ -105,7 +105,7 @@ func TestPollerPullRequests(t *testing.T) {
 		Sha:    sha,
 	}
 	// Load fake status with label that doesn't match our context match pattern
-	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: "Jenkins"}}}
+	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
 	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")


### PR DESCRIPTION
If there are multiple CI jobs running against the same repository, poller may think that the Lighthouse job has run, when actually it was another system (e.g. Jenkins). This PR adds support for a flag to supply a regex pattern for matching the commit status context so that poller is looking for signs of the correct job.