### PR TITLE
fix: evaluate ignoreChanges before checking if pre-submit should always run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,31 +36,31 @@ build: build-webhooks build-poller build-keeper build-foghorn build-tekton-contr
 
 .PHONY: build-webhooks
 build-webhooks: ## Build the webhooks controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(WEBHOOKS_EXECUTABLE) $(WEBHOOKS_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(WEBHOOKS_EXECUTABLE) $(WEBHOOKS_MAIN_SRC_FILE)
 
 .PHONY: build-poller
 build-poller: ## Build the poller controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(POLLER_EXECUTABLE) $(POLLER_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(POLLER_EXECUTABLE) $(POLLER_MAIN_SRC_FILE)
 
 .PHONY: build-keeper
 build-keeper: ## Build the keeper controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(KEEPER_EXECUTABLE) $(KEEPER_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(KEEPER_EXECUTABLE) $(KEEPER_MAIN_SRC_FILE)
 
 .PHONY: build-foghorn
 build-foghorn: ## Build the foghorn controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(FOGHORN_EXECUTABLE) $(FOGHORN_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(FOGHORN_EXECUTABLE) $(FOGHORN_MAIN_SRC_FILE)
 
 .PHONY: build-gc-jobs
 build-gc-jobs: ## Build the GC jobs binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(GC_JOBS_EXECUTABLE) $(GC_JOBS_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(GC_JOBS_EXECUTABLE) $(GC_JOBS_MAIN_SRC_FILE)
 
 .PHONY: build-tekton-controller
 build-tekton-controller: ## Build the Tekton controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(TEKTON_CONTROLLER_EXECUTABLE) $(TEKTON_CONTROLLER_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(TEKTON_CONTROLLER_EXECUTABLE) $(TEKTON_CONTROLLER_MAIN_SRC_FILE)
 
 .PHONY: build-jenkins-controller
 build-jenkins-controller: ## Build the Jenkins controller binary for the native OS
-	$(GO) build -i -ldflags "$(GO_LDFLAGS)" -o bin/$(JENKINS_CONTROLLER_EXECUTABLE) $(JENKINS_CONTROLLER_MAIN_SRC_FILE)
+	$(GO) build -ldflags "$(GO_LDFLAGS)" -o bin/$(JENKINS_CONTROLLER_EXECUTABLE) $(JENKINS_CONTROLLER_MAIN_SRC_FILE)
 
 .PHONY: release
 release: linux

--- a/pkg/config/job/config.go
+++ b/pkg/config/job/config.go
@@ -78,40 +78,6 @@ func (c *Config) Merge(other Config) error {
 
 // Init sets defaults and initializes Config
 func (c *Config) Init(lh lighthouse.Config) error {
-	decoration := c.DecorationRequested()
-	if decoration {
-		// if c.Plank.DefaultDecorationConfig == nil {
-		// 	return errors.New("no default decoration config provided for plank")
-		// }
-		// if c.Plank.DefaultDecorationConfig.UtilityImages == nil {
-		// 	return errors.New("no default decoration image pull specs provided for plank")
-		// }
-		// if c.Plank.DefaultDecorationConfig.GCSConfiguration == nil {
-		// 	return errors.New("no default GCS decoration config provided for plank")
-		// }
-		// if c.Plank.DefaultDecorationConfig.GCSCredentialsSecret == "" {
-		// 	return errors.New("no default GCS credentials secret provided for plank")
-		// }
-		// for _, vs := range c.Presubmits {
-		// 	for i := range vs {
-		// 		// if ps.Decorate {
-		// 		// 	ps.DecorationConfig = ps.DecorationConfig.ApplyDefault(c.Plank.DefaultDecorationConfig)
-		// 		// }
-		// 	}
-		// }
-		// for _, js := range c.Postsubmits {
-		// 	for i := range js {
-		// 		// if ps.Decorate {
-		// 		// 	ps.DecorationConfig = ps.DecorationConfig.ApplyDefault(c.Plank.DefaultDecorationConfig)
-		// 		// }
-		// 	}
-		// }
-		// for i := range c.Periodics {
-		// 	// if ps.Decorate {
-		// 	// 	ps.DecorationConfig = ps.DecorationConfig.ApplyDefault(c.Plank.DefaultDecorationConfig)
-		// 	// }
-		// }
-	}
 	for _, ps := range c.Presubmits {
 		for i := range ps {
 			ps[i].SetDefaults(lh.PodNamespace)

--- a/pkg/jobutil/filter.go
+++ b/pkg/jobutil/filter.go
@@ -73,7 +73,6 @@ func AggregateFilter(filters []Filter) Filter {
 // FilterPresubmits determines which presubmits should run and which should be skipped
 // by evaluating the user-provided filter.
 func FilterPresubmits(filter Filter, changes job.ChangedFilesProvider, branch string, presubmits []job.Presubmit, logger *logrus.Entry) ([]job.Presubmit, []job.Presubmit, error) {
-
 	var toTrigger []job.Presubmit
 	var namesToTrigger []string
 	var toSkipSuperset []job.Presubmit

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -63,7 +63,7 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.Gen
 			return err
 		}
 		if !trusted {
-			resp := fmt.Sprintf("Cannot trigger testing until a trusted user reviews the PR and leaves an `/ok-to-test` message.")
+			resp := "Cannot trigger testing until a trusted user reviews the PR and leaves an `/ok-to-test` message."
 			c.Logger.Infof("Commenting \"%s\".", resp)
 			return c.SCMProviderClient.CreateComment(org, repo, number, true, plugins.FormatResponseRaw(gc.Body, gc.Link, c.SCMProviderClient.QuoteAuthorForComment(gc.Author.Login), resp))
 		}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

ignore changes are not ignored if always_run is set to true.
So even if the user wants to not trigger a build when README file is changed for example, lighthouse will still trigger a build because always_run is evaluated first in the logic.

Context: https://kubernetes.slack.com/archives/C9MBGQJRH/p1657794048005119