### PR TITLE
feat: Support poller require release success

### DIFF
--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -41,6 +41,9 @@ spec:
           {{- if .Values.poller.contextMatchPattern }}
           - "--context-match-pattern={{ .Values.poller.contextMatchPattern }}"
           {{- end }}
+          {{- if .Values.poller.requireSuccess }}
+          - --require-success
+          {{- end }}
         ports:
           - name: http
             containerPort: {{ .Values.poller.internalPort }}

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -41,11 +41,8 @@ spec:
           {{- if .Values.poller.contextMatchPattern }}
           - "--context-match-pattern={{ .Values.poller.contextMatchPattern }}"
           {{- end }}
-          {{- if .Values.poller.requireSuccess }}
-          - --require-success
-          {{- if .Values.poller.successContextMatchPattern }}
-          - "--success-context-match-pattern={{ .Values.poller.successContextMatchPattern }}"
-          {{- end }}
+          {{- if .Values.poller.requireReleaseSuccess }}
+          - --require-release-success
           {{- end }}
         ports:
           - name: http

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -43,6 +43,9 @@ spec:
           {{- end }}
           {{- if .Values.poller.requireSuccess }}
           - --require-success
+          {{- if .Values.poller.successContextMatchPattern }}
+          - "--success-context-match-pattern={{ .Values.poller.successContextMatchPattern }}"
+          {{- end }}
           {{- end }}
         ports:
           - name: http

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -442,7 +442,7 @@ poller:
   # poller.contextMatchPattern -- Regex pattern to use to match commit status context
   contextMatchPattern: ""
 
-  # poller.requireReleaseSuccess -- Keep polling releases until commit status is successful.
+  # poller.requireReleaseSuccess -- Keep polling releases until the most recent commit status is successful
   requireReleaseSuccess: false
 
   resources:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -442,6 +442,9 @@ poller:
   # poller.contextMatchPattern -- Regex pattern to use to match commit status context
   contextMatchPattern: ""
 
+  # poller.requireSuccess -- Keep polling until commit status is successful
+  requireSuccess: false
+
   resources:
     # poller.resources.limits -- Resource limits applied to the poller pods
     limits:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -442,7 +442,7 @@ poller:
   # poller.contextMatchPattern -- Regex pattern to use to match commit status context
   contextMatchPattern: ""
 
-  # poller.requireReleaseSuccess -- Keep polling until release commit status is successful
+  # poller.requireReleaseSuccess -- Keep polling releases until commit status is successful.
   requireReleaseSuccess: false
 
   resources:

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -442,12 +442,8 @@ poller:
   # poller.contextMatchPattern -- Regex pattern to use to match commit status context
   contextMatchPattern: ""
 
-  # poller.requireSuccess -- Keep polling until commit status is successful
-  requireSuccess: false
-
-  # poller.successContextMatchPattern -- Only used when poller.requireSuccess is true. Polling will
-  # only retry for success if commit status context matches this regex pattern
-  successContextMatchPattern: ""
+  # poller.requireReleaseSuccess -- Keep polling until release commit status is successful
+  requireReleaseSuccess: false
 
   resources:
     # poller.resources.limits -- Resource limits applied to the poller pods

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -445,6 +445,10 @@ poller:
   # poller.requireSuccess -- Keep polling until commit status is successful
   requireSuccess: false
 
