### PR TITLE
Trigger command

### DIFF
--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -214,7 +214,7 @@ webhooks:
       # webhooks.ingress.tls.secretName -- Specify webhooks ingress tls secretName
       secretName: ""
 
-  # webhooks.customDeploymentTriggerCommand -- deployments can configure the ability to allow custom lighthouse triggers
+  # webhooks.customDeploymentTriggerCommand -- takes in a comma seperated list of lighthouse triggers. deployments can configure the ability to allow custom lighthouse triggers
   # using their own unique chat prefix, for example extending the default `/test` trigger prefix let them specify
   # `customDeploymentTriggerPrefix: foo` which means they can also use their own custom trigger /foo mycoolthing
   customDeploymentTriggerCommand: ""

--- a/docs/trigger/README.md
+++ b/docs/trigger/README.md
@@ -2,7 +2,7 @@
 
 You can enable use LH_CUSTOM_TRIGGER_COMMAND environment variable to add custom triggers. It takes in a comma seperated list of commands.
 
-When these commands are triggered using ChatOps Lighthouse will convert the command arg into TRIGGER_COMMAND_ARG enviroment variable which you can refer from the pipeline.
+When these commands are triggered using ChatOps, Lighthouse will store the command arg in TRIGGER_COMMAND_ARG PipelineRunPara which you can refer from the pipeline.
 
 eg:
 `

--- a/docs/trigger/README.md
+++ b/docs/trigger/README.md
@@ -1,0 +1,44 @@
+# Lighthouse custome triggers
+
+You can enable use LH_CUSTOM_TRIGGER_COMMAND environment variable to add custom triggers. It takes in a comma seperated list of commands.
+
+When these commands are triggered using ChatOps Lighthouse will convert the command arg into TRIGGER_COMMAND_ARG enviroment variable which you can refer from the pipeline.
+
+eg:
+`
+LH_CUSTOM_TRIGGER_COMMAND=deploy,trigger
+`
+```
+apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
+kind: TriggerConfig
+spec:
+  presubmits:
+  - name: pr
+    context: "pr"
+    always_run: true
+    optional: false
+    source: "pullrequest.yaml"
+  - name: trigger
+    context: "trigger"
+    always_run: false
+    optional: false
+    rerun_command: /trigger this
+    trigger: (?m)^/trigger( all| this),?(\s+|$)
+    source: "trigger.yaml"
+  - name: deploy
+    context: "deployr"
+    always_run: false
+    optional: false
+    rerun_command: /deploy dev 
+    trigger: (?m)^/deploy(?:[ \t]+([-\w]+(?:,[-\w]+)*))?(?:[ \t]+([-\w]+(?:,[-\w]+)*))?
+    source: "deploy.yaml"
+  postsubmits:
+  - name: release
+    context: "release"
+    source: "release.yaml"
+    branches:
+    - ^main$
+```
+you can use ChatOps command to trigger each pipeline
+eg:
+***/deploy qa***

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -30,7 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent) error {
+func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent) error{
+  return handleGenericCommentWithArg(c, trigger, gc, "")
+
+}
+func handleGenericCommentWithArg(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent, arg string) error {
 	org := gc.Repo.Namespace
 	repo := gc.Repo.Name
 	number := gc.Number
@@ -94,6 +98,14 @@ func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.Gen
 	if err != nil {
 		return err
 	}
+  if arg != "" {
+    for i := range toTest {
+      toTest[i].Base.PipelineRunParams = append(toTest[i].Base.PipelineRunParams , job.PipelineRunParam{
+        Name: "TRIGGER_COMMAND_ARG",
+        ValueTemplate: arg,
+      })
+    }
+  }
 	return RunAndSkipJobs(c, pr, toTest, toSkip, gc.GUID, trigger.ElideSkippedContexts)
 }
 

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -30,11 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent) error{
-  return handleGenericCommentWithArg(c, trigger, gc, "")
-
-}
-func handleGenericCommentWithArg(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent, arg string) error {
+func handleGenericComment(c Client, trigger *plugins.Trigger, gc scmprovider.GenericCommentEvent, arg string) error {
 	org := gc.Repo.Namespace
 	repo := gc.Repo.Name
 	number := gc.Number

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -77,13 +77,13 @@ var plugin = plugins.Plugin{
 
 func init() {
 	customTriggerCommand := os.Getenv(customerTriggerCommandEnvVar)
-	if customTriggerCommand != "" {
+  for _, trigger := range strings.Split(customTriggerCommand, ","){
 		customCommand := plugins.Command{
-			Name: customTriggerCommand,
+			Name: trigger,
 			Arg: &plugins.CommandArg{
 				Pattern: `[-\w]+(?:,[-\w]+)*`,
 			},
-			Description: fmt.Sprintf("Manually trigger /%s chatops commands.", customTriggerCommand),
+			Description: fmt.Sprintf("Manually trigger /%s chatops commands.", trigger),
 			Featured:    true,
 			Action: plugins.
 				Invoke(handleGenericCommentEvent).

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -170,8 +170,8 @@ func handlePullRequest(pc plugins.Agent, pr scm.PullRequestHook) error {
 	return handlePR(getClient(pc), pc.PluginConfig.TriggerFor(org, repo), pr)
 }
 
-func handleGenericCommentEvent(_ plugins.CommandMatch, pc plugins.Agent, gc scmprovider.GenericCommentEvent) error {
-	return handleGenericComment(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Namespace, gc.Repo.Name), gc)
+func handleGenericCommentEvent(cm plugins.CommandMatch, pc plugins.Agent, gc scmprovider.GenericCommentEvent) error {
+	return handleGenericCommentWithArg(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Namespace, gc.Repo.Name), gc, cm.Arg)
 }
 
 func handlePush(pc plugins.Agent, pe scm.PushHook) error {

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -76,23 +76,22 @@ var plugin = plugins.Plugin{
 }
 
 func init() {
-	customTriggerCommand := os.Getenv(customerTriggerCommandEnvVar)
+  customTriggerCommand := os.Getenv(customerTriggerCommandEnvVar)
   for _, trigger := range strings.Split(customTriggerCommand, ","){
-		customCommand := plugins.Command{
-			Name: trigger,
-			Arg: &plugins.CommandArg{
-				Pattern: `[-\w]+(?:,[-\w]+)*`,
-			},
-			Description: fmt.Sprintf("Manually trigger /%s chatops commands.", trigger),
-			Featured:    true,
-			Action: plugins.
-				Invoke(handleGenericCommentEvent).
-				When(plugins.Action(scm.ActionCreate), plugins.IsPR(), plugins.IssueState("open")),
-		}
-		plugin.Commands = append(plugin.Commands, customCommand)
-	}
-
-	plugins.RegisterPlugin(pluginName, plugin)
+    customCommand := plugins.Command{
+      Name: trigger,
+      Arg: &plugins.CommandArg{
+        Pattern: `[-\w]+(?:,[-\w]+)*`,
+      },
+      Description: fmt.Sprintf("Manually trigger /%s chatops commands.", trigger),
+      Featured:    true,
+      Action: plugins.
+        Invoke(handleGenericCommentEvent).
+        When(plugins.Action(scm.ActionCreate), plugins.IsPR(), plugins.IssueState("open")),
+    }
+    plugin.Commands = append(plugin.Commands, customCommand)
+  }
+  plugins.RegisterPlugin(pluginName, plugin)
 }
 
 func configHelp(config *plugins.Configuration, enabledRepos []string) (map[string]string, error) {
@@ -171,7 +170,7 @@ func handlePullRequest(pc plugins.Agent, pr scm.PullRequestHook) error {
 }
 
 func handleGenericCommentEvent(cm plugins.CommandMatch, pc plugins.Agent, gc scmprovider.GenericCommentEvent) error {
-	return handleGenericCommentWithArg(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Namespace, gc.Repo.Name), gc, cm.Arg)
+	return handleGenericComment(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Namespace, gc.Repo.Name), gc, cm.Arg)
 }
 
 func handlePush(pc plugins.Agent, pe scm.PushHook) error {


### PR DESCRIPTION
- pass trigger commands arg as a PipelineRunParam TRIGGER_COMMAND_ARG to presubmit
   with this change we can pass a parameter to out pipeline and use that parameter in the pipeline
   eg: 
   `/deploy dev`
   TRIGGER_COMMAND_ARG=dev
- ability to add multiple trigger commands LH_CUSTOM_TRIGGER_COMMAND will accept a comma seperated list of trigger