### PR TITLE
feat: update cronjob version for lighthouse

### DIFF
--- a/charts/lighthouse/templates/gc-jobs-cj.yaml
+++ b/charts/lighthouse/templates/gc-jobs-cj.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "gcJobs.name" . }}


### PR DESCRIPTION
Going to go through the jenkins-x objects to get them ready for an upgrade

```
NAME                                                              KIND                      VERSION               REPLACEMENT      REMOVED   DEPRECATED   REPL AVAIL
lighthouse-gc-jobs                                                CronJob                   batch/v1beta1         batch/v1         false     true         true        