+  # poller.successContextMatchPattern -- Only used when poller.requireSuccess is true. Polling will
+  # only retry for success if commit status context matches this regex pattern
+  successContextMatchPattern: ""
+
   resources:
     # poller.resources.limits -- Resource limits applied to the poller pods
     limits:

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -44,9 +44,9 @@ type options struct {
 	contextMatchPattern    string
 	runOnce                bool
 	dryRun                 bool
+	requireReleaseSuccess  bool
 	disablePollRelease     bool
 	disablePollPullRequest bool
-	requireReleaseSuccess  bool
 	pollPeriod             time.Duration
 	pollReleasePeriod      time.Duration
 	pollPullRequestPeriod  time.Duration

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -72,7 +72,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Disable POSTing to the webhook service and just log the webhooks instead.")
 	fs.BoolVar(&o.disablePollRelease, "no-release", false, "Disable polling for new commits on the main branch (releases) - mostly used for easier testing/debugging.")
 	fs.BoolVar(&o.disablePollPullRequest, "no-pr", false, "Disable polling for Pull Request changes - mostly used for easier testing/debugging.")
-	fs.BoolVar(&o.requireReleaseSuccess, "require-release-success", false, "Keep polling releases until commit status is successful.")
+	fs.BoolVar(&o.requireReleaseSuccess, "require-release-success", false, "Keep polling releases until the most recent commit status is successful.")
 
 	fs.StringVar(&o.namespace, "namespace", "jx", "The namespace to listen in")
 	fs.StringVar(&o.repoNames, "repo", "", "The git repository names to poll. If not specified all the repositories are polled")

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -46,7 +46,7 @@ type options struct {
 	dryRun                 bool
 	disablePollRelease     bool
 	disablePollPullRequest bool
-	requireSuccess         bool
+	requireReleaseSuccess  bool
 	pollPeriod             time.Duration
 	pollReleasePeriod      time.Duration
 	pollPullRequestPeriod  time.Duration
@@ -68,12 +68,11 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.gitServerURL, "git-url", "", "The git provider URL")
 	fs.StringVar(&o.gitKind, "git-kind", "", "The git provider kind (e.g. github, gitlab, bitbucketserver")
 	fs.StringVar(&o.contextMatchPattern, "context-match-pattern", "", "Regex pattern to use to match commit status context.")
-	fs.StringVar(&o.successContextMatchPattern, "success-context-match-pattern", "", "Regex pattern to use to match success commit status context.")
 	fs.BoolVar(&o.runOnce, "run-once", false, "If true, run only once then quit.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Disable POSTing to the webhook service and just log the webhooks instead.")
 	fs.BoolVar(&o.disablePollRelease, "no-release", false, "Disable polling for new commits on the main branch (releases) - mostly used for easier testing/debugging.")
 	fs.BoolVar(&o.disablePollPullRequest, "no-pr", false, "Disable polling for Pull Request changes - mostly used for easier testing/debugging.")
-	fs.BoolVar(&o.requireSuccess, "require-success", false, "Keep polling until commit status is successful.")
+	fs.BoolVar(&o.requireReleaseSuccess, "require-release-success", false, "Keep polling until release commit status is successful.")
 
 	fs.StringVar(&o.namespace, "namespace", "jx", "The namespace to listen in")
 	fs.StringVar(&o.repoNames, "repo", "", "The git repository names to poll. If not specified all the repositories are polled")
@@ -181,14 +180,6 @@ func main() {
 		}
 	}
 
-	var successContextMatchPatternCompiled *regexp.Regexp
-	if o.successContextMatchPattern != "" {
-		successContextMatchPatternCompiled, err = regexp.Compile(o.successContextMatchPattern)
-		if err != nil {
-			logrus.WithError(err).Fatalf("failed to compile success context match pattern \"%s\"", o.successContextMatchPattern)
-		}
-	}
-
 	configureOpts := func(opts *gitv2.ClientFactoryOpts) {
 		opts.Token = func() []byte {
 			return []byte(o.gitToken)
@@ -229,7 +220,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to create scm client")
 	}
 
-	c, err := poller.NewPollingController(repoNames, serverURL, scmClient, contextMatchPatternCompiled, o.requireSuccess, successContextMatchPatternCompiled, fb, o.notifier)
+	c, err := poller.NewPollingController(repoNames, serverURL, scmClient, contextMatchPatternCompiled, o.requireReleaseSuccess, fb, o.notifier)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating Poller controller.")
 	}

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -46,6 +46,7 @@ type options struct {
 	dryRun                 bool
 	disablePollRelease     bool
 	disablePollPullRequest bool
+	requireSuccess         bool
 	pollPeriod             time.Duration
 	pollReleasePeriod      time.Duration
 	pollPullRequestPeriod  time.Duration
@@ -71,6 +72,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Disable POSTing to the webhook service and just log the webhooks instead.")
 	fs.BoolVar(&o.disablePollRelease, "no-release", false, "Disable polling for new commits on the main branch (releases) - mostly used for easier testing/debugging.")
 	fs.BoolVar(&o.disablePollPullRequest, "no-pr", false, "Disable polling for Pull Request changes - mostly used for easier testing/debugging.")
+	fs.BoolVar(&o.requireSuccess, "require-success", false, "Keep polling until commit status is successful.")
 
 	fs.StringVar(&o.namespace, "namespace", "jx", "The namespace to listen in")
 	fs.StringVar(&o.repoNames, "repo", "", "The git repository names to poll. If not specified all the repositories are polled")
@@ -218,7 +220,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to create scm client")
 	}
 
