### PR TITLE
Added restartPolicy for keeper

### DIFF
--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -35,6 +35,7 @@ spec:
       - name: {{ template "keeper.name" . }}
         image: {{ tpl .Values.keeper.image.repository . }}:{{ tpl .Values.keeper.image.tag . }}
         imagePullPolicy: {{ tpl .Values.keeper.image.pullPolicy . }}
+        restartPolicy: {{ tpl .Values.keeper.restartPolicy . }}
         args:
           - "--namespace={{ .Release.Namespace }}"
         ports:


### PR DESCRIPTION
Keeper Pod Readiness and Liveness is failing when pod got restarted.
So, we wanted to give keeper ability to controlling restart.
