### PR TITLE
feat: support loadBalancerSourceRanges for hook

### DIFF
--- a/charts/lighthouse/templates/webhooks-service.yaml
+++ b/charts/lighthouse/templates/webhooks-service.yaml
@@ -15,3 +15,6 @@ spec:
     name: http
   selector:
     app: {{ template "webhooks.name" . }}
+{{ with .Values.webhooks.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml . | nindent 2 }}
+{{ end }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -156,6 +156,8 @@ webhooks:
     externalPort: 80
     internalPort: 8080
     annotations: {}
+  # Uncomment to set loadBalancerSourceRanges for service
+  #  loadBalancerSourceRanges: []
 
   resources:
     # webhooks.resources.limits -- Resource limits applied to the webhooks pods


### PR DESCRIPTION
Makes it possible to only allow traffic from certain source ranges.

Typical use case would be if the ingress load balancer is internal and you only have an external network load balancer for the hook.