### PR TITLE
fix: allow params from previous tasks results

### DIFF
--- a/pkg/triggerconfig/inrepo/params.go
+++ b/pkg/triggerconfig/inrepo/params.go
@@ -20,20 +20,37 @@ type UseLocation struct {
 	TaskSpec        *v1beta1.TaskSpec
 }
 
+func getParamsFromTasksResults(loc *UseLocation) map[string]bool {
+	areParamsFromTasksResults := make(map[string]bool)
+	pipelineTasksAndFinally := loc.PipelineSpec.Tasks
+	pipelineTasksAndFinally = append(pipelineTasksAndFinally, loc.PipelineSpec.Finally...)
+	for _, pipelineTask := range pipelineTasksAndFinally {
+		params := pipelineTask.Params
+		for _, param := range params {
+			paramValStr := param.Value.StringVal
+			if strings.HasPrefix(paramValStr, "$(tasks.") && strings.Contains(paramValStr, ".results.") && strings.HasSuffix(paramValStr, ")") {
+				areParamsFromTasksResults[param.Name] = true
+			}
+		}
+	}
+	return areParamsFromTasksResults
+}
+
 // UseParametersAndResults adds the parameters from the used Task to the PipelineSpec if specified and the PipelineTask
 func UseParametersAndResults(ctx context.Context, loc *UseLocation, uses *v1beta1.TaskSpec) error {
 	parameterSpecs := uses.Params
 	parameters := ToParams(parameterSpecs)
 	results := uses.Results
+	areParamsFromTasksResults := getParamsFromTasksResults(loc)
 
 	prs := loc.PipelineRunSpec
 	if prs != nil {
-		prs.Params = useParameters(prs.Params, ToDefaultParams(parameterSpecs))
+		prs.Params = useParameters(prs.Params, ToDefaultParams(parameterSpecs), areParamsFromTasksResults)
 		prs.Workspaces = useWorkspaceBindings(prs.Workspaces, ToWorkspaceBindings(uses.Workspaces))
 	}
 	ps := loc.PipelineSpec
 	if ps != nil {
-		ps.Params = useParameterSpecs(ctx, ps.Params, parameterSpecs)
+		ps.Params = useParameterSpecs(ctx, ps.Params, parameterSpecs, areParamsFromTasksResults)
 		ps.Results = usePipelineResults(ps.Results, results, loc.TaskName)
 		ps.Workspaces = usePipelineWorkspaces(ps.Workspaces, uses.Workspaces)
 	}
@@ -43,11 +60,11 @@ func UseParametersAndResults(ctx context.Context, loc *UseLocation, uses *v1beta
 	}
 	trs := loc.TaskRunSpec
 	if trs != nil {
-		trs.Params = useParameters(trs.Params, parameters)
+		trs.Params = useParameters(trs.Params, parameters, areParamsFromTasksResults)
 	}
 	ts := loc.TaskSpec
 	if ts != nil {
-		ts.Params = useParameterSpecs(ctx, ts.Params, parameterSpecs)
+		ts.Params = useParameterSpecs(ctx, ts.Params, parameterSpecs, areParamsFromTasksResults)
 		ts.Results = useResults(ts.Results, results)
 		ts.Sidecars = useSidecars(ts.Sidecars, uses.Sidecars)
 		ts.Workspaces = useWorkspaces(ts.Workspaces, uses.Workspaces)
@@ -89,7 +106,7 @@ func ToDefaultParams(params []v1beta1.ParamSpec) []v1beta1.Param {
 	return answer
 }
 
-func useParameterSpecs(ctx context.Context, params []v1beta1.ParamSpec, uses []v1beta1.ParamSpec) []v1beta1.ParamSpec {
+func useParameterSpecs(ctx context.Context, params []v1beta1.ParamSpec, uses []v1beta1.ParamSpec, areParamsFromTasksResults map[string]bool) []v1beta1.ParamSpec {
 	for _, u := range uses {
 		found := false
 		for i := range params {
@@ -105,13 +122,15 @@ func useParameterSpecs(ctx context.Context, params []v1beta1.ParamSpec, uses []v
 		}
 		if !found {
 			u.SetDefaults(ctx)
-			params = append(params, u)
+			if areParamsFromTasksResults == nil || !areParamsFromTasksResults[u.Name] {
+				params = append(params, u)
+			}
 		}
 	}
 	return params
 }
 
-func useParameters(params []v1beta1.Param, uses []v1beta1.Param) []v1beta1.Param {
+func useParameters(params []v1beta1.Param, uses []v1beta1.Param, areParamsFromTasksResults map[string]bool) []v1beta1.Param {
 	for _, u := range uses {
 		found := false
 		for i := range params {
@@ -134,7 +153,9 @@ func useParameters(params []v1beta1.Param, uses []v1beta1.Param) []v1beta1.Param
 			}
 		}
 		if !found {
-			params = append(params, u)
+			if areParamsFromTasksResults == nil || !areParamsFromTasksResults[u.Name] {
+				params = append(params, u)
+			}
 		}
 	}
 	return params

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/expected.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/expected.yaml
@@ -1,0 +1,339 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: jx3-test-save-show-results
+spec:
+  params:
+  - name: value_to_save
+    value: ""
+  - name: BUILD_ID
+    value: ""
+  - name: JOB_NAME
+    value: ""
+  - name: JOB_SPEC
+    value: ""
+  - name: JOB_TYPE
+    value: ""
+  - name: PULL_BASE_REF
+    value: ""
+  - name: PULL_BASE_SHA
+    value: ""
+  - name: PULL_NUMBER
+    value: ""
+  - name: PULL_PULL_REF
+    value: ""
+  - name: PULL_PULL_SHA
+    value: ""
+  - name: PULL_REFS
+    value: ""
+  - name: REPO_NAME
+    value: ""
+  - name: REPO_OWNER
+    value: ""
+  - name: REPO_URL
+    value: ""
+  pipelineSpec:
+    params:
+    - default: ""
+      name: value_to_save
+      type: string
+    - description: the unique build number
+      name: BUILD_ID
+      type: string
+    - description: the name of the job which is the trigger context name
+      name: JOB_NAME
+      type: string
+    - description: the specification of the job
+      name: JOB_SPEC
+      type: string
+    - description: '''the kind of job: postsubmit or presubmit'''
+      name: JOB_TYPE
+      type: string
+    - description: the base git reference of the pull request
+      name: PULL_BASE_REF
+      type: string
+    - description: the git sha of the base of the pull request
+      name: PULL_BASE_SHA
+      type: string
+    - default: ""
+      description: git pull request number
+      name: PULL_NUMBER
+      type: string
+    - default: ""
+      description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+      name: PULL_PULL_REF
+      type: string
+    - default: ""
+      description: git revision to checkout (branch, tag, sha, ref…)
+      name: PULL_PULL_SHA
+      type: string
+    - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+      name: PULL_REFS
+      type: string
+    - description: git repository name
+      name: REPO_NAME
+      type: string
+    - description: git repository owner (user or organisation)
+      name: REPO_OWNER
+      type: string
+    - description: git url to clone
+      name: REPO_URL
+      type: string
+    results:
+    - description: result_value
+      name: result_value
+      value: $(tasks.save-results.results.result_value)
+    tasks:
+    - name: save-results
+      params:
+      - name: value_to_save
+        value: test_demo
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        metadata: {}
+        params:
+        - default: ""
+          name: value_to_save
+          type: string
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - default: ""
+          description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - default: ""
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        results:
+        - description: result_value
+          name: result_value
+        spec: null
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          imagePullPolicy: IfNotPresent
+          name: ""
+          resources: {}
+          workingDir: /workspace/source
+        steps:
+        - image: ubuntu:jammy
+          name: save-result
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            set -ex
+            result_value="$(params.value_to_save)"
+            echo "results.result_value.path is $(results.result_value.path)"
+            echo -n "${result_value}" > $(results.result_value.path)
+            echo "result_value is ${result_value}"
+    - name: display-results
+      params:
+      - name: value_to_show
+        value: $(tasks.save-results.results.result_value)
+      - name: BUILD_ID
+        value: $(params.BUILD_ID)
+      - name: JOB_NAME
+        value: $(params.JOB_NAME)
+      - name: JOB_SPEC
+        value: $(params.JOB_SPEC)
+      - name: JOB_TYPE
+        value: $(params.JOB_TYPE)
+      - name: PULL_BASE_REF
+        value: $(params.PULL_BASE_REF)
+      - name: PULL_BASE_SHA
+        value: $(params.PULL_BASE_SHA)
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: PULL_PULL_REF
+        value: $(params.PULL_PULL_REF)
+      - name: PULL_PULL_SHA
+        value: $(params.PULL_PULL_SHA)
+      - name: PULL_REFS
+        value: $(params.PULL_REFS)
+      - name: REPO_NAME
+        value: $(params.REPO_NAME)
+      - name: REPO_OWNER
+        value: $(params.REPO_OWNER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      runAfter:
+      - save-results
+      taskSpec:
+        metadata: {}
+        params:
+        - default: ""
+          name: value_to_show
+          type: string
+        - description: the unique build number
+          name: BUILD_ID
+          type: string
+        - description: the name of the job which is the trigger context name
+          name: JOB_NAME
+          type: string
+        - description: the specification of the job
+          name: JOB_SPEC
+          type: string
+        - description: '''the kind of job: postsubmit or presubmit'''
+          name: JOB_TYPE
+          type: string
+        - description: the base git reference of the pull request
+          name: PULL_BASE_REF
+          type: string
+        - description: the git sha of the base of the pull request
+          name: PULL_BASE_SHA
+          type: string
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - default: ""
+          description: git pull request ref in the form 'refs/pull/$PULL_NUMBER/head'
+          name: PULL_PULL_REF
+          type: string
+        - default: ""
+          description: git revision to checkout (branch, tag, sha, ref…)
+          name: PULL_PULL_SHA
+          type: string
+        - description: git pull reference strings of base and latest in the form 'master:$PULL_BASE_SHA,$PULL_NUMBER:$PULL_PULL_SHA:refs/pull/$PULL_NUMBER/head'
+          name: PULL_REFS
+          type: string
+        - description: git repository name
+          name: REPO_NAME
+          type: string
+        - description: git repository owner (user or organisation)
+          name: REPO_OWNER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        spec: null
+        stepTemplate:
+          env:
+          - name: BUILD_ID
+            value: $(params.BUILD_ID)
+          - name: JOB_NAME
+            value: $(params.JOB_NAME)
+          - name: JOB_SPEC
+            value: $(params.JOB_SPEC)
+          - name: JOB_TYPE
+            value: $(params.JOB_TYPE)
+          - name: PULL_BASE_REF
+            value: $(params.PULL_BASE_REF)
+          - name: PULL_BASE_SHA
+            value: $(params.PULL_BASE_SHA)
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: PULL_PULL_REF
+            value: $(params.PULL_PULL_REF)
+          - name: PULL_PULL_SHA
+            value: $(params.PULL_PULL_SHA)
+          - name: PULL_REFS
+            value: $(params.PULL_REFS)
+          - name: REPO_NAME
+            value: $(params.REPO_NAME)
+          - name: REPO_OWNER
+            value: $(params.REPO_OWNER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          imagePullPolicy: IfNotPresent
+          name: ""
+          resources: {}
+          workingDir: /workspace/source
+        steps:
+        - image: ubuntu:jammy
+          name: show-result
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            set -ex
+            echo "tasks.save-results.results.result_value is $(tasks.save-results.results.result_value)"
+            value_to_show="$(params.value_to_show)"
+            echo "value_to_show is ${value_to_show}"
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 30m0s
+status: {}

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/save-results-task.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/save-results-task.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: save-results
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  params:
+  - name: value_to_save
+    type: string
+    default: ""
+  results:
+  - name: "result_value"
+    description: "result_value"
+  stepTemplate:
+    imagePullPolicy: IfNotPresent
+    resources:
+      # override limits for all containers here
+      limits: {}
+    workingDir: /workspace/source
+  steps:
+    - name: save-result
+      image: ubuntu:jammy
+      script: |
+        #!/usr/bin/env sh
+        set -ex
+        result_value="$(params.value_to_save)"
+        echo "results.result_value.path is $(results.result_value.path)"
+        echo -n "${result_value}" > $(results.result_value.path)
+        echo "result_value is ${result_value}"

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/show-results-task.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/show-results-task.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: show-results
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  params:
+  - name: value_to_show
+    type: string
+    default: ""
+  stepTemplate:
+    imagePullPolicy: IfNotPresent
+    resources:
+      # override limits for all containers here
+      limits: {}
+    workingDir: /workspace/source
+  steps:
+    - name: show-result
+      image: ubuntu:jammy
+      script: |
+        #!/usr/bin/env sh
+        set -ex
+        echo "tasks.save-results.results.result_value is $(tasks.save-results.results.result_value)"
+        value_to_show="$(params.value_to_show)"
+        echo "value_to_show is ${value_to_show}"

--- a/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/source.yaml
+++ b/pkg/triggerconfig/inrepo/test_data/load_pipelinerun/pipeline-params-from-tasks-results/source.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: jx3-test-save-show-results
+spec:
+  pipelineSpec:
+    tasks:
+      - name: save-results
+        params:
+        - name: value_to_save
+          value: "test_demo"
+        taskSpec:
+          params:
+          - name: value_to_save
+            type: string
+            default: ""
+          results:
+          - name: "result_value"
+            description: "result_value"
+          stepTemplate:
+            imagePullPolicy: IfNotPresent
+            resources:
+              # override limits for all containers here
+              limits: {}
+            workingDir: /workspace/source
+          steps:
+            - image: uses:./test_data/load_pipelinerun/pipeline-params-from-tasks-results/save-results-task.yaml
+              name: ""
+      - name: display-results
+        runAfter:
+          - save-results
+        params:
+        - name: value_to_show
+          value: "$(tasks.save-results.results.result_value)"
+        taskSpec:
+          params:
+          - name: value_to_show
+            type: string
+            default: ""
+          stepTemplate:
+            imagePullPolicy: IfNotPresent
+            resources:
+              # override limits for all containers here
+              limits: {}
+            workingDir: /workspace/source
+          steps:
+            - image: uses:./test_data/load_pipelinerun/pipeline-params-from-tasks-results/show-results-task.yaml
+              name: ""
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 00h30m0s
+status: {}

--- a/pkg/triggerconfig/inrepo/uses_resolver.go
+++ b/pkg/triggerconfig/inrepo/uses_resolver.go
@@ -72,7 +72,7 @@ func (r *UsesResolver) UsesSteps(sourceURI string, taskName string, step tektonv
 
 	// lets preserve any parameters, results, workspaces on the ts before overriding...
 	ctx := context.TODO()
-	useTS.Params = useParameterSpecs(ctx, useTS.Params, ts.Params)
+	useTS.Params = useParameterSpecs(ctx, useTS.Params, ts.Params, nil)
 	useTS.Results = useResults(useTS.Results, ts.Results)
 	useTS.Workspaces = useWorkspaces(useTS.Workspaces, ts.Workspaces)
 	useTS.Sidecars = useSidecars(useTS.Sidecars, ts.Sidecars)


### PR DESCRIPTION
Hello,

I first want to thank you so much for the help to allow the upgrade to 1.25 @tomhobson @msvticket and all others i'm forgetting.

I am using params with as value the results from previous tasks.
It worked in jx 3.10.83, but since I have upgraded to 3.10.86 in order to upgrade my cluster to 1.25 it broke

I know that jx uses resolver will be removed, but in order to prepare the right way, I need to keep a little more the uses inside my jx3 catalog, and so this PR would help be a lot.

I was able to reproduce with this PipelineRun that is generated after `jx uses` resolver.

```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: jx3-test-save-show-results
spec:
  pipelineSpec:
    tasks:
      - name: save-results
        params:
        - name: value_to_save
          value: "test_demo"
        taskSpec:
          params:
          - name: value_to_save
            type: string
            default: ""
          results:
          - name: "result_value"
            description: "result_value"
          stepTemplate:
            imagePullPolicy: IfNotPresent
            resources:
              # override limits for all containers here
              limits: {}
            workingDir: /workspace/source
          steps:
            - image: uses:jx3-catalog/tasks/test-previous-results-params/0.1/save-results.yaml@4cf2604452bde421e90b3cb79f04ecb81d452188
              name: ""
      - name: display-results
        runAfter:
          - save-results
        params:
        - name: value_to_show
          value: "$(tasks.save-results.results.result_value)"
        taskSpec:
          params:
          - name: value_to_show
            type: string
            default: ""
          stepTemplate:
            imagePullPolicy: IfNotPresent
            resources:
              # override limits for all containers here
              limits: {}
            workingDir: /workspace/source
          steps:
            - image: uses:jx3-catalog/tasks/test-previous-results-params/0.1/show-results.yaml@4cf2604452bde421e90b3cb79f04ecb81d452188
              name: ""
  podTemplate: {}
  serviceAccountName: tekton-bot
  timeout: 00h30m0s
status: {}
```

with these 2 tasks that are resolved by the jx uses resolver:
```
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: save-results
  labels:
    app.kubernetes.io/version: "0.1"
spec:
  params:
  - name: value_to_save
    type: string
    default: ""
  results:
  - name: "result_value"
    description: "result_value"
  stepTemplate:
    imagePullPolicy: IfNotPresent
    resources:
      # override limits for all containers here
      limits: {}
    workingDir: /workspace/source
  steps:
    - name: save-result
      image: ubuntu:jammy
      script: |
        #!/usr/bin/env sh
        set -ex
        result_value="$(params.value_to_save)"
        echo "results.result_value.path is $(results.result_value.path)"
        echo -n "${result_value}" > $(results.result_value.path)
        echo "result_value is ${result_value}"

```

```
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: show-results
  labels:
    app.kubernetes.io/version: "0.1"
spec:
  params:
  - name: value_to_show
    type: string
    default: ""
  stepTemplate:
    imagePullPolicy: IfNotPresent
    resources:
      # override limits for all containers here
      limits: {}
    workingDir: /workspace/source
  steps:
    - name: show-result
      image: ubuntu:jammy
      script: |
        #!/usr/bin/env sh
        set -ex
        echo "tasks.save-results.results.result_value is $(tasks.save-results.results.result_value)"
        value_to_show="$(params.value_to_show)"
        echo "value_to_show is ${value_to_show}"

```

Before this PullRequest was done, all of this was resolved to this PipelineRun with some cleaning from myself to make it more visible:

```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: failed
  namespace: jx
spec:
  params:
  - name: value_to_save
    value: ""
  - name: value_to_show
    value: ""
  pipelineSpec:
    params:
    - default: ""
      name: value_to_save
      type: string
    - default: ""
      name: value_to_show
      type: string
    results:
    - description: result_value
      name: result_value
      value: $(tasks.save-results.results.result_value)
    tasks:
    - name: save-results
      params:
      - name: value_to_save
        value: test_demo
      taskSpec:
        params:
        - default: ""
          name: value_to_save
          type: string
        results:
        - description: result_value
          name: result_value
          type: string
        stepTemplate:
          imagePullPolicy: IfNotPresent
          name: ""
          workingDir: /workspace/source
        steps:
        - image: ubuntu:jammy
          name: save-result
          script: |
            #!/usr/bin/env sh
            set -ex
            result_value="$(params.value_to_save)"
            echo "results.result_value.path is $(results.result_value.path)"
            echo -n "${result_value}" > $(results.result_value.path)
            echo "result_value is ${result_value}"
    - name: display-results
      params:
      - name: value_to_show
        value: $(tasks.save-results.results.result_value)
      runAfter:
      - save-results
      taskSpec:
        params:
        - default: ""
          name: value_to_show
          type: string
        stepTemplate:
          imagePullPolicy: IfNotPresent
          name: ""
          workingDir: /workspace/source
        steps:
        - image: ubuntu:jammy
          name: show-result
          script: |
            #!/usr/bin/env sh
            set -ex
            echo "tasks.save-results.results.result_value is $(tasks.save-results.results.result_value)"
            value_to_show="$(params.value_to_show)"
            echo "value_to_show is ${value_to_show}"
  serviceAccountName: tekton-bot
  timeout: 30m0s

```
Here the problem is that it seems with tekton 0.41.0+ we don't need the `PipelineRun.spec.params value_to_show` and the `PipelineRun.spec.pipelineSpec.params value_to_show` because value_to_show is just a task previous result as shown here:

``` 
params:
  - name: value_to_show
    value: $(tasks.save-results.results.result_value)
```

After this PullRequest, it is now working, this a PipelineRun that is generated because of jx uses resolver
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: success
  namespace: jx
spec:
  params:
  - name: value_to_save
    value: ""
  pipelineSpec:
    params:
    - default: ""
      name: value_to_save
    results:
    - description: result_value
      name: result_value
      value: $(tasks.save-results.results.result_value)
    tasks:
    - name: save-results
      params:
      - name: value_to_save
        value: test_demo
      taskSpec:
        params:
        - default: ""
          name: value_to_save
          type: string
        results:
        - description: result_value
          name: result_value
          type: string
        stepTemplate:
          imagePullPolicy: IfNotPresent
          name: ""
          workingDir: /workspace/source
        steps:
        - image: ubuntu:jammy
          name: save-result
          script: |
            #!/usr/bin/env sh
            set -ex
            result_value="$(params.value_to_save)"
            echo "results.result_value.path is $(results.result_value.path)"
            echo -n "${result_value}" > $(results.result_value.path)
            echo "result_value is ${result_value}"
    - name: display-results
      params:
      - name: value_to_show
        value: $(tasks.save-results.results.result_value)
      runAfter:
      - save-results
      taskSpec:
        params:
        - default: ""
          name: value_to_show
          type: string
        stepTemplate:
          imagePullPolicy: IfNotPresent
          name: ""
          workingDir: /workspace/source
        steps:
        - image: ubuntu:jammy
          name: show-result
          script: |
            #!/usr/bin/env sh
            set -ex
            echo "tasks.save-results.results.result_value is $(tasks.save-results.results.result_value)"
            value_to_show="$(params.value_to_show)"
            echo "value_to_show is ${value_to_show}"
  serviceAccountName: tekton-bot
  timeout: 30m0s
```