### PR TITLE
fix: `patchDevImages.sh`  register arg not take effect

### DIFF
--- a/hack/patchDevImages.sh
+++ b/hack/patchDevImages.sh
@@ -68,7 +68,7 @@ for val in {0..5}; do
     image_names=(webhooks keeper foghorn gc-jobs tekton-controller jenkins-controller)
 
     full_image_name=""
-    if [ -n "${registry+}" ]
+    if [ -n "${registry}" ]
      then full_image_name="${full_image_name}${registry}/"
     fi
     if [ -n "${user}" ]


### PR DESCRIPTION
I tried to change docker registery by add `-r` option, but it not take effect. After some debug, I change `if [ -n "${registry+}" ]` to `if [ -n "${registry}" ]`, then `-r` option take effect.

It looks like a typo