### PR TITLE
feat: allow to skip draft prs unless ready for review or /ok-to-test is added

### DIFF
--- a/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
+++ b/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
@@ -210,6 +210,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 | `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
 | `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |
 | `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
+| `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
 
 ## Welcome
 

--- a/docs/install_lighthouse_with_tekton.md
+++ b/docs/install_lighthouse_with_tekton.md
@@ -534,6 +534,7 @@ Now we need to add the sample project to the Lighthouse configuration and setup 
       - $bot_user/$sample_repo_name
       ignore_ok_to_test: false
       elide_skipped_contexts: false
+      skip_draft_pr: false
     plugins:
       $bot_user/$config_repo_name:
       - config-updater

--- a/docs/plugins/Plugins config.md
+++ b/docs/plugins/Plugins config.md
@@ -215,6 +215,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 | OnlyOrgMembers | `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
 | IgnoreOkToTest | `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |
 | ElideSkippedContexts | `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
+| SkipDraftPR | `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
 
 ## Welcome
 

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -309,6 +309,8 @@ type Trigger struct {
 	// ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs
 	// that could run but do not run.
 	ElideSkippedContexts bool `json:"elide_skipped_contexts,omitempty"`
+	// SkipDraftPR when enabled, skips triggering pipelines for draft PRs, unless /ok-to-test is added.
+	SkipDraftPR bool `json:"skip_draft_pr,omitempty"`
 }
 
 // Milestone contains the configuration options for the milestone and

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -125,6 +125,7 @@ type scmProviderClient interface {
 	GetPullRequest(org, repo string, number int) (*scm.PullRequest, error)
 	GetRef(org, repo, ref string) (string, error)
 	CreateComment(owner, repo string, number int, pr bool, comment string) error
+	ListPullRequestComments(org, repo string, number int) ([]*scm.Comment, error)
 	ListIssueComments(owner, repo string, issue int) ([]*scm.Comment, error)
 	CreateStatus(org, repo, ref string, s *scm.StatusInput) (*scm.Status, error)
 	GetCombinedStatus(org, repo, ref string) (*scm.CombinedStatus, error)


### PR DESCRIPTION
related to https://github.com/jenkins-x/lighthouse/pull/1476 && https://github.com/jenkins-x/lighthouse/issues/886

:warning: Once this PR merged we will need to 
- wait for lighthouse-client update
- update this jx-gitops PR: https://github.com/jenkins-x-plugins/jx-gitops/pull/953

Context: 
- We can't add label when opening a PR so we can only Draft a PR to disable the trigger of pipelines in case we need massive batch opening of PRs in 100+ repositories for instance . 
- Then we can activate manually the pipelines by clicking on 'Ready for Review' or commenting `/ok-to-test` from a trusted member

How to enable this feature ?
Add `skip_draft_pr` feature on the Trigger Plug-in from you scheduler:
- setup `skip_draft_pr` in scheduler trigger like `only_org_members` to allow easy migration of multiple team-app repositories in one time (Would be automatically applied to all repositories using the scheduler with this trigger.skip_draft_pr set to true)
- jx gitops scheduler would need to be run then from your bootjob to edit the plugin configmap 

How it works ?
- trigger pipelines in a Draft PR if `skip_draft_pr` is `false` depending if trusted or not (by default)
- trigger pipelines in a Draft PR if `skip_draft_pr` is `true` with `ok-to-test` label
- doesn't trigger pipelines in a Draft PR if `skip_draft_pr` is `true` but without `ok-to-test` label

- trigger pipelines when you click on `ready for review` if trusted and you don't have the ok-to-test label to avoid triggering the same pipelines than in previous draft mode before clicking the ready for review button 
- doesn't trigger pipelines when you click on `convert to draft` even if you have the ok-to-test label to avoid triggering the same pipelines than in previous non draft mode before clicking the convert to draft button 

Why this feature ?
- keep costs low when developers don't want to run builds
- Interesting when we need to open multiple Draft PRs in repositories using Jx without wanting to trigger all the repositories pipelines in same time


:point_down: :point_down: :point_down: :point_down: 
I have commented each testing scenarios in `pkg/plugins/trigger/pull-request_test.go` with the following PR Actions:
- `prAction: scm.ActionReadyForReview` 
- `prAction: scm.ActionConvertedToDraft`

to explain the logic behind when we click the "Ready for Review" or "Convert to Draft" button. 
I wanted here to avoid useless rerun of pipelines between both these modes.

```
go test ./pkg/plugins/trigger/ 
ok      github.com/jenkins-x/lighthouse/pkg/plugins/trigger     0.028s
```

:point_up: :point_up: :point_up: :point_up: 