### PR TITLE
fix: do not include tekton roles when disabled

### DIFF
--- a/charts/lighthouse/templates/keeper-role.yaml
+++ b/charts/lighthouse/templates/keeper-role.yaml
@@ -12,6 +12,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.engines.tekton }}
   - apiGroups:
       - tekton.dev
     resources:
@@ -27,6 +28,7 @@ rules:
       - watch
       - patch
       - delete
+  {{- end }}
   - apiGroups:
       - lighthouse.jenkins.io
     resources:


### PR DESCRIPTION
- do not include tekton roles when tekton engine is disabled

Signed-off-by: Brian Davis <dbrian@vmware.com>