### PR TITLE
fix: make /test work with branches

### DIFF
--- a/pkg/config/job/presubmit.go
+++ b/pkg/config/job/presubmit.go
@@ -48,7 +48,7 @@ type Presubmit struct {
 	JenkinsSpec  *JenkinsSpec `json:"jenkins_spec,omitempty"`
 
 	// We'll set these when we load it.
-	// re *regexp.Regexp // from Trigger.
+	re *regexp.Regexp // from Trigger.
 }
 
 // SetDefaults initializes default values
@@ -91,6 +91,7 @@ func (p *Presubmit) SetRegexes() error {
 
 // ClearCompiledRegexes compiles and validates all the regular expressions
 func (p *Presubmit) ClearCompiledRegexes() {
+	p.re = nil
 	p.Brancher.re = nil
 	p.Brancher.reSkip = nil
 	p.RegexpChangeMatcher.reChanges = nil
@@ -153,12 +154,12 @@ func (p Presubmit) TriggerMatches(body string) bool {
 			return body == p.Trigger
 		}
 	}
-	return p.Trigger != "" && re != nil && re.MatchString(body)
+	return re != nil && re.MatchString(body)
 }
 
 // ContextRequired checks whether a context is required from github points of view (required check).
 func (p Presubmit) ContextRequired() bool {
-	return !p.Optional && !p.SkipReport
+	return !(p.Optional || p.SkipReport)
 }
 
 // Validate validates job base

--- a/pkg/jobutil/filter.go
+++ b/pkg/jobutil/filter.go
@@ -79,6 +79,7 @@ func FilterPresubmits(filter Filter, changes job.ChangedFilesProvider, branch st
 	for _, presubmit := range presubmits {
 		matches, forced, defaults := filter(presubmit)
 		if !matches {
+			logger.WithField("presubmit", presubmit).Trace("doesn't match command filter")
 			continue
 		}
 		shouldRun, err := presubmit.ShouldRun(branch, changes, forced, defaults)

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -49,6 +49,7 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.Gen
 	if err != nil {
 		return err
 	}
+	c.Logger.Tracef("Fetched pull request: %+v", pr)
 
 	// Skip untrusted users comments.
 	trusted, err := TrustedUser(c.SCMProviderClient, trigger, commentAuthor, org, repo)

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -44,12 +44,12 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.Gen
 	if commentAuthor == botName {
 		c.Logger.Warn("Comment is made by the bot, for production installs it is recommended to use a different bot user account that your personal one")
 	}
-
+	c.Logger.WithField("event", gc).Trace("Generic comment event")
 	pr, err := c.SCMProviderClient.GetPullRequest(org, repo, number)
 	if err != nil {
 		return err
 	}
-	c.Logger.Tracef("Fetched pull request: %+v", pr)
+	c.Logger.WithField("pull_request", pr).Trace("Fetched pull request")
 
 	// Skip untrusted users comments.
 	trusted, err := TrustedUser(c.SCMProviderClient, trigger, commentAuthor, org, repo)

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -546,7 +546,6 @@ func TestHandleGenericComment(t *testing.T) {
 			AddedLabels:   issueLabels(labels.OkToTest),
 			RemovedLabels: issueLabels(labels.NeedsOkToTest),
 		},
-		/* TODO
 		{
 			name:   "/test of branch-sharded job",
 			Author: "trusted-member",
@@ -557,7 +556,7 @@ func TestHandleGenericComment(t *testing.T) {
 				"org/repo": {
 					{
 						Base: job.Base{
-							Name: "jab",
+							Name: "master-jab",
 						},
 						Brancher: job.Brancher{Branches: []string{"master"}},
 						Reporter: job.Reporter{
@@ -568,7 +567,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 					{
 						Base: job.Base{
-							Name: "jab",
+							Name: "release-jab",
 						},
 						Brancher: job.Brancher{Branches: []string{"release"}},
 						Reporter: job.Reporter{
@@ -617,7 +616,6 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldReport: true,
 		},
-		*/
 		{
 			name:   "branch-sharded job. no shard matches base branch. Skipped statuses elided.",
 			Author: "trusted-member",

--- a/pkg/scmprovider/pull_requests.go
+++ b/pkg/scmprovider/pull_requests.go
@@ -20,6 +20,7 @@ type MergeDetails struct {
 func (c *Client) GetPullRequest(owner, repo string, number int) (*scm.PullRequest, error) {
 	ctx := context.Background()
 	fullName := c.repositoryName(owner, repo)
+	// Isn't pr.Base.Ref populated?
 	pr, _, err := c.client.PullRequests.Find(ctx, fullName, number)
 	if err != nil {
 		return nil, err

--- a/pkg/scmprovider/pull_requests.go
+++ b/pkg/scmprovider/pull_requests.go
@@ -20,7 +20,6 @@ type MergeDetails struct {
 func (c *Client) GetPullRequest(owner, repo string, number int) (*scm.PullRequest, error) {
 	ctx := context.Background()
 	fullName := c.repositoryName(owner, repo)
-	// Isn't pr.Base.Ref populated?
 	pr, _, err := c.client.PullRequests.Find(ctx, fullName, number)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
You couldn't trigger pipelines with /test if they had branches specified. This is fixed with this PR. There where commented out tests that failed without this fix.

I let the trace logs be. They might be useful some other time.