### PR TITLE
feat: skip running status (running/pending) if last state

### DIFF
--- a/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
+++ b/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
@@ -213,6 +213,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 | `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
 | `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
 | `skip_report_comment` | bool | No | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs. |
+| `skip_report_running_status` | bool | No | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of the LighthouseJobs. |
 
 ## Welcome
 

--- a/docs/plugins/Plugins config.md
+++ b/docs/plugins/Plugins config.md
@@ -218,6 +218,7 @@ Trigger specifies a configuration for a single trigger.<br /><br />The configura
 | ElideSkippedContexts | `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
 | SkipDraftPR | `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
 | SkipReportComment | `skip_report_comment` | bool | No | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs. |
+| SkipReportRunningStatus | `skip_report_running_status` | bool | No | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of<br />the LighthouseJobs. |
 
 ## Welcome
 

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -292,6 +292,9 @@ type Trigger struct {
 	// SkipReportComment when enabled, skips report comments in the SCM provider based on the state of
 	// the LighthouseJobs.
 	SkipReportComment bool `json:"skip_report_comment,omitempty"`
+	// SkipReportRunningStatus when enabled, skips report status in the SCM provider
+	// based on the current and last state of the LighthouseJobs.
+	SkipReportRunningStatus bool `json:"skip_report_running_status,omitempty"`
 }
 
 // Milestone contains the configuration options for the milestone and


### PR DESCRIPTION
This PR is intended to allow you to bypass the reporting running/pending status done in the Forghon controller.
This mean the SCM Status won't change if previous status was (Running/Pending) and your current is still (Running/Pending).

Also with this option enabled we don't use anymore the Running Stages in the description like
- Pipeline running stage(s): from-buil

We are now only using this kind of pipeline status:
- Pending - Pipeline running
- Pipeline failed
- Pipeline successfull

The need behind this feature is to limit calls to SCM API and avoid rate limiting issues.
