### PR TITLE
fix: GIT_USER

### DIFF
--- a/charts/lighthouse/templates/foghorn-deployment.yaml
+++ b/charts/lighthouse/templates/foghorn-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             value: "/secrets/githubapp/tokens"
 {{- else }}
           - name: "GIT_USER"
-            value: {{ .Values.user }}
+            value: "{{ .Values.user }}"
           - name: "GIT_TOKEN"
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Error from server (BadRequest): error when creating "config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml": Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 3, error found in #10 byte of ...|,"value":36821702},{|..., bigger context ...|"https://github.com"},{"name":"GIT_USER","value":36821702},{"name":"GIT_TOKEN","valueFrom":{"secretK|...