### PR TITLE
fix: correct url for gitea blobs

### DIFF
--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -166,6 +166,8 @@ func BlobURLForProvider(providerType string, baseURL *url.URL, owner, repo, bran
 		return u
 	case "gitlab":
 		return fmt.Sprintf("%s/%s/%s/-/blob/%s/%v", strings.TrimSuffix(baseURL.String(), "/"), owner, repo, branch, fullPath)
+	case "gitea":
+		return fmt.Sprintf("%s/%s/%s/src/branch/%s/%v", strings.TrimSuffix(baseURL.String(), "/"), owner, repo, branch, fullPath)
 	default:
 		return fmt.Sprintf("%s/%s/%s/blob/%s/%v", strings.TrimSuffix(baseURL.String(), "/"), owner, repo, branch, fullPath)
 	}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -852,6 +852,8 @@ func URLForFile(providerType string, serverURL string, owner string, repo string
 		return fmt.Sprintf("%s/projects/%s/repos/%s/browse/%s", serverURL, strings.ToUpper(owner), repo, path)
 	case "gitlab":
 		return fmt.Sprintf("%s/%s/%s/-/blob/master/%s", serverURL, owner, repo, path)
+	case "gitea":
+		return fmt.Sprintf("%s/%s/%s/src/branch/master/%s", serverURL, owner, repo, path)
 	default:
 		return fmt.Sprintf("%s/%s/%s/blob/master/%s", serverURL, owner, repo, path)
 	}


### PR DESCRIPTION
for example this URL is the URL to the readme in the gitea go-sdk,
https://gitea.com/gitea/go-sdk/src/branch/master/README.md

The format uses `src/branch` and not blob like GitHub.