### PR TITLE
Replace `io/ioutil` with `io` and `os` packages

### DIFF
--- a/cmd/jenkins/main.go
+++ b/cmd/jenkins/main.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -222,7 +221,7 @@ func loadCerts(certFile, keyFile, caCertFile string) (*tls.Config, error) {
 	}
 
 	if caCertFile != "" { // #nosec
-		caCert, err := ioutil.ReadFile(caCertFile)
+		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -313,7 +313,7 @@ func (o *options) notifier(hook *scm.WebhookWrapper) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	l := logrus.WithFields(map[string]interface{}{
 		"Status":   resp.Status,
 		"Endpoint": o.hookEndpoint,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,7 +164,7 @@ func loadConfigFromFiles(prowConfig, jobConfig string) (*Config, error) {
 
 // yamlToConfig converts a yaml file into a Config object
 func yamlToConfig(path string, nc interface{}) error {
-	b, err := ioutil.ReadFile(path) // #nosec
+	b, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return fmt.Errorf("error reading %s: %v", path, err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -829,20 +828,20 @@ periodics:
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// save the config
-			prowConfigDir, err := ioutil.TempDir("", "prowConfig")
+			prowConfigDir, err := os.MkdirTemp("", "prowConfig")
 			if err != nil {
 				t.Fatalf("fail to make tempdir: %v", err)
 			}
 			defer os.RemoveAll(prowConfigDir)
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
-			if err := ioutil.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
+			if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
 				t.Fatalf("fail to write prow config: %v", err)
 			}
 
 			jobConfig := ""
 			if len(tc.jobConfigs) > 0 {
-				jobConfigDir, err := ioutil.TempDir("", "jobConfig")
+				jobConfigDir, err := os.MkdirTemp("", "jobConfig")
 				if err != nil {
 					t.Fatalf("fail to make tempdir: %v", err)
 				}
@@ -852,7 +851,7 @@ periodics:
 				if len(tc.jobConfigs) == 1 {
 					// a single file
 					jobConfig = filepath.Join(jobConfigDir, "config.yaml")
-					if err := ioutil.WriteFile(jobConfig, []byte(tc.jobConfigs[0]), 0666); err != nil {
+					if err := os.WriteFile(jobConfig, []byte(tc.jobConfigs[0]), 0666); err != nil {
 						t.Fatalf("fail to write job config: %v", err)
 					}
 				} else {
@@ -860,7 +859,7 @@ periodics:
 					jobConfig = jobConfigDir
 					for idx, config := range tc.jobConfigs {
 						subConfig := filepath.Join(jobConfigDir, fmt.Sprintf("config_%d.yaml", idx))
-						if err := ioutil.WriteFile(subConfig, []byte(config), 0666); err != nil {
+						if err := os.WriteFile(subConfig, []byte(config), 0666); err != nil {
 							t.Fatalf("fail to write job config: %v", err)
 						}
 					}
@@ -1068,7 +1067,7 @@ func TestSecretAgentLoading(t *testing.T) {
 	changedTokenValue := "121f3cb3e7f70feeb35f9204f5a988d7292c7ba0"
 
 	// Creating a temporary directory.
-	secretDir, err := ioutil.TempDir("", "secretDir")
+	secretDir, err := os.MkdirTemp("", "secretDir")
 	if err != nil {
 		t.Fatalf("fail to create a temporary directory: %v", err)
 	}
@@ -1076,13 +1075,13 @@ func TestSecretAgentLoading(t *testing.T) {
 
 	// Launch the first temporary secret.
 	firstTempSecret := filepath.Join(secretDir, "firstTempSecret")
-	if err := ioutil.WriteFile(firstTempSecret, []byte(tempTokenValue), 0666); err != nil {
+	if err := os.WriteFile(firstTempSecret, []byte(tempTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 
 	// Launch the second temporary secret.
 	secondTempSecret := filepath.Join(secretDir, "secondTempSecret")
-	if err := ioutil.WriteFile(secondTempSecret, []byte(tempTokenValue), 0666); err != nil {
+	if err := os.WriteFile(secondTempSecret, []byte(tempTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 
@@ -1103,10 +1102,10 @@ func TestSecretAgentLoading(t *testing.T) {
 	}
 
 	// Change the values of the files.
-	if err := ioutil.WriteFile(firstTempSecret, []byte(changedTokenValue), 0666); err != nil {
+	if err := os.WriteFile(firstTempSecret, []byte(changedTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
-	if err := ioutil.WriteFile(secondTempSecret, []byte(changedTokenValue), 0666); err != nil {
+	if err := os.WriteFile(secondTempSecret, []byte(changedTokenValue), 0666); err != nil {
 		t.Fatalf("fail to write secret: %v", err)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -828,11 +828,7 @@ periodics:
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// save the config
-			prowConfigDir, err := os.MkdirTemp("", "prowConfig")
-			if err != nil {
-				t.Fatalf("fail to make tempdir: %v", err)
-			}
-			defer os.RemoveAll(prowConfigDir)
+			prowConfigDir := t.TempDir()
 
 			prowConfig := filepath.Join(prowConfigDir, "config.yaml")
 			if err := os.WriteFile(prowConfig, []byte(tc.prowConfig), 0666); err != nil {
@@ -841,11 +837,7 @@ periodics:
 
 			jobConfig := ""
 			if len(tc.jobConfigs) > 0 {
-				jobConfigDir, err := os.MkdirTemp("", "jobConfig")
-				if err != nil {
-					t.Fatalf("fail to make tempdir: %v", err)
-				}
-				defer os.RemoveAll(jobConfigDir)
+				jobConfigDir := t.TempDir()
 
 				// cover both job config as a file & a dir
 				if len(tc.jobConfigs) == 1 {
@@ -1067,11 +1059,7 @@ func TestSecretAgentLoading(t *testing.T) {
 	changedTokenValue := "121f3cb3e7f70feeb35f9204f5a988d7292c7ba0"
 
 	// Creating a temporary directory.
-	secretDir, err := os.MkdirTemp("", "secretDir")
-	if err != nil {
-		t.Fatalf("fail to create a temporary directory: %v", err)
-	}
-	defer os.RemoveAll(secretDir)
+	secretDir := t.TempDir()
 
 	// Launch the first temporary secret.
 	firstTempSecret := filepath.Join(secretDir, "firstTempSecret")

--- a/pkg/config/secret/secret.go
+++ b/pkg/config/secret/secret.go
@@ -19,7 +19,7 @@ package secret
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // LoadSecrets loads multiple paths of secrets and add them in a map.
@@ -38,7 +38,7 @@ func LoadSecrets(paths []string) (map[string][]byte, error) {
 
 // LoadSingleSecret reads and returns the value of a single file.
 func LoadSingleSecret(path string) ([]byte, error) {
-	b, err := ioutil.ReadFile(path) // #nosec
+	b, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %v", path, err)
 	}

--- a/pkg/engines/jenkins/client.go
+++ b/pkg/engines/jenkins/client.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -221,7 +221,7 @@ func readResp(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("response not 2XX: %s", resp.Status)
 	}
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engines/tekton/activity_test.go
+++ b/pkg/engines/tekton/activity_test.go
@@ -1,7 +1,7 @@
 package tekton_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,7 +55,7 @@ func loadPipelineRun(t *testing.T, dir string) *v1beta1.PipelineRun {
 	fileName := filepath.Join(dir, "pr.yaml")
 	if assertFileExists(t, fileName) {
 		pr := &v1beta1.PipelineRun{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if assert.NoError(t, err, "Failed to load file %s", fileName) {
 			err = yaml.Unmarshal(data, pr)
 			if assert.NoError(t, err, "Failed to unmarshall YAML file %s", fileName) {
@@ -70,7 +70,7 @@ func loadRecord(t *testing.T, dir string) *v1alpha1.ActivityRecord {
 	fileName := filepath.Join(dir, "record.yaml")
 	if assertFileExists(t, fileName) {
 		record := &v1alpha1.ActivityRecord{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if assert.NoError(t, err, "Failed to load file %s", fileName) {
 			err = yaml.Unmarshal(data, record)
 			if assert.NoError(t, err, "Failed to unmarshall YAML file %s", fileName) {

--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -2,7 +2,6 @@ package tekton
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -151,7 +150,7 @@ func TestReconcile(t *testing.T) {
 				if generateTestOutput {
 					data, err := yaml.Marshal(updatedPR)
 					require.NoError(t, err, "failed to marshal expected PR %#v", updatedPR)
-					err = ioutil.WriteFile(expectedPRFile, data, 0o644)
+					err = os.WriteFile(expectedPRFile, data, 0o644)
 					require.NoError(t, err, "failed to save file %s", expectedPRFile)
 					t.Logf("saved expected PR file %s\n", expectedPRFile)
 				} else {
@@ -173,7 +172,7 @@ func TestReconcile(t *testing.T) {
 				if generateTestOutput {
 					data, err := yaml.Marshal(updatedJob)
 					require.NoError(t, err, "failed to marshal expected job %#v", updatedJob)
-					err = ioutil.WriteFile(expectedJobFile, data, 0o644)
+					err = os.WriteFile(expectedJobFile, data, 0o644)
 					require.NoError(t, err, "failed to save file %s", expectedJobFile)
 					t.Logf("saved expected Job file %s\n", expectedJobFile)
 				} else {
@@ -200,7 +199,7 @@ func loadLighthouseJob(isObserved bool, dir string) (*v1alpha1.LighthouseJob, st
 	}
 	if exists {
 		lhjob := &v1alpha1.LighthouseJob{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if err != nil {
 			return nil, fileName, err
 		}
@@ -227,7 +226,7 @@ func loadControllerPipelineRun(isObserved bool, dir string) (*tektonv1beta1.Pipe
 	}
 	if exists {
 		pr := &tektonv1beta1.PipelineRun{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if err != nil {
 			return nil, fileName, err
 		}
@@ -248,7 +247,7 @@ func loadObservedPipeline(dir string) (*tektonv1beta1.Pipeline, error) {
 	}
 	if exists {
 		p := &tektonv1beta1.Pipeline{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/filebrowser/git_file_browser.go
+++ b/pkg/filebrowser/git_file_browser.go
@@ -1,7 +1,6 @@
 package filebrowser
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +61,7 @@ func (f *gitFileBrowser) GetFile(owner, repo, path, ref string, fc FetchCache) (
 			answer = nil
 			return nil
 		}
-		answer, err = ioutil.ReadFile(f) // #nosec
+		answer, err = os.ReadFile(f) // #nosec
 		return err
 	})
 	return
@@ -78,11 +77,19 @@ func (f *gitFileBrowser) ListFiles(owner, repo, path, ref string, fc FetchCache)
 		if !exists {
 			return nil
 		}
-		fileNames, err := ioutil.ReadDir(dir)
+		entries, err := os.ReadDir(dir)
 		if err != nil {
 			return errors.Wrapf(err, "failed to list files in directory %s", dir)
 		}
-		for _, f := range fileNames {
+		infos := make([]os.FileInfo, 0, len(entries))
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			infos = append(infos, info)
+		}
+		for _, f := range infos {
 			name := f.Name()
 			if name == ".git" {
 				continue

--- a/pkg/filebrowser/git_file_browser_test.go
+++ b/pkg/filebrowser/git_file_browser_test.go
@@ -106,17 +106,14 @@ func TestGitFileBrowser_Clone_CreateTag_FetchRef(t *testing.T) {
 
 	logger := logrus.WithField("client", "git")
 
-	baseDir, err := os.MkdirTemp("", "localdir")
-	require.NoError(t, err, "failed to find git binary")
+	baseDir := t.TempDir()
 	fmt.Println(baseDir)
 
 	fc := filebrowser.NewFetchCache()
 
-	defer os.RemoveAll(baseDir)
-
 	repoDir := filepath.Join(baseDir, "org", "repo")
 
-	err = os.MkdirAll(repoDir, 0700)
+	err := os.MkdirAll(repoDir, 0700)
 	require.NoError(t, err, "failed to make repo dir")
 
 	userGetter := func() (name, email string, err error) {

--- a/pkg/filebrowser/git_file_browser_test.go
+++ b/pkg/filebrowser/git_file_browser_test.go
@@ -2,7 +2,6 @@ package filebrowser_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,7 +106,7 @@ func TestGitFileBrowser_Clone_CreateTag_FetchRef(t *testing.T) {
 
 	logger := logrus.WithField("client", "git")
 
-	baseDir, err := ioutil.TempDir("", "localdir")
+	baseDir, err := os.MkdirTemp("", "localdir")
 	require.NoError(t, err, "failed to find git binary")
 	fmt.Println(baseDir)
 
@@ -139,7 +138,7 @@ func TestGitFileBrowser_Clone_CreateTag_FetchRef(t *testing.T) {
 	}
 	t.Logf("using default branch: %s\n", defaultBranch)
 
-	err = ioutil.WriteFile(filepath.Join(repoDir, "README.md"), []byte("README"), 0600)
+	err = os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("README"), 0600)
 	require.NoError(t, err, "failed to write README.md file")
 
 	_, err = executor.Run("init", ".")
@@ -164,7 +163,7 @@ func TestGitFileBrowser_Clone_CreateTag_FetchRef(t *testing.T) {
 	_, err = executor.Run("checkout", "-b", "update-1")
 	require.NoError(t, err, "failed to create new branch")
 
-	err = ioutil.WriteFile(filepath.Join(repoDir, "README.md"), []byte("README-update-1"), 0600)
+	err = os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("README-update-1"), 0600)
 	require.NoError(t, err, "failed write updated README.md")
 
 	_, err = executor.Run("commit", "-a", "-m", "update README.md")

--- a/pkg/foghorn/controller_test.go
+++ b/pkg/foghorn/controller_test.go
@@ -2,7 +2,6 @@ package foghorn
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -145,7 +144,7 @@ func loadLighthouseJob(dir string, baseFn string) (*lighthousev1alpha1.Lighthous
 	}
 	if exists {
 		lhjob := &lighthousev1alpha1.LighthouseJob{}
-		data, err := ioutil.ReadFile(fileName)
+		data, err := os.ReadFile(fileName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -3,7 +3,6 @@ package git
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -67,7 +66,7 @@ func (c *client) Clean() error {
 // NewClient returns a client that talks to GitHub. It will fail if git is not
 // in the PATH.
 func NewClient(serverURL string, gitKind string) (Client, error) {
-	t, err := ioutil.TempDir("", "git")
+	t, err := os.MkdirTemp("", "git")
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +164,7 @@ func (c *client) Clone(repo string) (*Repo, error) {
 			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
 		}
 	}
-	t, err := ioutil.TempDir("", "git")
+	t, err := os.MkdirTemp("", "git")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/localgit/localgit.go
+++ b/pkg/git/localgit/localgit.go
@@ -20,7 +20,6 @@ package localgit
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +43,7 @@ func New() (*LocalGit, git.Client, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	t, err := ioutil.TempDir("", "localgit")
+	t, err := os.MkdirTemp("", "localgit")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -128,7 +127,7 @@ func (lg *LocalGit) AddCommit(org, repo string, files map[string][]byte) error {
 		if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(path, b, os.ModePerm); err != nil {
+		if err := os.WriteFile(path, b, os.ModePerm); err != nil {
 			return err
 		}
 		if err := runCmd(lg.Git, rdir, "add", f); err != nil {

--- a/pkg/git/v2/client_factory.go
+++ b/pkg/git/v2/client_factory.go
@@ -17,7 +17,6 @@ limitations under the License.
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -134,7 +133,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 		opt(&o)
 	}
 
-	cacheDir, err := ioutil.TempDir(*o.CacheDirBase, "gitcache")
+	cacheDir, err := os.MkdirTemp(*o.CacheDirBase, "gitcache")
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +167,7 @@ func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 // NewLocalClientFactory allows for the creation of repository clients
 // based on a local filepath remote for testing
 func NewLocalClientFactory(baseDir string, gitUser UserGetter, censor Censor) (ClientFactory, error) {
-	cacheDir, err := ioutil.TempDir("", "gitcache")
+	cacheDir, err := os.MkdirTemp("", "gitcache")
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +255,7 @@ func (c *clientFactory) ClientFor(org, repo string, sparseCheckoutPatterns []str
 		return nil, err
 	}
 
-	repoDir, err := ioutil.TempDir(c.cacheDirBase, "gitrepo")
+	repoDir, err := os.MkdirTemp(c.cacheDirBase, "gitrepo")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/v2/no_mirror_client_factory.go
+++ b/pkg/git/v2/no_mirror_client_factory.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"sync"
@@ -19,7 +18,7 @@ func NewNoMirrorClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 		opt(&o)
 	}
 
-	cacheDir, err := ioutil.TempDir(*o.CacheDirBase, "gitcache")
+	cacheDir, err := os.MkdirTemp(*o.CacheDirBase, "gitcache")
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func (c *noMirrorClientFactory) ClientFromDir(org, repo, dir string) (RepoClient
 // ClientFor returns a repository client for the specified repository.
 func (c *noMirrorClientFactory) ClientFor(org, repo string, sparseCheckoutPatterns []string) (RepoClient, error) {
 	start := time.Now()
-	repoDir, err := ioutil.TempDir(c.cacheDirBase, "gitrepo")
+	repoDir, err := os.MkdirTemp(c.cacheDirBase, "gitrepo")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interrupts/interrupts_test.go
+++ b/pkg/interrupts/interrupts_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -227,7 +226,7 @@ func generateCerts(url string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to create certificate: %s", err)
 	}
 
-	certOut, err := ioutil.TempFile("", "cert.pem")
+	certOut, err := os.CreateTemp("", "cert.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to open cert.pem for writing: %s", err)
 	}
@@ -238,7 +237,7 @@ func generateCerts(url string) (string, string, error) {
 		return "", "", fmt.Errorf("error closing cert.pem: %s", err)
 	}
 
-	keyOut, err := ioutil.TempFile("", "key.pem")
+	keyOut, err := os.CreateTemp("", "key.pem")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to open key.pem for writing: %v", err)
 	}

--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -18,8 +18,8 @@ package approve
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -48,7 +48,7 @@ func TestPluginConfig(t *testing.T) {
 
 	pa := &plugins.ConfigAgent{}
 
-	b, err := ioutil.ReadFile("../../plugins.yaml")
+	b, err := os.ReadFile("../../plugins.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read plugin config: %v.", err)
 	}

--- a/pkg/plugins/cat/cat.go
+++ b/pkg/plugins/cat/cat.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -104,7 +104,7 @@ func (c *realClowder) setKey(keyPath string, log *logrus.Entry) {
 		c.key = ""
 		return
 	}
-	b, err := ioutil.ReadFile(keyPath) // #nosec
+	b, err := os.ReadFile(keyPath) // #nosec
 	if err == nil {
 		c.key = strings.TrimSpace(string(b))
 		return

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -19,8 +19,8 @@ package plugins
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -180,7 +180,7 @@ type ConfigAgent struct {
 // Load attempts to load config from the path. It returns an error if either
 // the file can't be read or the configuration is invalid.
 func (pa *ConfigAgent) Load(path string) error {
-	b, err := ioutil.ReadFile(path) // #nosec
+	b, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/updateconfig/updateconfig_test.go
+++ b/pkg/plugins/updateconfig/updateconfig_test.go
@@ -19,7 +19,7 @@ package updateconfig
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1166,15 +1166,15 @@ func TestUpdateConfig(t *testing.T) {
 				event.PullRequest.MergeSha = tc.mergeCommit
 			}
 
-			invalidYaml, err := ioutil.ReadFile(filepath.Join("test_data", "invalid-yaml.yaml"))
+			invalidYaml, err := os.ReadFile(filepath.Join("test_data", "invalid-yaml.yaml"))
 			if err != nil {
 				t.Fatalf("couldn't read test_data/invalid-yaml.yaml: %v", err)
 			}
-			validConfig, err := ioutil.ReadFile(filepath.Join("test_data", "valid-config.yaml"))
+			validConfig, err := os.ReadFile(filepath.Join("test_data", "valid-config.yaml"))
 			if err != nil {
 				t.Fatalf("couldn't read test_data/valid-config.yaml: %v", err)
 			}
-			invalidConfig, err := ioutil.ReadFile(filepath.Join("test_data", "invalid-config.yaml"))
+			invalidConfig, err := os.ReadFile(filepath.Join("test_data", "invalid-config.yaml"))
 			if err != nil {
 				t.Fatalf("couldn't read test_data/invalid-config.yaml: %v", err)
 			}

--- a/pkg/plugins/welcome/welcome_test.go
+++ b/pkg/plugins/welcome/welcome_test.go
@@ -18,7 +18,7 @@ package welcome
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -282,7 +282,7 @@ func TestPluginConfig(t *testing.T) {
 
 	pa := &plugins.ConfigAgent{}
 
-	b, err := ioutil.ReadFile("../../plugins.yaml")
+	b, err := os.ReadFile("../../plugins.yaml")
 	if err != nil {
 		t.Fatalf("Failed to read plugin config: %v.", err)
 	}

--- a/pkg/repoowners/repoowners.go
+++ b/pkg/repoowners/repoowners.go
@@ -18,7 +18,6 @@ package repoowners
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -323,7 +322,7 @@ func (a RepoAliases) ExpandAliases(logins sets.String) sets.String {
 
 func (c *Client) loadAliasesFrom(baseDir string, log *logrus.Entry, org string) RepoAliases {
 	path := filepath.Join(baseDir, aliasesFileName)
-	b, err := ioutil.ReadFile(path) // #nosec
+	b, err := os.ReadFile(path) // #nosec
 	if os.IsNotExist(err) {
 		log.WithError(err).Infof("No alias file exists at %q. Using empty alias map.", path)
 		return nil
@@ -444,7 +443,7 @@ func (o *RepoOwners) walkFunc(path string, info os.FileInfo, err error) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadFile(path) // #nosec
+	b, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		log.WithError(err).Errorf("Failed to read the OWNERS file.")
 		return nil
@@ -507,7 +506,7 @@ var mdStructuredHeaderRegex = regexp.MustCompile("^---\n(.|\n)*\n---")
 // If no yaml header is found, do nothing
 // Returns an error if the file cannot be read or the yaml header is found but cannot be unmarshalled.
 func decodeOwnersMdConfig(path string, config *SimpleConfig) error {
-	fileBytes, err := ioutil.ReadFile(path) // #nosec
+	fileBytes, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return err
 	}

--- a/pkg/triggerconfig/inrepo/load_pipelinerun.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun.go
@@ -3,7 +3,7 @@ package inrepo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -307,7 +307,7 @@ func loadTaskByURL(uri string) (*tektonv1beta1.Task, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read body from URL %s", uri)
 	}

--- a/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
+++ b/pkg/triggerconfig/inrepo/load_pipelinerun_test.go
@@ -2,7 +2,6 @@ package inrepo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +27,7 @@ var (
 
 func TestLoadPipelineRunTest(t *testing.T) {
 	sourceDir := filepath.Join("test_data", "load_pipelinerun")
-	fs, err := ioutil.ReadDir(sourceDir)
+	fs, err := os.ReadDir(sourceDir)
 	require.NoError(t, err, "failed to read source Dir %s", sourceDir)
 
 	fileBrowser := fbfake.NewFakeFileBrowser("test_data", true)
@@ -102,7 +101,7 @@ func TestLoadPipelineRunTest(t *testing.T) {
 			expectedPath := filepath.Join(dir, fmt.Sprintf("expected%s.yaml", suffix))
 
 			message := "load file " + path
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			require.NoError(t, err, "failed to load "+message)
 
 			pr, err := LoadTektonResourceAsPipelineRun(resolver, data)
@@ -120,11 +119,11 @@ func TestLoadPipelineRunTest(t *testing.T) {
 			require.NoError(t, err, "failed to marshal generated PipelineRun for "+message)
 
 			if generateTestOutput {
-				err = ioutil.WriteFile(expectedPath, data, 0666)
+				err = os.WriteFile(expectedPath, data, 0666)
 				require.NoError(t, err, "failed to save file %s", expectedPath)
 				continue
 			}
-			expectedData, err := ioutil.ReadFile(expectedPath)
+			expectedData, err := os.ReadFile(expectedPath)
 			require.NoError(t, err, "failed to load file "+expectedPath)
 
 			text := strings.TrimSpace(string(data))

--- a/pkg/triggerconfig/inrepo/load_triggers.go
+++ b/pkg/triggerconfig/inrepo/load_triggers.go
@@ -3,7 +3,7 @@ package inrepo
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -51,7 +51,7 @@ func LoadTriggerConfig(fileBrowsers *filebrowser.FileBrowsers, fc filebrowser.Fe
 		}
 		m := map[string]*triggerconfig.Config{}
 		if exists {
-			fs, err := ioutil.ReadDir(path)
+			fs, err := os.ReadDir(path)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read dir %s", path)
 			}
@@ -130,7 +130,7 @@ func loadConfigFile(filePath string, fileBrowsers *filebrowser.FileBrowsers, fc 
 	if !exists {
 		return nil, nil
 	}
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read file %s with sha %s", filePath, sha)
 	}
@@ -203,7 +203,7 @@ func loadLocalFile(dir, name, sha string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed to find file %s", path)
 	}
 	if exists {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read file %s with sha %s", path, sha)
 		}
@@ -269,7 +269,7 @@ func getPipelineFromURL(path string) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read body from URL %s", path)
 	}

--- a/pkg/triggerconfig/inrepo/uses_resolver.go
+++ b/pkg/triggerconfig/inrepo/uses_resolver.go
@@ -3,7 +3,6 @@ package inrepo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -121,7 +120,7 @@ func (r *UsesResolver) GetData(path string, ignoreNotExist bool) ([]byte, error)
 			}
 		}
 		/* #nosec */
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read file %s", path)
 		}

--- a/pkg/triggerconfig/merge/merge_test.go
+++ b/pkg/triggerconfig/merge/merge_test.go
@@ -1,7 +1,7 @@
 package merge_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -78,7 +78,7 @@ func TestMergeTriggerConfig(t *testing.T) {
 
 func TestMergeTriggerConfigFiles(t *testing.T) {
 	sourceData := "test_data"
-	fileNames, err := ioutil.ReadDir(sourceData)
+	fileNames, err := os.ReadDir(sourceData)
 	assert.NoError(t, err)
 
 	repoOwner := "myorg"
@@ -126,7 +126,7 @@ func TestMergeTriggerConfigFiles(t *testing.T) {
 }
 
 func LoadTrimmedText(t *testing.T, expectedConfigFile string) string {
-	expectData, err := ioutil.ReadFile(expectedConfigFile)
+	expectData, err := os.ReadFile(expectedConfigFile)
 	require.NoError(t, err, "failed to load results %s", expectedConfigFile)
 	expectedText := strings.TrimSpace(string(expectData))
 	return expectedText
@@ -143,7 +143,7 @@ func ToYAMLString(t *testing.T, cfg interface{}, testName string) string {
 func LoadYAMLFile(t *testing.T, fileName string, dest interface{}) {
 	require.FileExists(t, fileName)
 
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	require.NoError(t, err, "failed to read file %s", fileName)
 
 	err = yaml.Unmarshal(data, dest)

--- a/pkg/util/externalplugins.go
+++ b/pkg/util/externalplugins.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -24,7 +23,7 @@ import (
 
 // ParseExternalPluginEvent parses a webhook relayed to an external plugin
 func ParseExternalPluginEvent(req *http.Request, secretToken string) (scm.Webhook, *v1alpha1.ActivityRecord, error) {
-	data, err := ioutil.ReadAll(
+	data, err := io.ReadAll(
 		io.LimitReader(req.Body, 10000000),
 	)
 	if err != nil {
@@ -239,7 +238,7 @@ func dispatch(endpoint string, payload []byte, h http.Header) error {
 		return err
 	}
 	defer resp.Body.Close()
-	rb, err := ioutil.ReadAll(resp.Body)
+	rb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/githubapp.go
+++ b/pkg/util/githubapp.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,7 +38,7 @@ func GetGitHubAppAPIUser() (string, error) {
 	}
 
 	/* #nosec */
-	data, err := ioutil.ReadFile(userFile)
+	data, err := os.ReadFile(userFile)
 	if err != nil {
 		return "", errors.Wrapf(err, "reading username file in secrets directory for GitHub App integration %s", secretsDir)
 	}

--- a/pkg/util/owner_tokens_dir.go
+++ b/pkg/util/owner_tokens_dir.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,7 +25,7 @@ func (o *OwnerTokensDir) FindToken(owner string) (string, error) {
 	dir := o.dir
 	ownerURL := URLJoin(o.gitServer, owner)
 	prefix := ownerURL + "="
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to list files in dir %s", dir)
 	}
@@ -38,7 +38,7 @@ func (o *OwnerTokensDir) FindToken(owner string) (string, error) {
 
 		logrus.Tracef("loading file %s", name)
 		/* #nosec */
-		data, err := ioutil.ReadFile(name)
+		data, err := os.ReadFile(name)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to load file %s", name)
 		}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -142,7 +142,7 @@ func (o *WebhooksController) HandleWebhookRequests(w http.ResponseWriter, r *htt
 // HandlePollingRequests handles incoming polling events
 func (o *WebhooksController) HandlePollingRequests(w http.ResponseWriter, r *http.Request) {
 	o.handleWebhookOrPollRequest(w, r, "Pollhook", func(scmClient *scm.Client, r *http.Request) (scm.Webhook, error) {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read poll payload")
 		}
@@ -182,7 +182,7 @@ func (o *WebhooksController) handleWebhookOrPollRequest(w http.ResponseWriter, r
 
 	cfg := o.server.ConfigAgent.Config
 
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.Errorf("failed to Read Body: %s", err.Error())
 		responseHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("500 Internal Server Error: Read Body: %s", err.Error()))
@@ -196,7 +196,7 @@ func (o *WebhooksController) handleWebhookOrPollRequest(w http.ResponseWriter, r
 		return
 	}
 
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	_, scmClient, serverURL, _, err := util.GetSCMClient("", cfg)
 	if err != nil {
 		logrus.Errorf("failed to create SCM scmClient: %s", err.Error())

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -126,13 +125,13 @@ func (suite *WebhookTestSuite) SetupSuite() {
 
 	workDir, err := os.Getwd()
 	assert.NoError(t, err)
-	configBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/test_data/test_config.yaml", workDir))
+	configBytes, err := os.ReadFile(fmt.Sprintf("%s/test_data/test_config.yaml", workDir))
 	assert.NoError(t, err)
 	loadedConfig, err := config.LoadYAMLConfig(configBytes)
 	configAgent.Set(loadedConfig)
 	assert.NoError(t, err)
 
-	pluginBytes, err := ioutil.ReadFile(fmt.Sprintf("%s/test_data/test_plugins.yaml", workDir))
+	pluginBytes, err := os.ReadFile(fmt.Sprintf("%s/test_data/test_plugins.yaml", workDir))
 	assert.NoError(t, err)
 	loadedPlugins, err := pluginAgent.LoadYAMLConfig(pluginBytes)
 	pluginAgent.Set(loadedPlugins)

--- a/test/e2e/jenkins/helper.go
+++ b/test/e2e/jenkins/helper.go
@@ -3,7 +3,6 @@ package jenkins
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -62,7 +61,7 @@ func (jc *Client) doRequest(method string, url string, data io.Reader, headers m
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, body, err
 	}

--- a/test/e2e/jenkins/jenkins_test.go
+++ b/test/e2e/jenkins/jenkins_test.go
@@ -4,6 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"text/template"
+
 	"github.com/cenkalti/backoff"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jenkins-x/go-scm/scm"
@@ -15,13 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
-	"text/template"
 )
 
 const (
@@ -50,7 +51,7 @@ func TestJenkins(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("setting up logging")
 	if os.Getenv("E2E_QUIET_LOG") == "true" {
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 	}
 
 	By("ensuring environment configured")
@@ -143,7 +144,7 @@ func ChatOpsTests() bool {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			newFile := filepath.Join(localClone.Dir, "README")
-			err = ioutil.WriteFile(newFile, []byte("Hello world"), 0600)
+			err = os.WriteFile(newFile, []byte("Hello world"), 0600)
 			e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "add", newFile)
 			e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "commit", "-a", "-m", "Adding for test PR")
 
@@ -204,11 +205,11 @@ func ChatOpsTests() bool {
 
 			By("creating a failing go file")
 			failFile := filepath.Join("test_data", "main.go.failing")
-			failFileContent, err := ioutil.ReadFile(filepath.Clean(failFile))
+			failFileContent, err := os.ReadFile(filepath.Clean(failFile))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			outFile := filepath.Join(localClone.Dir, "main.go")
-			err = ioutil.WriteFile(outFile, failFileContent, 0600)
+			err = os.WriteFile(outFile, failFileContent, 0600)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "commit", "-a", "-m", "Updating main.go for failing test PR")

--- a/test/e2e/tekton/tekton_test.go
+++ b/test/e2e/tekton/tekton_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/jenkins-x/lighthouse/test/e2e"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,6 +17,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/config/job"
 	"github.com/jenkins-x/lighthouse/pkg/git"
 	"github.com/jenkins-x/lighthouse/pkg/scmprovider"
+	"github.com/jenkins-x/lighthouse/test/e2e"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -145,15 +144,15 @@ func ChatOpsTests() bool {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				newFile := filepath.Join(localClone.Dir, "README")
-				err = ioutil.WriteFile(newFile, []byte("Hello world"), 0600)
+				err = os.WriteFile(newFile, []byte("Hello world"), 0600)
 				e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "add", newFile)
 
 				changedScriptFile := filepath.Join("test_data", "passingRepoScript.sh")
-				changedScript, err := ioutil.ReadFile(changedScriptFile) /* #nosec */
+				changedScript, err := os.ReadFile(changedScriptFile) /* #nosec */
 				Expect(err).ShouldNot(HaveOccurred())
 
 				scriptOutputFile := filepath.Join(localClone.Dir, "script.sh")
-				err = ioutil.WriteFile(scriptOutputFile, changedScript, 0600)
+				err = os.WriteFile(scriptOutputFile, changedScript, 0600)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "commit", "-a", "-m", "Adding for test PR")
@@ -198,11 +197,11 @@ func ChatOpsTests() bool {
 
 			By("changing the PR to fail", func() {
 				failScriptFile := filepath.Join("test_data", "failingRepoScript.sh")
-				failScript, err := ioutil.ReadFile(failScriptFile) /* #nosec */
+				failScript, err := os.ReadFile(failScriptFile) /* #nosec */
 				Expect(err).ShouldNot(HaveOccurred())
 
 				scriptOutputFile := filepath.Join(localClone.Dir, "script.sh")
-				err = ioutil.WriteFile(scriptOutputFile, failScript, 0600)
+				err = os.WriteFile(scriptOutputFile, failScript, 0600)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				e2e.ExpectCommandExecution(localClone.Dir, 1, 0, "git", "commit", "-a", "-m", "Updating to fail")
@@ -318,14 +317,14 @@ type pipelineCRDInput struct {
 }
 
 func applyPipelineAndTask() error {
-	tmpDir, err := ioutil.TempDir("", "pipeline-and-task")
+	tmpDir, err := os.MkdirTemp("", "pipeline-and-task")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
 
 	pAndTFile := filepath.Join("test_data", "tekton", "pipelineAndTask.tmpl.yaml")
-	rawPAndT, err := ioutil.ReadFile(pAndTFile)
+	rawPAndT, err := os.ReadFile(pAndTFile)
 	if err != nil {
 		return errors.Wrapf(err, "reading pipeline/task template %s", pAndTFile)
 	}
@@ -354,7 +353,7 @@ func applyPipelineAndTask() error {
 	}
 
 	outputFile := filepath.Join(tmpDir, "pipelineAndTask.yaml")
-	err = ioutil.WriteFile(outputFile, pAndTBuf.Bytes(), 0644)
+	err = os.WriteFile(outputFile, pAndTBuf.Bytes(), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "writing to output file %s", outputFile)
 	}

--- a/test/e2e/util/copy.go
+++ b/test/e2e/util/copy.go
@@ -2,13 +2,13 @@ package util
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // Copy copies the the src directory recursively to the destination directory.
@@ -33,7 +33,7 @@ func Copy(src string, dst string, template bool) error {
 		return err
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func Copy(src string, dst string, template bool) error {
 			}
 		} else {
 			// Skip symlinks.
-			if entry.Mode()&os.ModeSymlink != 0 {
+			if entry.Type()&os.ModeSymlink != 0 {
 				continue
 			}
 


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir