### PR TITLE
chore: allows use of tekton pipelineRef.Resolver

### DIFF
--- a/pkg/engines/tekton/utils.go
+++ b/pkg/engines/tekton/utils.go
@@ -169,6 +169,8 @@ func determineGitCloneOrMergeTaskParams(ctx context.Context, pr *tektonv1beta1.P
 
 	if pr.Spec.PipelineSpec != nil {
 		pipelineSpec = pr.Spec.PipelineSpec
+	} else if pr.Spec.PipelineRef.Name == "" {
+		return nil, nil
 	} else {
 		pipeline := tektonv1beta1.Pipeline{ObjectMeta: metav1.ObjectMeta{Name: pr.Spec.PipelineRef.Name, Namespace: pr.Namespace}}
 		key := client.ObjectKeyFromObject(&pipeline)


### PR DESCRIPTION
allows us to use the native tekton pipelineRef git resolver

```
  pipelineRef:
    resolver: git
    params:
      - name: repo
        value: xxx
      - name: revision
        value: main
      - name: pathInRepo
        value: /path/to/pipeline.yaml
```

in such case, our pipelineRef.name is empty, but it's not an error