### PR TITLE
fix: add labels to tide-github-app secret

### DIFF
--- a/charts/lighthouse/templates/tide-githubapp-secrets.yaml
+++ b/charts/lighthouse/templates/tide-githubapp-secrets.yaml
@@ -4,6 +4,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: tide-githubapp-tokens
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 data:
   username: {{ default "jenkins-x[bot]" .Values.githubApp.username | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Brings the github app secret inline with the other secrets created by lighthouse