### PR TITLE
fix: use jx-boot image for changelog

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -75,16 +75,19 @@ spec:
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=docker/gc/Dockerfile --destination=ghcr.io/jenkins-x/lighthouse-gc-jobs:$VERSION --destination=ghcr.io/jenkins-x/lighthouse-gc-jobs:latest --build-arg=VERSION=$VERSION
         - name: chart-docs
           resources: {}
-        - image: ghcr.io/jenkins-x/jx-changelog:0.10.3
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.73
           name: changelog
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
 
-            sed -i -e "s/^version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
-            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
-
+            if [ -d "charts/$REPO_NAME" ]; then
+              jx gitops yset -p version -v "$VERSION" -f ./charts/$REPO_NAME/Chart.yaml
+              jx gitops yset -p appVersion -v "$VERSION" -f ./charts/$REPO_NAME/Chart.yaml
+              jx gitops yset -p 'image.tag' -v "$VERSION" -f ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+            
             jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --prerelease
         - name: release-chart
           resources: {}


### PR DESCRIPTION
Background: the jx-changelog image isn't built anymore. The problem with it was that the jx command downloaded jx-changelog on the first invokation, even though it was already in the image. So the jx-boot image is recommended instead; it doesn't have that problem.

also cleaning up a bit