### PR TITLE
feat: Add support for HMAC token volume

### DIFF
--- a/charts/lighthouse/templates/foghorn-deployment.yaml
+++ b/charts/lighthouse/templates/foghorn-deployment.yaml
@@ -48,12 +48,18 @@ spec:
                 key: oauth
 {{- end }}
 {{- end }}
+{{- if .Values.hmacTokenEnabled }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+          - name: "HMAC_TOKEN_PATH"
+            value: /secrets/lighthouse-hmac-token/hmac
+{{- else }}
           - name: "HMAC_TOKEN"
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
                 key: hmac
-                optional: {{ not .Values.hmacTokenEnabled }}
+{{- end }}
+{{- end }}
           - name: "JX_LOG_FORMAT"
             value: "{{ .Values.logFormat }}"
           - name: "LOGRUS_FORMAT"
@@ -84,6 +90,11 @@ spec:
             mountPath: /secrets/lighthouse-oauth-token
             readOnly: true
 {{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+          - name: lighthouse-hmac-token
+            mountPath: /secrets/lighthouse-hmac-token
+            readOnly: true
+{{- end }}
       volumes:
 {{- if .Values.githubApp.enabled }}
         - name: githubapp-tokens
@@ -93,6 +104,11 @@ spec:
         - name: lighthouse-oauth-token
           secret:
             secretName: lighthouse-oauth-token
+{{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+        - name: lighthouse-hmac-token
+          secret:
+            secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.foghorn.terminationGracePeriodSeconds }}
 {{- with .Values.foghorn.nodeSelector }}

--- a/charts/lighthouse/templates/foghorn-deployment.yaml
+++ b/charts/lighthouse/templates/foghorn-deployment.yaml
@@ -90,7 +90,7 @@ spec:
             mountPath: /secrets/lighthouse-oauth-token
             readOnly: true
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
           - name: lighthouse-hmac-token
             mountPath: /secrets/lighthouse-hmac-token
             readOnly: true
@@ -105,7 +105,7 @@ spec:
           secret:
             secretName: lighthouse-oauth-token
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
         - name: lighthouse-hmac-token
           secret:
             secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -131,7 +131,7 @@ spec:
           mountPath: /secrets/lighthouse-oauth-token
           readOnly: true
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
         - name: lighthouse-hmac-token
           mountPath: /secrets/lighthouse-hmac-token
           readOnly: true
@@ -146,7 +146,7 @@ spec:
         secret:
           secretName: lighthouse-oauth-token
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
       - name: lighthouse-hmac-token
         secret:
           secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -85,12 +85,18 @@ spec:
               key: oauth
 {{- end }}
 {{- end }}
+{{- if .Values.hmacTokenEnabled }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+        - name: "HMAC_TOKEN_PATH"
+          value: /secrets/lighthouse-hmac-token/hmac
+{{- else }}
         - name: "HMAC_TOKEN"
           valueFrom:
             secretKeyRef:
               name: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
               key: hmac
-              optional: {{ not .Values.hmacTokenEnabled }}
+{{- end }}
+{{- end }}
         - name: "JX_LOG_FORMAT"
           value: "{{ .Values.logFormat }}"
         - name: LOG_LEVEL
@@ -125,6 +131,11 @@ spec:
           mountPath: /secrets/lighthouse-oauth-token
           readOnly: true
 {{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+        - name: lighthouse-hmac-token
+          mountPath: /secrets/lighthouse-hmac-token
+          readOnly: true
+{{- end }}
       volumes:
 {{- if .Values.githubApp.enabled }}
       - name: githubapp-tokens
@@ -134,6 +145,11 @@ spec:
       - name: lighthouse-oauth-token
         secret:
           secretName: lighthouse-oauth-token
+{{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+      - name: lighthouse-hmac-token
+        secret:
+          secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
 {{- end }}
 {{- with .Values.poller.nodeSelector }}
       nodeSelector:

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -128,7 +128,7 @@ spec:
             mountPath: /secrets/lighthouse-oauth-token
             readOnly: true
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
           - name: lighthouse-hmac-token
             mountPath: /secrets/lighthouse-hmac-token
             readOnly: true
@@ -143,7 +143,7 @@ spec:
           secret:
             secretName: lighthouse-oauth-token
 {{- end }}
-{{- if .Values.hmacTokenVolumeMount.enabled }}
+{{- if and .Values.hmacTokenEnabled .Values.hmacTokenVolumeMount.enabled }}
         - name: lighthouse-hmac-token
           secret:
             secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -65,12 +65,18 @@ spec:
                 key: oauth
 {{- end }}
 {{- end }}
+{{- if .Values.hmacTokenEnabled }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+          - name: "HMAC_TOKEN_PATH"
+            value: /secrets/lighthouse-hmac-token/hmac
+{{- else }}
           - name: "HMAC_TOKEN"
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
                 key: hmac
-                optional: {{ not .Values.hmacTokenEnabled }}
+{{- end }}
+{{- end }}
           - name: "JX_LOG_FORMAT"
             value: "{{ .Values.logFormat }}"
           - name: "LOGRUS_FORMAT"
@@ -122,6 +128,11 @@ spec:
             mountPath: /secrets/lighthouse-oauth-token
             readOnly: true
 {{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+          - name: lighthouse-hmac-token
+            mountPath: /secrets/lighthouse-hmac-token
+            readOnly: true
+{{- end }}
       volumes:
 {{- if .Values.githubApp.enabled }}
         - name: githubapp-tokens
@@ -131,6 +142,11 @@ spec:
         - name: lighthouse-oauth-token
           secret:
             secretName: lighthouse-oauth-token
+{{- end }}
+{{- if .Values.hmacTokenVolumeMount.enabled }}
+        - name: lighthouse-hmac-token
+          secret:
+            secretName: {{ .Values.hmacSecretName | default "lighthouse-hmac-token" }}
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.webhooks.terminationGracePeriodSeconds }}
 {{- with .Values.webhooks.nodeSelector }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -38,6 +38,10 @@ hmacSecretName: ""
 # hmacTokenEnabled -- Enables the use of a hmac token. This should always be enabled if possible - though some git providers don't support it such as bitbucket cloud
 hmacTokenEnabled: true
 
+# hmacTokenVolumeMount -- Mount hmac token as a volume instead of using an environment variable Secret reference
+hmacTokenVolumeMount:
+  enabled: false
+
 # logFormat -- Log format either json or stackdriver
 logFormat: "json"
 

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -54,7 +54,11 @@ type options struct {
 
 func (o *options) Validate() error {
 	if o.hmacToken == "" {
-		o.hmacToken = os.Getenv("HMAC_TOKEN")
+		hmacToken, err := util.HMACToken()
+		if err != nil {
+			return err
+		}
+		o.hmacToken = hmacToken
 	}
 	return nil
 }

--- a/cmd/poller/main.go
+++ b/cmd/poller/main.go
@@ -54,11 +54,7 @@ type options struct {
 
 func (o *options) Validate() error {
 	if o.hmacToken == "" {
-		hmacToken, err := util.HMACToken()
-		if err != nil {
-			return err
-		}
-		o.hmacToken = hmacToken
+		o.hmacToken = util.HMACToken()
 	}
 	return nil
 }

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -179,7 +179,7 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 	return string(b), nil
 }
 
-// HMACToken gets the HMAC token from the environment or the filesystem
+// HMACToken gets the HMAC token from the environment or filesystem
 func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
 	// For backwards compatibility we only attempt to read from the filesystem

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -182,7 +182,8 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 // HMACToken gets the HMAC token from the environment or the filesystem
 func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
-	// Prioritise the value from the environment for backwards compatibility
+	// For backwards compatibility we only attempt to read from the filesystem
+	// if the token is not set
 	if len(hmacToken) == 0 {
 		// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
 		hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -182,7 +182,7 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 // HMACToken gets the HMAC token from the environment or the filesystem
 func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
-	// If HMAC_TOKEN_PATH is specified then attempt to read from filesystem
+	// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
 	hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
 	if len(hmacTokenPath) > 0 {
 		b, err := os.ReadFile(hmacTokenPath)

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -180,18 +180,19 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 }
 
 // HMACToken gets the HMAC token from the environment or the filesystem
-func HMACToken() (string, error) {
+func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
 	// If HMAC_TOKEN_PATH is specified then attempt to read from filesystem
 	hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
 	if len(hmacTokenPath) > 0 {
 		b, err := os.ReadFile(hmacTokenPath)
 		if err != nil {
-			return "", err
+			logrus.Errorf("failed to read HMAC_TOKEN_PATH %s: %s", hmacTokenPath, err)
+			return hmacToken
 		}
 		hmacToken = string(b)
 	}
-	return hmacToken, nil
+	return hmacToken
 }
 
 // BlobURLForProvider gets the link to the blob for an individual file in a commit or branch

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -183,7 +183,7 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
 	// For backwards compatibility we only attempt to read from the filesystem
-	// if the token is not set
+	// if the HMAC token is not set in the environment
 	if len(hmacToken) == 0 {
 		// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
 		hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -184,7 +184,7 @@ func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
 	// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
 	hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
-	if len(hmacTokenPath) > 0 {
+	if len(hmacToken) == 0 && len(hmacTokenPath) > 0 {
 		b, err := os.ReadFile(hmacTokenPath)
 		if err != nil {
 			logrus.Errorf("failed to read HMAC_TOKEN_PATH %s: %s", hmacTokenPath, err)

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -182,15 +182,18 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 // HMACToken gets the HMAC token from the environment or the filesystem
 func HMACToken() string {
 	hmacToken := os.Getenv("HMAC_TOKEN")
-	// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
-	hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
-	if len(hmacToken) == 0 && len(hmacTokenPath) > 0 {
-		b, err := os.ReadFile(hmacTokenPath)
-		if err != nil {
-			logrus.Errorf("failed to read HMAC_TOKEN_PATH %s: %s", hmacTokenPath, err)
-			return hmacToken
+	// Prioritise the value from the environment for backwards compatibility
+	if len(hmacToken) == 0 {
+		// If HMAC_TOKEN_PATH is specified then attempt to read from the filesystem
+		hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
+		if len(hmacTokenPath) > 0 {
+			b, err := os.ReadFile(hmacTokenPath)
+			if err != nil {
+				logrus.Errorf("failed to read HMAC_TOKEN_PATH %s: %s", hmacTokenPath, err)
+				return hmacToken
+			}
+			hmacToken = string(b)
 		}
-		hmacToken = string(b)
 	}
 	return hmacToken
 }

--- a/pkg/util/scmclient.go
+++ b/pkg/util/scmclient.go
@@ -179,9 +179,19 @@ func getSCMTokenFromPath(gitKind string) (string, error) {
 	return string(b), nil
 }
 
-// HMACToken gets the HMAC token from the environment
-func HMACToken() string {
-	return os.Getenv("HMAC_TOKEN")
+// HMACToken gets the HMAC token from the environment or the filesystem
+func HMACToken() (string, error) {
+	hmacToken := os.Getenv("HMAC_TOKEN")
+	// If HMAC_TOKEN_PATH is specified then attempt to read from filesystem
+	hmacTokenPath := os.Getenv("HMAC_TOKEN_PATH")
+	if len(hmacTokenPath) > 0 {
+		b, err := os.ReadFile(hmacTokenPath)
+		if err != nil {
+			return "", err
+		}
+		hmacToken = string(b)
+	}
+	return hmacToken, nil
 }
 
 // BlobURLForProvider gets the link to the blob for an individual file in a commit or branch

--- a/pkg/util/scmclient_test.go
+++ b/pkg/util/scmclient_test.go
@@ -72,21 +72,18 @@ func TestHMACToken(t *testing.T) {
 	}{
 		"missing env vars": {
 			envVars:   map[string]string{},
-			wantError: false,
 			hmacToken: "",
 		},
 		"hmac token env var": {
 			envVars: map[string]string{
 				"HMAC_TOKEN": "myhmactokenfromenvvar",
 			},
-			wantError: false,
 			hmacToken: "myhmactokenfromenvvar",
 		},
 		"hmac token path env var": {
 			envVars: map[string]string{
 				"HMAC_TOKEN_PATH": filepath.Join("test_data", "secret_dir", "hmac-token"),
 			},
-			wantError: false,
 			hmacToken: "myhmactokenfrompath",
 		},
 		"hmac token env var and path env var": {
@@ -94,14 +91,12 @@ func TestHMACToken(t *testing.T) {
 				"HMAC_TOKEN":      "myhmactokenfromenvvar",
 				"HMAC_TOKEN_PATH": filepath.Join("test_data", "secret_dir", "hmac-token"),
 			},
-			wantError: false,
 			hmacToken: "myhmactokenfrompath",
 		},
 		"hmac token missing path env var": {
 			envVars: map[string]string{
 				"HMAC_TOKEN_PATH": filepath.Join("test_data", "secret_dir", "does-not-exist"),
 			},
-			wantError: true,
 			hmacToken: "",
 		},
 	}
@@ -114,18 +109,14 @@ func TestHMACToken(t *testing.T) {
 			}
 
 			// Attempt to retrieve HMAC token
-			hmacToken, err := util.HMACToken()
-			if test.wantError {
-				require.Error(t, err, "successfully retrieved HMAC token")
-			} else {
-				require.NoError(t, err, "failed to retrieve HMAC token")
-				// Verify HMAC token value
-				assert.Equal(t, test.hmacToken, hmacToken, "failed to get expected HMAC token: %s", hmacToken)
-			}
+			hmacToken := util.HMACToken()
+
+			// Verify HMAC token value
+			assert.Equal(t, test.hmacToken, hmacToken, "failed to get expected HMAC token: %s", hmacToken)
 
 			// Unset environment variables
 			for envVarName := range test.envVars {
-				err = os.Unsetenv(envVarName)
+				err := os.Unsetenv(envVarName)
 				require.NoErrorf(t, err, "failed to unset environment variable %s", envVarName)
 			}
 		})

--- a/pkg/util/scmclient_test.go
+++ b/pkg/util/scmclient_test.go
@@ -64,7 +64,7 @@ func TestGetSCMTokenUnsetError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// The following tests verify that the HMACToken function works
+// The following tests verify that the HMACToken function works correctly
 func TestHMACToken(t *testing.T) {
 	tests := map[string]struct {
 		envVars   map[string]string

--- a/pkg/util/scmclient_test.go
+++ b/pkg/util/scmclient_test.go
@@ -92,7 +92,7 @@ func TestHMACToken(t *testing.T) {
 				"HMAC_TOKEN":      "myhmactokenfromenvvar",
 				"HMAC_TOKEN_PATH": filepath.Join("test_data", "secret_dir", "hmac-token"),
 			},
-			hmacToken: "myhmactokenfrompath",
+			hmacToken: "myhmactokenfromenvvar",
 		},
 		"hmac token missing path env var": {
 			envVars: map[string]string{

--- a/pkg/util/scmclient_test.go
+++ b/pkg/util/scmclient_test.go
@@ -64,6 +64,7 @@ func TestGetSCMTokenUnsetError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// The following tests verify that the HMACToken function works
 func TestHMACToken(t *testing.T) {
 	tests := map[string]struct {
 		envVars   map[string]string

--- a/pkg/util/test_data/secret_dir/hmac-token
+++ b/pkg/util/test_data/secret_dir/hmac-token
@@ -1,0 +1,1 @@
+myhmactokenfrompath


### PR DESCRIPTION
Similarly to https://github.com/jenkins-x/lighthouse/pull/1511 some highly restricted environments do not allow secrets to be supplied via environment variables since they are a common attack vector.

This PR adds support for reading the HMAC token from a path supplied through an environment variable `HMAC_TOKEN_PATH`. Corresponding tests and a Helm chart option `hmacTokenVolumeMount.enabled` have also been added.

Backwards compatibility is maintained by looking for the `HMAC_TOKEN` environment variable first.

@ankitm123 I tried to add table driven tests as suggested in https://github.com/jenkins-x/lighthouse/pull/1511. Not sure if the tests in this PR is what you meant? If they are then I can add them for https://github.com/jenkins-x/lighthouse/pull/1511 in a subsequent PR