### PR TITLE
feat: allow to list trusted apps

### DIFF
--- a/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
+++ b/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
@@ -206,6 +206,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 |---|---|---|---|
 | `repos` | []string | No | Repos is either of the form org/repos or just org. |
 | `trusted_org` | string | No | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org. |
+| `trusted_apps` | []string | No | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
 | `join_org_url` | string | No | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg. |
 | `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
 | `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |

--- a/docs/plugins/Plugins config.md
+++ b/docs/plugins/Plugins config.md
@@ -211,6 +211,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 |---|---|---|---|---|
 | Repos | `repos` | []string | No | Repos is either of the form org/repos or just org. |
 | TrustedOrg | `trusted_org` | string | No | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org. |
+| TrustedApps | `trusted_apps` | []string | No | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
 | JoinOrgURL | `join_org_url` | string | No | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg. |
 | OnlyOrgMembers | `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
 | IgnoreOkToTest | `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -270,6 +270,10 @@ type Trigger struct {
 	// TrustedOrg is the org whose members' PRs will be automatically built
 	// for PRs to the above repos. The default is the PR's org.
 	TrustedOrg string `json:"trusted_org,omitempty"`
+	// TrustedApps is the explicit list of GitHub apps whose PRs will be automatically
+	// considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.
+	// By default, trigger will ignore this list.
+	TrustedApps []string `json:"trusted_apps,omitempty"`
 	// JoinOrgURL is a link that redirects users to a location where they
 	// should be able to read more about joining the organization in order
 	// to become trusted members. Defaults to the Github link of TrustedOrg.


### PR DESCRIPTION
Currently, the way Lighthouse work doesn't allow us to automatically trigger PRs pipelines when the PR is created by a Github App.

This behaviour is related to the fact that Lighthouse trigger pipelines only for [trusted PRs authors](https://github.com/jenkins-x/lighthouse/blob/main/pkg/plugins/trigger/pull-request.go#L48-L58). [Trusted authors](https://github.com/jenkins-x/lighthouse/blob/main/pkg/plugins/trigger/trigger.go#L187-L229) being either the [collaborators of the repository](https://github.com/jenkins-x/go-scm/blob/1e8a1891da590c07e24075afe8748483d74e9705/scm/driver/github/repo.go#L100-L130) or the [members of the organization](https://github.com/jenkins-x/go-scm/blob/1e8a1891da590c07e24075afe8748483d74e9705/scm/driver/github/org.go#L74-L90). However, Github apps can't be in any of these cases.

In order to allow Github Apps to be considered as trusted authors, I suggest adding a new configuration option for the `Trigger` plugin to list authorized applications.

Note: this is a copy of the implementation made in [`prow`](https://github.com/kubernetes/test-infra/pull/24978).