### PR TITLE
fix: base ref

### DIFF
--- a/pkg/keeper/keeper_test.go
+++ b/pkg/keeper/keeper_test.go
@@ -764,7 +764,7 @@ func TestDividePool(t *testing.T) {
 		npr := PullRequest{Number: githubql.Int(p.number)}
 		npr.BaseRef.Name = githubql.String(p.branch)
 		npr.BaseRef.Prefix = "refs/heads/"
-		npr.BaseRefOID = githubql.String(testPJs[idx].baseSHA)
+		npr.BaseRef.Target.OID = githubql.String(testPJs[idx].baseSHA)
 		npr.Repository.Name = githubql.String(p.repo)
 		npr.Repository.Owner.Login = githubql.String(p.org)
 		npr.Repository.URL = githubql.String(fmt.Sprintf("https://github.com/%s/%s.git", p.org, p.repo))

--- a/pkg/keeper/status_test.go
+++ b/pkg/keeper/status_test.go
@@ -259,10 +259,7 @@ func TestExpectedStatus(t *testing.T) {
 				secondQuery,
 			}.QueryMap()
 			var pr PullRequest
-			pr.BaseRef = struct {
-				Name   githubql.String
-				Prefix githubql.String
-			}{
+			pr.BaseRef = GraphQLBaseRef{
 				Name: githubql.String(tc.baseref),
 			}
 			for _, label := range tc.labels {
@@ -272,7 +269,7 @@ func TestExpectedStatus(t *testing.T) {
 				)
 			}
 			if len(tc.contexts) > 0 {
-				pr.HeadRefOID = githubql.String("head")
+				pr.HeadRefOID = "head"
 				pr.Commits.Nodes = append(
 					pr.Commits.Nodes,
 					struct{ Commit Commit }{
@@ -280,7 +277,7 @@ func TestExpectedStatus(t *testing.T) {
 							Status: struct{ Contexts []Context }{
 								Contexts: tc.contexts,
 							},
-							OID: githubql.String("head"),
+							OID: "head",
 						},
 					},
 				)


### PR DESCRIPTION
The baseRefOID field is used as the sha of the base ref. The problem is that the returned value for this field sometimes is another sha. Often I think it is the sha of the base when the PR was created, but sometimes it is the sha of a much older commit. 

In this PR I replace the use of baseRefIOD with 

```
baseRef {
    target {
        oid
    }
}
```

This seems to always be the current sha of the base ref, which is what we want.

This should fix the issue reported here: https://kubernetes.slack.com/archives/C9MBGQJRH/p1728050746717079