-	c, err := poller.NewPollingController(repoNames, serverURL, scmClient, contextMatchPatternCompiled, fb, o.notifier)
+	c, err := poller.NewPollingController(repoNames, serverURL, scmClient, contextMatchPatternCompiled, fb, o.requireSuccess, o.notifier)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating Poller controller.")
 	}

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -72,7 +72,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Disable POSTing to the webhook service and just log the webhooks instead.")
 	fs.BoolVar(&o.disablePollRelease, "no-release", false, "Disable polling for new commits on the main branch (releases) - mostly used for easier testing/debugging.")
 	fs.BoolVar(&o.disablePollPullRequest, "no-pr", false, "Disable polling for Pull Request changes - mostly used for easier testing/debugging.")
-	fs.BoolVar(&o.requireReleaseSuccess, "require-release-success", false, "Keep polling until release commit status is successful.")
+	fs.BoolVar(&o.requireReleaseSuccess, "require-release-success", false, "Keep polling releases until commit status is successful.")
 
 	fs.StringVar(&o.namespace, "namespace", "jx", "The namespace to listen in")
 	fs.StringVar(&o.repoNames, "repo", "", "The git repository names to poll. If not specified all the repositories are polled")

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -301,7 +301,9 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 
 func (c *pollingController) isMatchingStatus(s *scm.Status, isRelease bool) bool {
 	if isRelease && c.requireReleaseSuccess {
-		return s.State == scm.StateSuccess
+		if s.State != scm.StateSuccess {
+			return false
+		}
 	}
 
 	if c.contextMatchPatternCompiled != nil {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -124,7 +124,7 @@ func (c *pollingController) PollReleases() {
 			}
 
 			if c.requireSuccess {
-				// We have not been able to find a successful status so invalidate cache
+				// We have not been able to find a successful status so invalidate cache to retry
 				c.pollstate.Invalidate(fullName, "release", sha)
 			}
 
@@ -222,7 +222,7 @@ func (c *pollingController) pollPullRequest(ctx context.Context, l *logrus.Entry
 	}
 
 	if c.requireSuccess {
-		// We have not been able to find a successful status so invalidate cache
+		// We have not been able to find a successful status so invalidate cache to retry
 		c.pollstate.Invalidate(fullName, prName, "created")
 	}
 
@@ -262,7 +262,7 @@ func (c *pollingController) pollPullRequestPushHook(ctx context.Context, l *logr
 	}
 
 	if c.requireSuccess {
-		// We have not been able to find a successful status so invalidate cache
+		// We have not been able to find a successful status so invalidate cache to retry
 		c.pollstate.Invalidate(fullName, prName+"-push", sha)
 	}
 

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -313,8 +313,8 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 
 func (c *pollingController) isMatchingStatus(s *scm.Status) bool {
 	if c.requireSuccess {
-		// Only require success if no context match pattern is specified or if the context matches the
-		// specified context match pattern...
+		// Only require success if no success context match pattern is specified or if the context
+		// matches the specified success context match pattern...
 		if c.successContextMatchPatternCompiled == nil ||
 			(c.successContextMatchPatternCompiled != nil && c.successContextMatchPatternCompiled.MatchString(s.Label)) {
 			if s.State != scm.StateSuccess {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -124,7 +124,7 @@ func (c *pollingController) PollReleases() {
 			}
 
 			if c.requireReleaseSuccess {
-				// We have not been able to find a successful status so invalidate cache to retry
+				// We have not been able to find a successful release status so invalidate cache to retry
 				c.pollstate.Invalidate(fullName, "release", sha)
 			}
 

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -301,10 +301,7 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 
 func (c *pollingController) isMatchingStatus(s *scm.Status, isRelease bool) bool {
 	if isRelease && c.requireReleaseSuccess {
-		if s.State != scm.StateSuccess {
-			return false
-		}
-		return false
+		return s.State == scm.StateSuccess
 	}
 
 	if c.contextMatchPatternCompiled != nil {

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -50,7 +50,7 @@ func TestPollerReleases(t *testing.T) {
 	sha := strings.TrimSpace(string(out))
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, requireSuccess, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireSuccess, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollReleases()
@@ -108,7 +108,7 @@ func TestPollerPullRequests(t *testing.T) {
 	// Load fake status with label that doesn't match our context match pattern
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, requireSuccess, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireSuccess, contextMatchPatternCompiled, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollPullRequests()

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -22,6 +22,7 @@ var (
 	testDataDir         = "test_data"
 	contextMatchPattern = "^Lighthouse$"
 	statusLabel         = "Jenkins"
+	requireSuccess      = true
 )
 
 func TestPollerReleases(t *testing.T) {
@@ -49,7 +50,7 @@ func TestPollerReleases(t *testing.T) {
 	sha := strings.TrimSpace(string(out))
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, requireSuccess, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollReleases()
@@ -107,7 +108,7 @@ func TestPollerPullRequests(t *testing.T) {
 	// Load fake status with label that doesn't match our context match pattern
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, fb, requireSuccess, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollPullRequests()

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 var (
-	repoNames           = []string{"myorg/myrepo"}
-	gitServer           = "https://github.com"
-	testDataDir         = "test_data"
-	contextMatchPattern = "^Lighthouse$"
-	statusLabel         = "Jenkins"
-	requireSuccess      = true
+	repoNames             = []string{"myorg/myrepo"}
+	gitServer             = "https://github.com"
+	testDataDir           = "test_data"
+	contextMatchPattern   = "^Lighthouse$"
+	statusLabel           = "Jenkins"
+	requireReleaseSuccess = true
 )
 
 func TestPollerReleases(t *testing.T) {
@@ -50,7 +50,7 @@ func TestPollerReleases(t *testing.T) {
 	sha := strings.TrimSpace(string(out))
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireSuccess, contextMatchPatternCompiled, fb, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireReleaseSuccess, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollReleases()
@@ -108,7 +108,7 @@ func TestPollerPullRequests(t *testing.T) {
 	// Load fake status with label that doesn't match our context match pattern
 	fakeData.Statuses = map[string][]*scm.Status{sha: {{Label: statusLabel}}}
 
-	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireSuccess, contextMatchPatternCompiled, fb, fakeNotifier)
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, contextMatchPatternCompiled, requireReleaseSuccess, fb, fakeNotifier)
 	require.NoError(t, err, "failed to create PollingController")
 
 	p.PollPullRequests()


### PR DESCRIPTION
Adds a flag to keeping polling releases until the commit status is successful. This can be useful if you always expect releases to succeed.

The main issue with this implementation is that a more recent poll might overwrite an already successful status if the jobs overlap, causing unnecessary/continuous polling (since the go-scm library [only exposes the most recent status](https://github.com/jenkins-x/go-scm/blob/e6613ef378a644b1c464409a88d27f59484fffa8/scm/driver/github/repo.go#L462-L465) for a particular context) so the user needs to ensure the poll interval is long enough to reduce the chance of this happening (e.g. longer than the job timeout). I have created an issue and a WIP PR to allow go-scm to support fixing this issue (for GitHub at least): https://github.com/jenkins-x/go-scm/issues/314