### PR TITLE
feat: Sparse checkout

### DIFF
--- a/pkg/filebrowser/fake/fake_file_browser.go
+++ b/pkg/filebrowser/fake/fake_file_browser.go
@@ -63,7 +63,7 @@ func (f *fakeFileBrowser) getPath(owner, repo, path, ref string) string {
 	return filepath.Join(f.dir, path)
 }
 
-func (f *fakeFileBrowser) WithDir(owner, repo, ref string, fc filebrowser.FetchCache, fn func(dir string) error) error {
+func (f *fakeFileBrowser) WithDir(owner, repo, ref string, fc filebrowser.FetchCache, sparseCheckoutPatterns []string, fn func(dir string) error) error {
 	dir := f.getPath(owner, repo, "", ref)
 	return fn(dir)
 }

--- a/pkg/filebrowser/git_file_browser.go
+++ b/pkg/filebrowser/git_file_browser.go
@@ -235,7 +235,7 @@ func (c *repoClientFacade) UseRef(ref string, fc FetchCache) error {
 		}
 		if !isSHA {
 			// lets merge any new changes into the main branch
-			_, err := c.repoClient.Merge("FETCH_HEAD")
+			_, err := runCmd(c.repoClient.Directory(), "git", "merge", "FETCH_HEAD")
 			if err != nil {
 				return errors.Wrapf(err, "failed to merge repository %s", c.fullName)
 			}

--- a/pkg/filebrowser/interface.go
+++ b/pkg/filebrowser/interface.go
@@ -14,5 +14,5 @@ type Interface interface {
 	ListFiles(owner, repo, path, ref string, fc FetchCache) ([]*scm.FileEntry, error)
 
 	// WithDir processes the given repository and reference at the given directory
-	WithDir(owner, repo, ref string, fc FetchCache, f func(dir string) error) error
+	WithDir(owner, repo, ref string, fc FetchCache, sparseCheckoutPatterns []string, f func(dir string) error) error
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -413,6 +413,7 @@ func retryCmd(l *logrus.Entry, dir, cmd string, arg ...string) ([]byte, error) {
 			sleepyTime *= 2
 			continue
 		}
+		l.Debugf("Running %s %v succeeded with output %s.", cmd, arg, string(b))
 		break
 	}
 	return b, err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -25,6 +25,7 @@ type Client interface {
 	SetRemote(remote string)
 	SetCredentials(user string, tokenGenerator func() []byte)
 	Clone(repo string) (*Repo, error)
+	SparseClone(repo string, sparseCheckoutPatterns []string) (*Repo, error)
 }
 
 // client can clone repos. It keeps a local cache, so successive clones of the
@@ -150,18 +151,8 @@ func (c *client) Clone(repo string) (*Repo, error) {
 		if err := os.Mkdir(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
-		prefix := ""
-		repoText := repo
-		if c.gitKind == kindBitbucketServer {
-			prefix = "scm/"
-			idx := strings.Index(repo, "/")
+		remote := getRemote(repo, c, base)
 
-			// to clone on bitbucket we need to lower case the projectKey owner
-			if idx > 0 {
-				repoText = fmt.Sprintf("%s/%s", strings.ToLower(repo[0:idx]), repo[idx+1:])
-			}
-		}
-		remote := fmt.Sprintf("%s/%s%s", base, prefix, repoText)
 		if b, err := retryCmd(c.logger, "", c.git, "clone", "--mirror", remote, cache); err != nil {
 			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
 		}
@@ -191,6 +182,69 @@ func (c *client) Clone(repo string) (*Repo, error) {
 		user:   user,
 		pass:   pass,
 	}, nil
+}
+
+func (c *client) SparseClone(repo string, sparseCheckoutPatterns []string) (*Repo, error) {
+	// Make pattern part of cache key somehow.
+	replacer := strings.NewReplacer(".", "_", "/", "_")
+	cacheKey := repo + replacer.Replace(strings.Join(sparseCheckoutPatterns, "-"))
+	c.lockRepo(cacheKey)
+	defer c.unlockRepo(cacheKey)
+
+	base := c.base
+	user, pass := c.getCredentials()
+	if user != "" && pass != "" {
+		host, scheme := gitHostAndScheme(c.base)
+		base = fmt.Sprintf("%s://%s:%s@%s", scheme, user, pass, host)
+	}
+	cache := filepath.Join(c.dir, cacheKey)
+	if _, err := os.Stat(cache); os.IsNotExist(err) {
+		// Cache miss, clone it now.
+		c.logger.Infof("Cloning %s for the first time.", repo)
+		if err := os.Mkdir(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
+		remote := getRemote(repo, c, base)
+
+		if b, err := retryCmd(c.logger, "", c.git, "clone", "--no-checkout", "--filter=blob:none", "--sparse", "--depth=1", remote, cache); err != nil {
+			return nil, fmt.Errorf("failed to clone repository: %v. output: %s", err, string(b))
+		}
+		if b, err := retryCmd(c.logger, cache, c.git, append([]string{"sparse-checkout", "set"}, sparseCheckoutPatterns...)...); err != nil {
+			return nil, fmt.Errorf("failed to set sparse checkout patterns to %v: %v. output: %s", sparseCheckoutPatterns, err, string(b))
+		}
+	} else if err != nil {
+		return nil, err
+	} else {
+		// Cache hit. Do a git fetch to keep updated.
+		c.logger.Infof("Fetching %s.", repo)
+		if b, err := retryCmd(c.logger, cache, c.git, "fetch", "--depth=1"); err != nil {
+			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
+		}
+	}
+	return &Repo{
+		Dir:    cache,
+		logger: c.logger,
+		git:    c.git,
+		base:   base,
+		repo:   repo,
+		user:   user,
+		pass:   pass,
+	}, nil
+}
+
+func getRemote(repo string, c *client, base string) string {
+	prefix := ""
+	repoText := repo
+	if c.gitKind == kindBitbucketServer {
+		prefix = "scm/"
+		idx := strings.Index(repo, "/")
+
+		// to clone on bitbucket we need to lower case the projectKey owner
+		if idx > 0 {
+			repoText = fmt.Sprintf("%s/%s", strings.ToLower(repo[0:idx]), repo[idx+1:])
+		}
+	}
+	return fmt.Sprintf("%s/%s%s", base, prefix, repoText)
 }
 
 func gitHostAndScheme(s string) (string, string) {

--- a/pkg/git/v2/client_factory.go
+++ b/pkg/git/v2/client_factory.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -289,8 +290,14 @@ func (c *clientFactory) ClientFor(org, repo string, sparseCheckoutPatterns []str
 	}
 
 	// initialize the new derivative repo from the cache
-	if err := repoClientCloner.Clone(cacheDir, sparseCheckoutPatterns); err != nil {
+	if err := repoClientCloner.Clone(cacheDir); err != nil {
 		return nil, err
+	}
+	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
+	if sparseCheckout && len(sparseCheckoutPatterns) > 0 {
+		if err := repoClient.SetSparseCheckoutPatterns(sparseCheckoutPatterns); err != nil {
+			return nil, err
+		}
 	}
 
 	duration := time.Now().Sub(start)

--- a/pkg/git/v2/client_factory.go
+++ b/pkg/git/v2/client_factory.go
@@ -34,7 +34,7 @@ type ClientFactory interface {
 	// been cloned to the given directory.
 	ClientFromDir(org, repo, dir string) (RepoClient, error)
 	// ClientFor creates a client that operates on a new clone of the repo.
-	ClientFor(org, repo string) (RepoClient, error)
+	ClientFor(org, repo string, sparseCheckoutPatterns []string) (RepoClient, error)
 
 	// Clean removes the caches used to generate clients
 	Clean() error
@@ -245,7 +245,7 @@ func (c *clientFactory) ClientFromDir(org, repo, dir string) (RepoClient, error)
 // In that case, it must do a full git mirror clone. For large repos, this can
 // take a while. Once that is done, it will do a git fetch instead of a clone,
 // which will usually take at most a few seconds.
-func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
+func (c *clientFactory) ClientFor(org, repo string, sparseCheckoutPatterns []string) (RepoClient, error) {
 	start := time.Now()
 	cacheDir := path.Join(c.cacheDir, org, repo)
 	l := c.logger.WithFields(logrus.Fields{"org": org, "repo": repo, "dir": cacheDir})
@@ -289,7 +289,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 	}
 
 	// initialize the new derivative repo from the cache
-	if err := repoClientCloner.Clone(cacheDir); err != nil {
+	if err := repoClientCloner.Clone(cacheDir, sparseCheckoutPatterns); err != nil {
 		return nil, err
 	}
 

--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -83,7 +84,7 @@ type cacher interface {
 // cloner knows how to clone repositories from a central cache
 type cloner interface {
 	// Clone clones the repository from a local path.
-	Clone(from string) error
+	Clone(from string, sparseCheckoutPatterns []string) error
 }
 
 // MergeOpt holds options for git merge operations.
@@ -109,11 +110,25 @@ func (i *interactor) Clean() error {
 	return os.RemoveAll(i.dir)
 }
 
-// Clone clones the repository from a local path.
-func (i *interactor) Clone(from string) error {
-	i.logger.Debugf("Creating a clone of the repo at %s from %s", i.dir, from)
-	if out, err := i.executor.Run("clone", from, i.dir); err != nil {
+// Clone clones the repository from a repository.
+func (i *interactor) Clone(repo string, sparseCheckoutPatterns []string) error {
+	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
+	if sparseCheckout && sparseCheckoutPatterns != nil {
+		return i.SparseClone(repo, sparseCheckoutPatterns)
+	}
+	i.logger.Debugf("Creating a clone of the repo at %s from %s", i.dir, repo)
+	if out, err := i.executor.Run("clone", "--no-checkout", "--depth=1", repo, i.dir); err != nil {
 		return fmt.Errorf("error creating a clone: %v %v", err, string(out))
+	}
+	return nil
+}
+
+func (i *interactor) SparseClone(repo string, sparseCheckoutPatterns []string) error {
+	if out, err := i.executor.Run("clone", "--no-checkout", "--depth=1", "--filter=blob:none", "--sparse", repo, i.dir); err != nil {
+		return fmt.Errorf("failed to clone repository: %v. output: %s", err, string(out))
+	}
+	if out, err := i.executor.Run(append([]string{"sparse-checkout", "set"}, sparseCheckoutPatterns...)...); err != nil {
+		return fmt.Errorf("failed to set sparse checkout patterns to %v: %v. output: %s", sparseCheckoutPatterns, err, string(out))
 	}
 	return nil
 }
@@ -125,7 +140,7 @@ func (i *interactor) MirrorClone() error {
 	if err != nil {
 		return fmt.Errorf("could not resolve remote for cloning: %v", err)
 	}
-	out, err := i.executor.Run("clone", "--mirror", remote, i.dir)
+	out, err := i.executor.Run("clone", "--mirror", "--depth=1", remote, i.dir)
 	if err != nil {
 		// the returned error is not being reported
 		i.logger.Errorf("error creating a mirror clone: %v %v", err, string(out))

--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -113,7 +113,7 @@ func (i *interactor) Clean() error {
 // Clone clones the repository from a repository.
 func (i *interactor) Clone(repo string, sparseCheckoutPatterns []string) error {
 	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
-	if sparseCheckout && sparseCheckoutPatterns != nil {
+	if sparseCheckout && len(sparseCheckoutPatterns) > 0 {
 		return i.SparseClone(repo, sparseCheckoutPatterns)
 	}
 	i.logger.Debugf("Creating a clone of the repo at %s from %s", i.dir, repo)

--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -71,6 +71,8 @@ type Interactor interface {
 	HasSHA(ref string) (string, error)
 	// Pull pulls any changes into a branch from the remote
 	Pull() error
+	// SetSparseCheckoutPatterns initialises att set patterns for sparse checkout
+	SetSparseCheckoutPatterns(sparseCheckoutPatterns []string) error
 }
 
 // cacher knows how to cache and update repositories in a central cache
@@ -84,7 +86,7 @@ type cacher interface {
 // cloner knows how to clone repositories from a central cache
 type cloner interface {
 	// Clone clones the repository from a local path.
-	Clone(from string, sparseCheckoutPatterns []string) error
+	Clone(from string) error
 }
 
 // MergeOpt holds options for git merge operations.
@@ -111,21 +113,22 @@ func (i *interactor) Clean() error {
 }
 
 // Clone clones the repository from a repository.
-func (i *interactor) Clone(repo string, sparseCheckoutPatterns []string) error {
+func (i *interactor) Clone(repo string) error {
 	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
-	if sparseCheckout && len(sparseCheckoutPatterns) > 0 {
-		return i.SparseClone(repo, sparseCheckoutPatterns)
-	}
 	i.logger.Debugf("Creating a clone of the repo at %s from %s", i.dir, repo)
-	if out, err := i.executor.Run("clone", "--no-checkout", "--depth=1", repo, i.dir); err != nil {
+	args := []string{"clone", "--no-checkout", "--depth=1"}
+	if sparseCheckout {
+		args = append(args, "--filter=blob:none")
+	}
+	if out, err := i.executor.Run(append(args, repo, i.dir)...); err != nil {
 		return fmt.Errorf("error creating a clone: %v %v", err, string(out))
 	}
 	return nil
 }
 
-func (i *interactor) SparseClone(repo string, sparseCheckoutPatterns []string) error {
-	if out, err := i.executor.Run("clone", "--no-checkout", "--depth=1", "--filter=blob:none", "--sparse", repo, i.dir); err != nil {
-		return fmt.Errorf("failed to clone repository: %v. output: %s", err, string(out))
+func (i *interactor) SetSparseCheckoutPatterns(sparseCheckoutPatterns []string) error {
+	if out, err := i.executor.Run("sparse-checkout", "init"); err != nil {
+		return fmt.Errorf("failed to init sparse checkout: %v. output: %s", err, string(out))
 	}
 	if out, err := i.executor.Run(append([]string{"sparse-checkout", "set"}, sparseCheckoutPatterns...)...); err != nil {
 		return fmt.Errorf("failed to set sparse checkout patterns to %v: %v. output: %s", sparseCheckoutPatterns, err, string(out))

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -42,12 +42,12 @@ func TestInteractor_Clone(t *testing.T) {
 			dir:  "/else",
 			from: "/somewhere",
 			responses: map[string]execResponse{
-				"clone /somewhere /else": {
+				"clone --no-checkout --depth=1 /somewhere /else": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "/somewhere", "/else"},
+				{"clone", "--no-checkout", "--depth=1", "/somewhere", "/else"},
 			},
 			expectedErr: false,
 		},
@@ -56,12 +56,12 @@ func TestInteractor_Clone(t *testing.T) {
 			dir:  "/else",
 			from: "/somewhere",
 			responses: map[string]execResponse{
-				"clone /somewhere /else": {
+				"clone --no-checkout --depth=1 /somewhere /else": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "/somewhere", "/else"},
+				{"clone", "--no-checkout", "--depth=1", "/somewhere", "/else"},
 			},
 			expectedErr: true,
 		},
@@ -109,12 +109,12 @@ func TestInteractor_MirrorClone(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"clone --mirror someone.com /else": {
+				"clone --mirror --depth=1 someone.com /else": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "--mirror", "someone.com", "/else"},
+				{"clone", "--mirror", "--depth=1", "someone.com", "/else"},
 			},
 			expectedErr: false,
 		},
@@ -135,12 +135,12 @@ func TestInteractor_MirrorClone(t *testing.T) {
 				return "someone.com", nil
 			},
 			responses: map[string]execResponse{
-				"clone --mirror someone.com /else": {
+				"clone --mirror --depth=1 someone.com /else": {
 					err: errors.New("oops"),
 				},
 			},
 			expectedCalls: [][]string{
-				{"clone", "--mirror", "someone.com", "/else"},
+				{"clone", "--mirror", "--depth=1", "someone.com", "/else"},
 			},
 			expectedErr: true,
 		},

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -79,7 +79,7 @@ func TestInteractor_Clone(t *testing.T) {
 				dir:      testCase.dir,
 				logger:   logrus.WithField("test", testCase.name),
 			}
-			actualErr := i.Clone(testCase.from, nil)
+			actualErr := i.Clone(testCase.from)
 			if testCase.expectedErr && actualErr == nil {
 				t.Errorf("%s: expected an error but got none", testCase.name)
 			}

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -79,7 +79,7 @@ func TestInteractor_Clone(t *testing.T) {
 				dir:      testCase.dir,
 				logger:   logrus.WithField("test", testCase.name),
 			}
-			actualErr := i.Clone(testCase.from)
+			actualErr := i.Clone(testCase.from, nil)
 			if testCase.expectedErr && actualErr == nil {
 				t.Errorf("%s: expected an error but got none", testCase.name)
 			}

--- a/pkg/git/v2/no_mirror_client_factory.go
+++ b/pkg/git/v2/no_mirror_client_factory.go
@@ -3,6 +3,7 @@ package git
 import (
 	"io/ioutil"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -124,8 +125,14 @@ func (c *noMirrorClientFactory) ClientFor(org, repo string, sparseCheckoutPatter
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve remote for %s/%s", org, repo)
 	}
-	if err := repoClientCloner.Clone(remote, sparseCheckoutPatterns); err != nil {
+	if err := repoClientCloner.Clone(remote); err != nil {
 		return nil, err
+	}
+	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
+	if sparseCheckout && len(sparseCheckoutPatterns) > 0 {
+		if err := repoClient.SetSparseCheckoutPatterns(sparseCheckoutPatterns); err != nil {
+			return nil, err
+		}
 	}
 	duration := time.Now().Sub(start)
 	l.WithField("Duration", duration.String()).Debug("cloned repository")

--- a/pkg/git/v2/no_mirror_client_factory.go
+++ b/pkg/git/v2/no_mirror_client_factory.go
@@ -3,9 +3,6 @@ package git
 import (
 	"io/ioutil"
 	"os"
-	"path"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -111,54 +108,24 @@ func (c *noMirrorClientFactory) ClientFromDir(org, repo, dir string) (RepoClient
 }
 
 // ClientFor returns a repository client for the specified repository.
-// This function may take a long time if it is the first time cloning the repo.
-// In that case, it must do a full git mirror clone. For large repos, this can
-// take a while. Once that is done, it will do a git fetch instead of a clone,
-// which will usually take at most a few seconds.
 func (c *noMirrorClientFactory) ClientFor(org, repo string, sparseCheckoutPatterns []string) (RepoClient, error) {
 	start := time.Now()
-	sparseCheckout, _ := strconv.ParseBool(os.Getenv("SPARSE_CHECKOUT"))
-	cacheKey := repo
-	if sparseCheckout {
-		replacer := strings.NewReplacer(".", "_", "/", "_")
-		cacheKey = cacheKey + replacer.Replace(strings.Join(sparseCheckoutPatterns, "-"))
-	}
-	cacheDir := path.Join(c.cacheDir, org, cacheKey)
-	l := c.logger.WithFields(logrus.Fields{"org": org, "repo": repo, "dir": cacheDir})
-	l.Debug("Creating a client from the cache.")
-
-	_, repoClientCloner, repoClient, err := c.bootstrapClients(org, repo, cacheDir)
+	repoDir, err := ioutil.TempDir(c.cacheDirBase, "gitrepo")
 	if err != nil {
 		return nil, err
 	}
-	c.masterLock.Lock()
-	if _, exists := c.repoLocks[cacheDir]; !exists {
-		c.repoLocks[cacheDir] = &sync.Mutex{}
-	}
-	c.masterLock.Unlock()
-	c.repoLocks[cacheDir].Lock()
-	defer c.repoLocks[cacheDir].Unlock()
-	if _, err := os.Stat(path.Join(cacheDir, ".git", "HEAD")); os.IsNotExist(err) {
-		// we have not yet cloned this repo, we need to do a full clone
-		if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil && !os.IsExist(err) {
-			return nil, err
-		}
-
-		remote, err := c.remotes.CentralRemote(org, repo)()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to resolve remote for %s/%s", org, repo)
-		}
-		if err := repoClientCloner.Clone(remote, sparseCheckoutPatterns); err != nil {
-			return nil, err
-		}
-	} else if err != nil {
-		// something unexpected happened
+	l := c.logger.WithFields(logrus.Fields{"org": org, "repo": repo, "dir": repoDir})
+	l.Debug("Creating a client.")
+	_, repoClientCloner, repoClient, err := c.bootstrapClients(org, repo, repoDir)
+	if err != nil {
 		return nil, err
-	} else {
-		// we have cloned the repo previously, but will refresh it
-		if err := repoClient.Fetch(); err != nil {
-			return nil, err
-		}
+	}
+	remote, err := c.remotes.CentralRemote(org, repo)()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve remote for %s/%s", org, repo)
+	}
+	if err := repoClientCloner.Clone(remote, sparseCheckoutPatterns); err != nil {
+		return nil, err
 	}
 	duration := time.Now().Sub(start)
 	l.WithField("Duration", duration.String()).Debug("cloned repository")

--- a/pkg/plugins/approve/approvers/owners.go
+++ b/pkg/plugins/approve/approvers/owners.go
@@ -58,7 +58,7 @@ type Owners struct {
 
 // NewOwners consturcts a new Owners instance. filenames is the slice of files changed.
 func NewOwners(log *logrus.Entry, filenames []string, r Repo, s int64) Owners {
-	log.Warnf("OWNERS FILENAMES : %s", filenames)
+	log.Debugf("OWNERS FILENAMES : %s", filenames)
 	return Owners{filenames: filenames, repo: r, seed: s, log: log}
 }
 
@@ -386,9 +386,9 @@ func (ap Approvers) GetNoIssueApproversSet() sets.String {
 func (ap Approvers) GetFilesApprovers() map[string]sets.String {
 	filesApprovers := map[string]sets.String{}
 	currentApprovers := ap.GetCurrentApproversSetCased()
-	logrus.Warnf("CURRENT APPROVE SET CASED: %s", currentApprovers.List())
+	logrus.Tracef("CURRENT APPROVE SET CASED: %s", currentApprovers.List())
 	for fn, potentialApprovers := range ap.owners.GetApprovers() {
-		logrus.Warnf("POTENTIAL APPROVERS: %s", potentialApprovers.List())
+		logrus.Tracef("POTENTIAL APPROVERS: %s", potentialApprovers.List())
 		// The order of parameter matters here:
 		// - currentApprovers is the list of github handles that have approved
 		// - potentialApprovers is the list of handles in the OWNER

--- a/pkg/plugins/command_test.go
+++ b/pkg/plugins/command_test.go
@@ -421,7 +421,7 @@ func TestCommandGetMatches(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			matches, err := tc.command.GetMatches(tc.content)
 			if err != nil {
-				t.Errorf("an error has occured %w", err)
+				t.Errorf("an error has occured %v", err)
 			} else {
 				if !reflect.DeepEqual(tc.expected, matches) {
 					t.Errorf("expected matches %q, but got %q", tc.expected, matches)

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -302,7 +302,13 @@ func skipRequested(c Client, pr *scm.PullRequest, skippedJobs []job.Presubmit) e
 			continue
 		}
 		c.Logger.Infof("Skipping %s build.", job.Name)
-		if _, err := c.SCMProviderClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Head.Ref, skippedStatusFor(job.Context)); err != nil {
+		status := skippedStatusFor(job.Context)
+		if _, err := c.SCMProviderClient.CreateStatus(pr.Base.Repo.Namespace, pr.Base.Repo.Name, pr.Head.Ref, status); err != nil {
+			c.Logger.WithError(err).
+				WithField("status", status).
+				WithField("repo", pr.Base.Repo.Namespace+"/"+pr.Base.Repo.Name).
+				WithField("head", pr.Head.Ref).
+				Warnf("Failed creating status for build %s", job.Name)
 			errors = append(errors, err)
 		}
 	}

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	censor = func(content []byte) []byte { return content }
+	censor           = func(content []byte) []byte { return content }
 	StatusesPageSize = 100
 )
 
@@ -85,7 +85,7 @@ func (c *pollingController) PollReleases() {
 		ref := ""
 		sha := ""
 		fc := filebrowser.NewFetchCache()
-		err := c.fb.WithDir(owner, repo, ref, fc, func(dir string) error {
+		err := c.fb.WithDir(owner, repo, ref, fc, nil, func(dir string) error {
 			executor, err := git.NewCensoringExecutor(dir, censor, l)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create git executor")

--- a/pkg/triggerconfig/inrepo/load_triggers.go
+++ b/pkg/triggerconfig/inrepo/load_triggers.go
@@ -43,7 +43,7 @@ func MergeTriggers(cfg *config.Config, pluginCfg *plugins.Configuration, fileBro
 // LoadTriggerConfig loads the `lighthouse.yaml` configuration files in the repository
 func LoadTriggerConfig(fileBrowsers *filebrowser.FileBrowsers, fc filebrowser.FetchCache, cache *ResolverCache, ownerName string, repoName string, sha string) (*triggerconfig.Config, error) {
 	var answer *triggerconfig.Config
-	err := fileBrowsers.LighthouseGitFileBrowser().WithDir(ownerName, repoName, sha, fc, func(dir string) error {
+	err := fileBrowsers.LighthouseGitFileBrowser().WithDir(ownerName, repoName, sha, fc, []string{"/.lighthouse/**"}, func(dir string) error {
 		path := filepath.Join(dir, ".lighthouse")
 		exists, err := util.DirExists(path)
 		if err != nil {

--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -249,7 +249,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr *scm.PullRequestHook
 				go func(p string, h plugins.PullRequestHandler) {
 					defer s.wg.Done()
 					if err := h(agent, *pr); err != nil {
-						agent.Logger.WithError(err).Error("Error handling PullRequestEvent.")
+						agent.Logger.WithField("plugin", p).WithError(err).Error("Error handling PullRequestEvent.")
 					}
 				}(p, h.PullRequestHandler)
 			}


### PR DESCRIPTION
Sparse checkout is implemented especially for handling webhooks.

I have also changed to shallow clones even if you don't opt in to sparse checkout.

For now sparse checkout is enabled by setting the environment variable SPARSE_CHECKOUT=true.

I'm in the process of testing this in our own dev cluster now.

This is a part of solving jenkins-x/jx#8240
