### PR TITLE
feat: add source to lighthouse api

### DIFF
--- a/pkg/apis/lighthouse/v1alpha1/types.go
+++ b/pkg/apis/lighthouse/v1alpha1/types.go
@@ -144,6 +144,8 @@ type LighthouseJobSpec struct {
 	// MaxConcurrency restricts the total number of instances
 	// of this job that can run in parallel at once
 	MaxConcurrency int `json:"max_concurrency,omitempty"`
+  // Source to trigger for down stream agent
+  Source string `json:"source,omitempty"`
 	// PipelineRunSpec provides the basis for running the test as a Tekton Pipeline
 	// https://github.com/tektoncd/pipeline
 	PipelineRunSpec *tektonv1beta1.PipelineRunSpec `json:"pipeline_run_spec,omitempty"`

--- a/pkg/jobutil/jobutil.go
+++ b/pkg/jobutil/jobutil.go
@@ -182,6 +182,7 @@ func specFromJobBase(logger *logrus.Entry, jb job.Base) v1alpha1.LighthouseJobSp
 		PodSpec:           jb.Spec,
 		PipelineRunSpec:   jb.PipelineRunSpec,
 		PipelineRunParams: jb.PipelineRunParams,
+    Source:            jb.SourcePath,
 	}
 }
 


### PR DESCRIPTION
this change passes the sourcepath for the triggerconfig down to lighthousespec. with this change we can facilitate addition of new agents (engines), using the value in source to trigger pipelines of their own.