### PR TITLE
fix: Page through statuses when polling

### DIFF
--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -309,6 +309,9 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 			return allStatuses, err
 		}
 		allStatuses = append(allStatuses, statuses...)
+		if response == nil {
+			break
+		}
 		// Check for an invalid value for the next page
 		if response.Page.Next <= page {
 			break

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -300,11 +300,11 @@ func (c *pollingController) ListAllStatus(ctx context.Context, fullName string, 
 	allStatuses := []*scm.Status{}
 	page := 1
 	size := 100
-	opts := scm.ListOptions{
-		Page: page,
-		Size: size,
-	}
 	for {
+		opts := scm.ListOptions{
+			Page: page,
+			Size: size,
+		}
 		statuses, _, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {
 			return allStatuses, err

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -309,7 +309,8 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 			return allStatuses, err
 		}
 		allStatuses = append(allStatuses, statuses...)
-		if page == response.Page.Next || response.Page.Next < 1 {
+		// Check for an invalid value for the next page
+		if response.Page.Next <= page {
 			break
 		}
 		page = response.Page.Next

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -299,11 +299,10 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string, sha string) ([]*scm.Status, error) {
 	allStatuses := []*scm.Status{}
 	page := 1
-	size := 100
 	for {
 		opts := scm.ListOptions{
 			Page: page,
-			Size: size,
+			Size: 100,
 		}
 		statuses, response, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -302,6 +302,7 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 	for {
 		opts := scm.ListOptions{
 			Page: page,
+			Size: 100,
 		}
 		statuses, response, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -283,7 +283,7 @@ func (c *pollingController) pollPullRequestPushHook(ctx context.Context, l *logr
 }
 
 func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry, fullName string, sha string, isRelease bool) (bool, error) {
-	statuses, err := c.ListAllStatus(ctx, fullName, sha)
+	statuses, err := c.ListAllStatuses(ctx, fullName, sha)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to list status")
 	}
@@ -296,7 +296,7 @@ func (c *pollingController) hasStatusForSHA(ctx context.Context, l *logrus.Entry
 	return false, nil
 }
 
-func (c *pollingController) ListAllStatus(ctx context.Context, fullName string, sha string) ([]*scm.Status, error) {
+func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string, sha string) ([]*scm.Status, error) {
 	allStatuses := []*scm.Status{}
 	page := 1
 	size := 100

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -305,15 +305,15 @@ func (c *pollingController) ListAllStatus(ctx context.Context, fullName string, 
 			Page: page,
 			Size: size,
 		}
-		statuses, _, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
+		statuses, response, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {
 			return allStatuses, err
 		}
 		allStatuses = append(allStatuses, statuses...)
-		if len(statuses) < size {
+		page = response.Page.Next
+		if page == 0 {
 			break
 		}
-		page++
 	}
 	return allStatuses, nil
 }

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -309,10 +309,10 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 			return allStatuses, err
 		}
 		allStatuses = append(allStatuses, statuses...)
-		page = response.Page.Next
-		if page == 0 {
+		if page == response.Page.Next || response.Page.Next < 1 {
 			break
 		}
+		page = response.Page.Next
 	}
 	return allStatuses, nil
 }

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -302,7 +302,6 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 	for {
 		opts := scm.ListOptions{
 			Page: page,
-			Size: 100,
 		}
 		statuses, response, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -309,11 +309,8 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 			return allStatuses, err
 		}
 		allStatuses = append(allStatuses, statuses...)
-		if response == nil {
-			break
-		}
 		// Check for an invalid value for the next page
-		if response.Page.Next <= page {
+		if response == nil || response.Page.Next <= page {
 			break
 		}
 		page = response.Page.Next

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	censor = func(content []byte) []byte { return content }
+	StatusesPageSize = 100
 )
 
 type pollingController struct {
@@ -302,7 +303,7 @@ func (c *pollingController) ListAllStatuses(ctx context.Context, fullName string
 	for {
 		opts := scm.ListOptions{
 			Page: page,
-			Size: 100,
+			Size: StatusesPageSize,
 		}
 		statuses, response, err := c.scmClient.Repositories.ListStatus(ctx, fullName, sha, opts)
 		if err != nil {

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -128,7 +128,7 @@ func TestPollerPullRequests(t *testing.T) {
 }
 
 func TestListAllStatuses(t *testing.T) {
-	sha := "master"
+	sha := "mysha1234"
 	fullName := repoNames[0]
 
 	scmClient, fakeData := scmfake.NewDefault()

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -1,10 +1,12 @@
 package poller_test
 
 import (
+	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
+	"context"
 
 	scmfake "github.com/jenkins-x/go-scm/scm/driver/fake"
 
@@ -123,4 +125,26 @@ func TestPollerPullRequests(t *testing.T) {
 	pushHook := pushHooks[0]
 	assert.NotNil(t, pushHook, "no PushHook")
 	t.Logf("created PushHook %#v", pushHook)
+}
+
+func TestListAllStatuses(t *testing.T) {
+	sha := "master"
+	fullName := repoNames[0]
+
+	scmClient, fakeData := scmfake.NewDefault()
+	fakeData.Statuses = map[string][]*scm.Status{sha: {}}
+	// Populate fake data with more entries than the page size to ensure there
+	// are multiple pages of data
+	statusesCount := poller.StatusesPageSize + 1
+	for i := 0; i < statusesCount; i++ {
+		status := scm.Status{}
+		fakeData.Statuses[sha] = append(fakeData.Statuses[sha], &status)
+	}
+
+	p, err := poller.NewPollingController(repoNames, gitServer, scmClient, nil, requireReleaseSuccess, nil, nil)
+	require.NoError(t, err, "failed to create PollingController")
+
+	statuses, err := p.ListAllStatuses(context.TODO(), fullName, sha)
+	assert.Nil(t, err, "failed to list statuses")
+	require.Len(t, statuses, statusesCount, fmt.Sprintf("should have %d statuses", statusesCount))
 }


### PR DESCRIPTION
This PR ensures that Lighthouse poller finds all statuses when polling instead of just using the first page