### PR TITLE
feat: Add backoff limit for cron job

### DIFF
--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -71,6 +71,7 @@ helm uninstall my-lighthouse --namespace lighthouse
 | `foghorn.resources.requests` | object | Resource requests applied to the foghorn pods | `{"cpu":"80m","memory":"128Mi"}` |
 | `foghorn.terminationGracePeriodSeconds` | int | Termination grace period for foghorn pods | `180` |
 | `foghorn.tolerations` | list | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) applied to the foghorn pods | `[]` |
+| `gcJobs.backoffLimit` | int | Set the backoff limit for failed cronJobs | `6` |
 | `gcJobs.concurrencyPolicy` | string | Drives the job's concurrency policy | `"Forbid"` |
 | `gcJobs.failedJobsHistoryLimit` | int | Drives the failed jobs history limit | `1` |
 | `gcJobs.image.pullPolicy` | string | Template for computing the gc job docker image pull policy | `"{{ .Values.image.pullPolicy }}"` |

--- a/charts/lighthouse/templates/gc-jobs-cj.yaml
+++ b/charts/lighthouse/templates/gc-jobs-cj.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       creationTimestamp: null
     spec:
+      backoffLimit: {{ .Values.gcJobs.backoffLimit }}
       template:
         metadata:
           creationTimestamp: null

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -89,6 +89,9 @@ gcJobs:
   # gcJobs.concurrencyPolicy -- Drives the job's concurrency policy
   concurrencyPolicy: Forbid
 
+  # gcJobs.backoffLimit -- Drives the job's backoff limit
+  backoffLimit: 6
+
   image:
     # gcJobs.image.repository -- Template for computing the gc job docker image repository
     repository: "{{ .Values.image.parentRepository }}/lighthouse-gc-jobs"


### PR DESCRIPTION
- Add backoff limit for cron job to override the default of 6 if needed

Signed-off-by: Brian Davis <dbrian@vmware.com>