### PR TITLE
feat: Add risk label

### DIFF
--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -40,7 +40,7 @@ var (
 		ConfigHelpProvider: configHelp,
 		Commands: []plugins.Command{{
 			Prefix: "remove-",
-			Name:   "area|committee|kind|language|priority|sig|team|triage|wg|label",
+			Name:   "area|committee|kind|language|priority|sig|team|triage|wg|label|risk",
 			Arg: &plugins.CommandArg{
 				Pattern: ".*",
 			},

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -134,7 +134,7 @@ func TestLabel(t *testing.T) {
 		},
 		{
 			name:                  "Add A Risk Label",
-			body:                  "/risk ops",
+			body:                  "/risk high",
 			repoLabels:            []string{"area/infra", "risk/high"},
 			issueLabels:           []string{"area/infra"},
 			expectedNewLabels:     formatLabels("risk/high"),
@@ -370,7 +370,7 @@ func TestLabel(t *testing.T) {
 		},
 		{
 			name:                  "Remove Risk Label",
-			body:                  "/remove-risk ops",
+			body:                  "/remove-risk low",
 			repoLabels:            []string{"area/infra", "risk/low"},
 			issueLabels:           []string{"area/infra", "risk/low"},
 			expectedNewLabels:     []string{},

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -133,6 +133,15 @@ func TestLabel(t *testing.T) {
 			commenter:             orgMember,
 		},
 		{
+			name:                  "Add A Risk Label",
+			body:                  "/risk ops",
+			repoLabels:            []string{"area/infra", "risk/high"},
+			issueLabels:           []string{"area/infra"},
+			expectedNewLabels:     formatLabels("risk/high"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+		},
+		{
 			name:                  "Add Single Triage Label",
 			body:                  "/triage needs-information",
 			repoLabels:            []string{"area/infra", "triage/needs-information"},
@@ -357,6 +366,15 @@ func TestLabel(t *testing.T) {
 			issueLabels:           []string{"area/infra", "team/ops"},
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("team/ops"),
+			commenter:             orgMember,
+		},
+		{
+			name:                  "Remove Risk Label",
+			body:                  "/remove-risk ops",
+			repoLabels:            []string{"area/infra", "risk/low"},
+			issueLabels:           []string{"area/infra", "risk/low"},
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: formatLabels("risk/low"),
 			commenter:             orgMember,
 		},
 		{


### PR DESCRIPTION
Add a `risk` label to allow assigning an impact label to merge requests. This provides an easy view of the overall impact of a change request and can faciliate the risk of multiple low vs high risk changes into a single code release.