### PR TITLE
WIP: feat: Add support for GIT_TOKEN_PATH environment variable

### DIFF
--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -144,14 +144,14 @@ func GetBotName(cfg config.Getter) string {
 func GetSCMToken(gitKind string) (string, error) {
 	envName := "GIT_TOKEN"
 	value := os.Getenv(envName)
-	var err
+	var err error
 	if value == "" {
 		err = fmt.Errorf("no token available for git kind %s at environment variable $%s", gitKind, envName)
 	}
 	// If we could not retrieve the Git token from the environment then attempt
 	// to read it from the filesystem
 	if err != nil {
-		value, pathErr := GetSCMTokenPath()
+		value, pathErr := GetSCMTokenPath(gitKind)
 		if pathErr == nil {
 			return value, nil
 		}
@@ -160,7 +160,7 @@ func GetSCMToken(gitKind string) (string, error) {
 }
 
 // GetSCMTokenPath gets the SCM secret from the filesystem
-func GetSCMTokenPath(gitKind) (string, error) {
+func GetSCMTokenPath(gitKind string) (string, error) {
 	envName := "GIT_TOKEN_PATH"
 	value := os.Getenv(envName)
 	if value == "" {
@@ -168,7 +168,7 @@ func GetSCMTokenPath(gitKind) (string, error) {
 	}
 	b, err := os.ReadFile(value)
     if err != nil {
-        "", err
+        return "", err
     }
 	return string(b), nil
 }

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -144,10 +144,33 @@ func GetBotName(cfg config.Getter) string {
 func GetSCMToken(gitKind string) (string, error) {
 	envName := "GIT_TOKEN"
 	value := os.Getenv(envName)
+	var err
 	if value == "" {
-		return value, fmt.Errorf("no token available for git kind %s at environment variable $%s", gitKind, envName)
+		err = fmt.Errorf("no token available for git kind %s at environment variable $%s", gitKind, envName)
 	}
-	return value, nil
+	// If we could not retrieve the Git token from the environment then attempt
+	// to read it from the filesystem
+	if err != nil {
+		value, pathErr := GetSCMTokenPath(gitKind)
+		if pathErr != nil {
+			err = pathErr
+		}
+	}
+	return value, err
+}
+
+// GetSCMTokenPath gets the SCM secret from the filesystem
+func GetSCMTokenPath(gitKind) (string, error) {
+	envName := "GIT_TOKEN_PATH"
+	value := os.Getenv(envName)
+	if value == "" {
+		return value, fmt.Errorf("no token path available for git kind %s at environment variable $%s", gitKind, envName)
+	}
+	b, err := os.ReadFile(value)
+    if err != nil {
+        value, err
+    }
+	return string(b), nil
 }
 
 // HMACToken gets the HMAC token from the environment

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -151,9 +151,9 @@ func GetSCMToken(gitKind string) (string, error) {
 	// If we could not retrieve the Git token from the environment then attempt
 	// to read it from the filesystem
 	if err != nil {
-		value, pathErr := GetSCMTokenPath(gitKind)
-		if pathErr != nil {
-			err = pathErr
+		value, pathErr := GetSCMTokenPath()
+		if pathErr == nil {
+			return value, nil
 		}
 	}
 	return value, err
@@ -168,7 +168,7 @@ func GetSCMTokenPath(gitKind) (string, error) {
 	}
 	b, err := os.ReadFile(value)
     if err != nil {
-        value, err
+        "", err
     }
 	return string(b), nil
 }

--- a/pkg/util/scmclient_test.go
+++ b/pkg/util/scmclient_test.go
@@ -1,0 +1,62 @@
+package util_test
+
+import (
+	"os"
+	"testing"
+	"path/filepath"
+
+	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSCMToken(t *testing.T) {
+	os.Setenv("GIT_TOKEN", "mytokenfromenvvar")
+	token, err := util.GetSCMToken("github")
+
+	require.NoError(t, err, "failed to get SCM token")
+	assert.Equal(t, "mytokenfromenvvar", token, "failed to get expected SCM token: %s", token)
+}
+
+func TestGetSCMTokenPath(t *testing.T) {
+	err := os.Unsetenv("GIT_TOKEN")
+	require.NoError(t, err, "failed to unset environment variable GIT_TOKEN")
+
+	os.Setenv("GIT_TOKEN_PATH", filepath.Join("test_data", "secret_dir", "git-token"))
+	token, err := util.GetSCMToken("github")
+
+	require.NoError(t, err, "failed to get SCM token")
+	assert.Equal(t, "mytokenfrompath", token, "failed to get expected SCM token: %s", token)
+}
+
+// This test ensures that we receive an error if path GIT_TOKEN_PATH does not exist
+func TestGetSCMTokenPathMissing(t *testing.T) {
+	err := os.Unsetenv("GIT_TOKEN")
+	require.NoError(t, err, "failed to unset environment variable GIT_TOKEN")
+
+	os.Setenv("GIT_TOKEN_PATH", filepath.Join("test_data", "secret_dir", "does-not-exist"))
+	_, err = util.GetSCMToken("github")
+	require.Error(t, err)
+}
+
+// This test ensures that we receive an error if neither GIT_TOKEN or GIT_TOKEN_PATH are set
+func TestGetSCMTokenFailure(t *testing.T) {
+	err := os.Unsetenv("GIT_TOKEN")
+	require.NoError(t, err, "failed to unset environment variable GIT_TOKEN")
+
+	err = os.Unsetenv("GIT_TOKEN_PATH")
+	require.NoError(t, err, "failed to unset environment variable GIT_TOKEN_PATH")
+
+	_, err = util.GetSCMToken("github")
+	require.Error(t, err)
+}
+
+// This test ensures that GIT_TOKEN takes priority over GIT_TOKEN_PATH
+func TestGetSCMTokenOverridesPath(t *testing.T) {
+	os.Setenv("GIT_TOKEN", "mytokenfromenvvar")
+	os.Setenv("GIT_TOKEN_PATH", filepath.Join("test_data", "secret_dir", "git-token"))
+	token, err := util.GetSCMToken("github")
+
+	require.NoError(t, err, "failed to get SCM token")
+	assert.Equal(t, "mytokenfromenvvar", token, "failed to get expected SCM token: %s", token)
+}

--- a/pkg/util/test_data/secret_dir/git-token
+++ b/pkg/util/test_data/secret_dir/git-token
@@ -1,0 +1,1 @@
+mytokenfrompath


### PR DESCRIPTION
This PR adds support from retrieving the Git token from the filesystem instead of from an environment variable. In our case, we require this since retrieving secrets from environment variables is considered insecure since it is a common attack vector. 