### PR TITLE
fix: Retry foghorn LighthouseJob update using original variable instead of DeepCopy variable

### DIFF
--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -3,6 +3,7 @@ package foghorn
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -17,7 +18,6 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/watcher"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,7 +121,7 @@ func (r *LighthouseJobReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.updateJobStatusForActivity(activityRecord, jobCopy)
 	r.reportStatus(activityRecord, jobCopy)
 
-	if !equality.Semantic.DeepEqual(job.Status, jobCopy.Status) {
+	if !reflect.DeepEqual(job.Status, jobCopy.Status) {
 		f := func(job *lighthousev1alpha1.LighthouseJob) error {
 			job.Status = jobCopy.Status
 			if err := r.client.Status().Update(ctx, job); err != nil {

--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -3,7 +3,6 @@ package foghorn
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/watcher"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,7 +121,7 @@ func (r *LighthouseJobReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.updateJobStatusForActivity(activityRecord, jobCopy)
 	r.reportStatus(activityRecord, jobCopy)
 
-	if !reflect.DeepEqual(job.Status, jobCopy.Status) {
+	if !equality.Semantic.DeepEqual(job.Status, jobCopy.Status) {
 		f := func(job *lighthousev1alpha1.LighthouseJob) error {
 			job.Status = jobCopy.Status
 			if err := r.client.Status().Update(ctx, job); err != nil {

--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -130,7 +130,7 @@ func (r *LighthouseJobReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 			return nil
 		}
-		if err := r.retryModifyJob(ctx, req.NamespacedName, jobCopy, f); err != nil {
+		if err := r.retryModifyJob(ctx, req.NamespacedName, &job, f); err != nil {
 			r.logger.Errorf("Failed to update LighthouseJob status: %s", err)
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
We are using Lighthouse foghorn v1.14.4 and very occasionally it is getting into a continuous loop trying to update a LighthouseJob when there is a conflict.

Initially there is a failure with the following message:

```
Failed to update LighthouseJob status: Operation cannot be fulfilled on lighthousejobs.lighthouse.jenkins.io "[LIGHTHOUSE_JOB_NAME]": the object has been modified; please apply your changes to the latest version and try again
```

It does try again and succeeds: `took 2 attempts to update Job`

However, I think this is false positive because `jobCopy` (instead of `&job`) is being passed into `retryModifyJob` so on retry `r.client.Get` is overwriting `jobCopy` and reverting the updated status, meaning the retry is just updating the LighthouseJob to its current value.

This PR instead passes `&job` into `retryModifyJob` which matches with the Tekton controller: https://github.com/jenkins-x/lighthouse/blob/867b0b5c900ce2f500307e3de9bf1057972077e0/pkg/engines/tekton/controller.go#L146

I don't fully understand why foghorn is getting into a continuous loop, I would have thought the update just wouldn't happen (perhaps the noop update is actually triggering another event and foghorn is continuously conflicting with itself), but either way this should fix the problem because on next reconciliation we shouldn't get past the `reflect.DeepEqual` check.

For a future improvement, Lighthouse foghorn and other controllers could instead use RetryOnConflict from client-go to handle conflicts instead of the custom `retryModifyJob` function: https://pkg.go.dev/k8s.io/client-go/util/retry#RetryOnConflict