### PR TITLE
feat: minimum reviewers on OWNERS file

### DIFF
--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -20,10 +20,14 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
@@ -147,8 +151,19 @@ func newFakeSCMProviderClient(hasLabel, humanApproved, labelComments bool, files
 type fakeRepo struct {
 	approvers, leafApprovers map[string]sets.String
 	approverOwners           map[string]string
+	minimumReviewers         map[string]int
 }
 
+func (fr fakeRepo) MinimumReviewersForFile(path string) int {
+	dir := filepath.Dir(path)
+	if dir == "." {
+		dir = ""
+	}
+	if n, ok := fr.minimumReviewers[dir]; ok {
+		return n
+	}
+	return 1
+}
 func (fr fakeRepo) Approvers(path string) sets.String {
 	return fr.approvers[path]
 }
@@ -244,7 +259,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -410,7 +426,8 @@ Approvers can cancel approval by writing `+"`/approve cancel`"+` in a comment
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[cjwagner](# "Author self-approved")*  
+This pull-request has been approved by: *[cjwagner](# "Author self-approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
 
@@ -451,7 +468,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[cjwagner](# "Author self-approved")*  
+This pull-request has been approved by: *[cjwagner](# "Author self-approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
 
@@ -674,7 +692,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			comments: []*scm.Comment{
 				newTestComment("k8s-ci-robot", `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing `+"`/assign @alice`"+` in a comment when ready.
 
@@ -752,7 +771,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -822,7 +842,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -860,7 +881,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -936,7 +958,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -971,7 +994,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by:  
+This pull-request has been approved by:
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **cjwagner**  
 You can assign the PR to them by writing ` + "`/assign @cjwagner`" + ` in a comment when ready.
 
@@ -1109,7 +1133,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			expectComment: true,
 			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[cjwagner](# "Author self-approved")*  
+This pull-request has been approved by: *[cjwagner](# "Author self-approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
 
@@ -1127,6 +1152,149 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 </details>
 <!-- META={"approvers":["alice"]} -->`,
 		},
+		{
+			name:                "2 minimum reviewers - no approvals",
+			hasLabel:            false,
+			files:               []string{"d/d.go"},
+			comments:            []*scm.Comment{},
+			reviews:             []*scm.Review{},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  false,
+			expectToggle:  false,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
+
+This pull-request has been approved by:
+The changes made require 2 more approval(s).  
+To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **derek**, **jerry**  
+You can assign the PR to them by writing ` + "`/assign @derek @jerry`" + ` in a comment when ready.
+
+The full list of commands accepted by this bot can be found [here](https://jenkins-x.io/v3/develop/reference/chatops/?repo=org%2Frepo).
+
+<details open>
+Needs approval from an approver in each of these files:
+
+- **[d/OWNERS](https://github.com/org/repo/blob/master/d/OWNERS)**
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":["derek","jerry"]} -->`,
+		},
+		{
+			name:     "2 minimum reviewers - 1 approval",
+			hasLabel: false,
+			files:    []string{"d/d.go"},
+			comments: []*scm.Comment{
+				newTestComment("derek", "/approve"),
+			},
+			reviews:             []*scm.Review{},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  false,
+			expectToggle:  false,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
+
+This pull-request has been approved by: *[derek](<> "Approved")*
+The changes made require 1 more approval(s).  
+To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **jerry**  
+You can assign the PR to them by writing ` + "`/assign @jerry`" + ` in a comment when ready.
+
+The full list of commands accepted by this bot can be found [here](https://jenkins-x.io/v3/develop/reference/chatops/?repo=org%2Frepo).
+
+<details open>
+Needs approval from an approver in each of these files:
+
+- ~~[d/OWNERS](https://github.com/org/repo/blob/master/d/OWNERS)~~ [derek]
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":["jerry"]} -->`,
+		},
+		{
+			name:     "2 minimum reviewers - 2 approval",
+			hasLabel: false,
+			files:    []string{"d/d.go"},
+			comments: []*scm.Comment{
+				newTestComment("derek", "/approve"),
+				newTestComment("jerry", "/approve"),
+			},
+			reviews:             []*scm.Review{},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  false,
+			expectToggle:  true,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by: *[derek](<> "Approved")*, *[jerry](<> "Approved")*
+
+The full list of commands accepted by this bot can be found [here](https://jenkins-x.io/v3/develop/reference/chatops/?repo=org%2Frepo).
+
+The pull request process is described [here](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process)
+
+<details >
+Needs approval from an approver in each of these files:
+
+- ~~[d/OWNERS](https://github.com/org/repo/blob/master/d/OWNERS)~~ [derek,jerry]
+
+Approvers can indicate their approval by writing ` + "`/approve` " + `in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel` " + `in a comment
+</details>
+<!-- META={"approvers":[]} -->`,
+		},
+		{
+			name:     "2 minimum reviewers - 1 approval, 1 not registered approval",
+			hasLabel: false,
+			files:    []string{"d/d.go"},
+			comments: []*scm.Comment{
+				newTestComment("derek", "/approve"),
+				newTestComment("alice", "/approve"),
+			},
+			reviews:             []*scm.Review{},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   false,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  false,
+			expectToggle:  false,
+			expectComment: true,
+			expectedComment: `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
+
+This pull-request has been approved by: *[alice](<> "Approved")*, *[derek](<> "Approved")*
+The changes made require 1 more approval(s).  
+To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **jerry**  
+You can assign the PR to them by writing ` + "`/assign @jerry`" + ` in a comment when ready.
+
+The full list of commands accepted by this bot can be found [here](https://jenkins-x.io/v3/develop/reference/chatops/?repo=org%2Frepo).
+
+<details open>
+Needs approval from an approver in each of these files:
+
+- ~~[d/OWNERS](https://github.com/org/repo/blob/master/d/OWNERS)~~ [derek]
+
+Approvers can indicate their approval by writing ` + "`/approve`" + ` in a comment
+Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":["jerry"]} -->`,
+		},
 	}
 
 	fr := fakeRepo{
@@ -1134,17 +1302,23 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 			"a":   sets.NewString("alice"),
 			"a/b": sets.NewString("alice", "bob"),
 			"c":   sets.NewString("cblecker", "cjwagner"),
+			"d":   sets.NewString("derek", "jerry"),
 		},
 		leafApprovers: map[string]sets.String{
 			"a":   sets.NewString("alice"),
 			"a/b": sets.NewString("bob"),
 			"c":   sets.NewString("cblecker", "cjwagner"),
+			"d":   sets.NewString("derek", "jerry"),
 		},
 		approverOwners: map[string]string{
 			"a/a.go":   "a",
 			"a/aa.go":  "a",
 			"a/b/b.go": "a/b",
 			"c/c.go":   "c",
+			"d/d.go":   "d",
+		},
+		minimumReviewers: map[string]int{
+			"d": 2,
 		},
 	}
 
@@ -1158,7 +1332,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 			rsa := !test.selfApprove
 			irs := !test.reviewActsAsApprove
-			if err := handle(
+			err := handle(
 				logrus.WithField("plugin", "approve"),
 				fakeClient,
 				fr,
@@ -1179,9 +1353,8 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 					author:    "cjwagner",
 					assignees: []scm.User{{Login: "spxtr"}},
 				},
-			); err != nil {
-				t.Errorf("[%s] Unexpected error handling event: %v.", test.name, err)
-			}
+			)
+			require.NoError(t, err)
 
 			fakeLabel := fmt.Sprintf("org/repo#%v:approved", prNumber)
 
@@ -1223,12 +1396,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 						len(fspc.PullRequestCommentsAdded),
 					)
 				} else if expect, got := fmt.Sprintf("org/repo#%v:", prNumber)+test.expectedComment, fspc.PullRequestCommentsAdded[0]; test.expectedComment != "" && got != expect {
-					t.Errorf(
-						"[%s] Expected the created notification to be:\n%s\n\nbut got:\n%s\n\n",
-						test.name,
-						expect,
-						got,
-					)
+					assert.Equal(t, expect, got, "actual notification does not equal expected")
 				}
 			} else {
 				if len(fspc.PullRequestCommentsAdded) != 0 {
@@ -1262,12 +1430,7 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 				}
 			}
 			if test.expectToggle != toggled {
-				t.Errorf(
-					"[%s] Expected 'approved' label toggled: %t, but got %t.",
-					test.name,
-					test.expectToggle,
-					toggled,
-				)
+				assert.Equal(t, test.expectToggle, toggled, "actual toggle state does not equal expected")
 			}
 		})
 	}
@@ -1304,6 +1467,10 @@ func (fro fakeRepoOwners) Reviewers(path string) sets.String {
 
 func (fro fakeRepoOwners) RequiredReviewers(path string) sets.String {
 	return sets.NewString()
+}
+
+func (fro fakeRepoOwners) MinimumReviewersForFile(path string) int {
+	return 1
 }
 
 func TestHandleGenericComment(t *testing.T) {

--- a/pkg/plugins/approve/approvers/approvers_test.go
+++ b/pkg/plugins/approve/approvers/approvers_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
@@ -394,6 +396,7 @@ func TestIsApproved(t *testing.T) {
 		"a/d":     dApprovers,
 		"a/combo": edcApprovers,
 	}
+
 	tests := []struct {
 		testName          string
 		filenames         []string
@@ -464,17 +467,330 @@ func TestIsApproved(t *testing.T) {
 			currentlyApproved: sets.NewString("Anne", "Ben", "Carol"),
 			isApproved:        true,
 		},
+		{
+			testName:          "C; 1 Approver",
+			filenames:         []string{"c/test"},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Anne"),
+			isApproved:        false,
+		},
 	}
 
 	for _, test := range tests {
-		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
-		for approver := range test.currentlyApproved {
-			testApprovers.AddApprover(approver, "REFERENCE", false)
-		}
-		calculated := testApprovers.IsApproved()
-		if test.isApproved != calculated {
-			t.Errorf("Failed for test %v.  Expected Approval Status: %v. Found %v", test.testName, test.isApproved, calculated)
-		}
+		t.Run(test.testName, func(t *testing.T) {
+			fakeRepo := createFakeRepo(FakeRepoMap)
+			testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: fakeRepo, seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
+			for approver := range test.currentlyApproved {
+				testApprovers.AddApprover(approver, "REFERENCE", false)
+			}
+			calculated := testApprovers.IsApproved()
+			assert.Equal(t, test.isApproved, calculated, "Failed for test %v", test.testName)
+		})
+	}
+}
+
+func TestIsApprovedWithMinReviewers(t *testing.T) {
+	tests := []struct {
+		testName          string
+		filenames         []string
+		leafApprovers     map[string]sets.String
+		minReviewersMap   map[string]int
+		noParentOwnersMap map[string]bool
+		currentlyApproved sets.String
+		testSeed          int64
+		isApproved        bool
+	}{
+		{
+			testName:  "1 min reviewer: 1 approval",
+			filenames: []string{"f/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 1,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice"),
+			isApproved:        true,
+		},
+		{
+			testName:  "2 min reviewers: 1 approval",
+			filenames: []string{"f/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice"),
+			isApproved:        false,
+		},
+		{
+			testName:  "2 min reviewers: 2 approvals from OWNERS",
+			filenames: []string{"f/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Bob"),
+			isApproved:        true,
+		},
+		{
+			testName:  "2 min reviewers: 1 approve from OWNERS, 1 not",
+			filenames: []string{"f/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Bob", "Tim"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Multi-file: 2 min reviewers: everyone approves",
+			filenames: []string{"f/test.go", "g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+				"g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+				"g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Bob", "Tom", "Harry"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Multi-file: 2 min reviewers: 1 approval from each file",
+			filenames: []string{"f/test.go", "g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+				"g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+				"g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Multi-file: 2 min reviewers: f fully approved, g not",
+			filenames: []string{"f/test.go", "g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f": sets.NewString("Alice", "Bob"),
+				"g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f": 2,
+				"g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Bob", "Tom"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Nested-files: equal min reviewers: everyone approves",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Bob"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Bob", "Tom", "Harry"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: equal min reviewers: 1 approval from each file",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Bob"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Nested-files: equal min reviewers: f fully approved, f/g not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Bob"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Bob", "Tom"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: equal min reviewers: f/g fully approved, f not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Bob"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Tom", "Harry", "Alice"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Nested-files: top-level less min reviewers: everyone approves",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   1,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom", "Harry"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: top-level less min reviewers: 1 approval from each file",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   1,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: top-level less min reviewers: f fully approved, f/g not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   1,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: top-level less min reviewers: f/g fully approved, f not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice"),
+				"f/g": sets.NewString("Tom", "Harry"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   1,
+				"f/g": 2,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Tom", "Harry"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Nested-files: top-level more min reviewers: everyone approves",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Harry"),
+				"f/g": sets.NewString("Tom"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 1,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom", "Harry"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: top-level more min reviewers: 1 approval from each file",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Harry"),
+				"f/g": sets.NewString("Tom"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 1,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Tom"),
+			isApproved:        false,
+		},
+		{
+			testName:  "Nested-files: top-level more min reviewers: f fully approved, f/g not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Harry"),
+				"f/g": sets.NewString("Tom"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 1,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Alice", "Harry"),
+			isApproved:        true,
+		},
+		{
+			testName:  "Nested-files: top-level more min reviewers: f/g fully approved, f not",
+			filenames: []string{"f/test.go", "f/g/test.go"},
+			leafApprovers: map[string]sets.String{
+				"f":   sets.NewString("Alice", "Harry"),
+				"f/g": sets.NewString("Tom"),
+			},
+			minReviewersMap: map[string]int{
+				"f":   2,
+				"f/g": 1,
+			},
+			testSeed:          0,
+			currentlyApproved: sets.NewString("Tom", "Harry"),
+			isApproved:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			fakeRepo := createFakeRepo(test.leafApprovers)
+			fakeRepo.minReviewersMap = test.minReviewersMap
+			fakeRepo.noParentOwnersMap = test.noParentOwnersMap
+			testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: fakeRepo, seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
+			for approver := range test.currentlyApproved {
+				testApprovers.AddApprover(approver, "REFERENCE", false)
+			}
+			calculated := testApprovers.IsApproved()
+			assert.Equal(t, test.isApproved, calculated)
+		})
 	}
 }
 
@@ -710,7 +1026,8 @@ func TestGetMessage(t *testing.T) {
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[Bill](REFERENCE "Approved")*  
+This pull-request has been approved by: *[Bill](REFERENCE "Approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
 
@@ -751,7 +1068,8 @@ func TestGetMessageBitBucketServer(t *testing.T) {
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[Bill](REFERENCE "Approved")*  
+This pull-request has been approved by: *[Bill](REFERENCE "Approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @\"alice\"`" + ` in a comment when ready.
 
@@ -792,7 +1110,8 @@ func TestGetMessageGitLab(t *testing.T) {
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[Bill](REFERENCE "Approved")*  
+This pull-request has been approved by: *[Bill](REFERENCE "Approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/assign @alice`" + ` in a comment when ready.
 
@@ -833,7 +1152,8 @@ func TestGetMessageWithPrefix(t *testing.T) {
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[Bill](REFERENCE "Approved")*  
+This pull-request has been approved by: *[Bill](REFERENCE "Approved")*
+The changes made require 1 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**  
 You can assign the PR to them by writing ` + "`/lh-assign @alice`" + ` in a comment when ready.
 
@@ -915,7 +1235,8 @@ func TestGetMessageNoneApproved(t *testing.T) {
 	ap.RequireIssue = true
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*  
+This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*
+The changes made require 2 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**, **bill**  
 You can assign the PR to them by writing ` + "`/assign @alice @bill`" + ` in a comment when ready.
 
@@ -1043,7 +1364,8 @@ func TestGetMessageMDOwners(t *testing.T) {
 	ap.RequireIssue = true
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*  
+This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*
+The changes made require 2 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**, **doctor**  
 You can assign the PR to them by writing ` + "`/assign @alice @doctor`" + ` in a comment when ready.
 
@@ -1084,7 +1406,8 @@ func TestGetMessageDifferentGitHubLink(t *testing.T) {
 	ap.RequireIssue = true
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*  
+This pull-request has been approved by: *[John](REFERENCE "Author self-approved")*
+The changes made require 2 more approval(s).  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign **alice**, **doctor**  
 You can assign the PR to them by writing ` + "`/assign @alice @doctor`" + ` in a comment when ready.
 

--- a/pkg/plugins/approve/approvers/owners.go
+++ b/pkg/plugins/approve/approvers/owners.go
@@ -45,6 +45,7 @@ type Repo interface {
 	LeafApprovers(path string) sets.String
 	FindApproverOwnersForFile(file string) string
 	IsNoParentOwners(path string) bool
+	MinimumReviewersForFile(path string) int
 }
 
 // Owners provides functionality related to owners of a specific code change.
@@ -147,7 +148,15 @@ func (o Owners) KeepCoveringApprovers(reverseMap map[string]sets.String, knownAp
 
 	unapproved := o.temporaryUnapprovedFiles(knownApprovers)
 
-	for _, suggestedApprover := range o.GetSuggestedApprovers(reverseMap, potentialApprovers).List() {
+	// Filter out known approvers from candidates - we shouldn't suggest people who have already approved
+	candidates := make([]string, 0, len(potentialApprovers))
+	for _, approver := range potentialApprovers {
+		if !knownApprovers.Has(approver) {
+			candidates = append(candidates, approver)
+		}
+	}
+
+	for _, suggestedApprover := range o.GetSuggestedApprovers(reverseMap, candidates).List() {
 		if reverseMap[suggestedApprover].Intersection(unapproved).Len() != 0 {
 			keptApprovers.Insert(suggestedApprover)
 		}
@@ -161,7 +170,18 @@ func (o Owners) KeepCoveringApprovers(reverseMap map[string]sets.String, knownAp
 func (o Owners) GetSuggestedApprovers(reverseMap map[string]sets.String, potentialApprovers []string) sets.String {
 	ap := NewApprovers(o)
 	for !ap.RequirementsMet() {
-		newApprover := findMostCoveringApprover(potentialApprovers, reverseMap, ap.UnapprovedFiles())
+		// Filter out already-selected approvers to ensure we find new unique approvers.
+		// This is important when minimum_reviewers > 1, as we need multiple distinct
+		// approvers for the same OWNERS directory.
+		currentApprovers := ap.GetCurrentApproversSet()
+		candidates := make([]string, 0, len(potentialApprovers))
+		for _, approver := range potentialApprovers {
+			if !currentApprovers.Has(approver) {
+				candidates = append(candidates, approver)
+			}
+		}
+
+		newApprover := findMostCoveringApprover(candidates, reverseMap, ap.UnapprovedFiles())
 		if newApprover == "" {
 			o.log.Warnf("Couldn't find/suggest approvers for each files. Unapproved: %q", ap.UnapprovedFiles().List())
 			return ap.GetCurrentApproversSet()
@@ -428,12 +448,57 @@ func (ap Approvers) NoIssueApprovers() map[string]Approval {
 // UnapprovedFiles returns owners files that still need approval
 func (ap Approvers) UnapprovedFiles() sets.String {
 	unapproved := sets.NewString()
+
+	// Build a map of OWNERS directory -> max minimum_reviewers for files in that directory
+	dirMinReviewers := map[string]int{}
+	for _, fn := range ap.owners.filenames {
+		dir := ap.owners.repo.FindApproverOwnersForFile(fn)
+		minReviewers := ap.owners.repo.MinimumReviewersForFile(fn)
+		if minReviewers > dirMinReviewers[dir] {
+			dirMinReviewers[dir] = minReviewers
+		}
+	}
+
 	for fn, approvers := range ap.GetFilesApprovers() {
-		if len(approvers) == 0 {
+		minRequired := dirMinReviewers[fn]
+		if minRequired == 0 {
+			minRequired = 1 // default
+		}
+		if len(approvers) < minRequired {
 			unapproved.Insert(fn)
 		}
 	}
 	return unapproved
+}
+
+// GetRemainingRequiredApprovers returns the number of additional OWNERS approvers needed.
+// It computes the deficit for each OWNERS directory and returns the sum of all deficits.
+// This ensures that when multiple directories each require multiple approvals, the total
+// remaining count reflects all outstanding approval requirements.
+func (ap Approvers) GetRemainingRequiredApprovers() int {
+	// Build a map of OWNERS directory -> max minimum_reviewers for files in that directory
+	dirMinReviewers := map[string]int{}
+	for _, fn := range ap.owners.filenames {
+		dir := ap.owners.repo.FindApproverOwnersForFile(fn)
+		minReviewers := ap.owners.repo.MinimumReviewersForFile(fn)
+		if minReviewers > dirMinReviewers[dir] {
+			dirMinReviewers[dir] = minReviewers
+		}
+	}
+
+	// Sum the deficits across all directories
+	totalRemaining := 0
+	for dir, approvers := range ap.GetFilesApprovers() {
+		minRequired := dirMinReviewers[dir]
+		if minRequired == 0 {
+			minRequired = 1 // default
+		}
+		deficit := minRequired - len(approvers)
+		if deficit > 0 {
+			totalRemaining += deficit
+		}
+	}
+	return totalRemaining
 }
 
 // GetFiles returns owners files that still need approval.
@@ -637,6 +702,9 @@ Approval requirements bypassed by manually added approval.
 
 {{end -}}
 This pull-request has been approved by:{{range $index, $approval := .ap.ListApprovals}}{{if $index}}, {{else}} {{end}}{{$approval}}{{end}}
+{{- if (and (gt .ap.GetRemainingRequiredApprovers 0) (not (call .ap.ManuallyApproved))) }}
+The changes made require {{ .ap.GetRemainingRequiredApprovers }} more approval(s).
+{{- end }}
 
 {{- if (and (not .ap.AreFilesApproved) (not (call .ap.ManuallyApproved))) }}  
 To complete the [pull request process](https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process), please assign {{range $index, $cc := .ap.GetCCs}}{{if $index}}, {{end}}**{{$cc}}**{{end}}  

--- a/pkg/plugins/approve/approvers/owners_test.go
+++ b/pkg/plugins/approve/approvers/owners_test.go
@@ -35,6 +35,16 @@ type FakeRepo struct {
 	approversMap      map[string]sets.String
 	leafApproversMap  map[string]sets.String
 	noParentOwnersMap map[string]bool
+	minReviewersMap   map[string]int
+}
+
+func (f FakeRepo) MinimumReviewersForFile(path string) int {
+	dir := filepath.Dir(path)
+	dir = canonicalize(dir)
+	if out, ok := f.minReviewersMap[dir]; ok {
+		return out
+	}
+	return 1
 }
 
 func (f FakeRepo) Approvers(path string) sets.String {
@@ -82,7 +92,6 @@ func createFakeRepo(la map[string]sets.String) FakeRepo {
 			}
 		}
 	}
-
 	return FakeRepo{approversMap: a, leafApproversMap: la}
 }
 

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -77,6 +77,7 @@ func (f *fakeRepoOwners) Approvers(path string) sets.String             { return
 func (f *fakeRepoOwners) LeafReviewers(path string) sets.String         { return nil }
 func (f *fakeRepoOwners) Reviewers(path string) sets.String             { return f.reviewers[path] }
 func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String     { return nil }
+func (f *fakeRepoOwners) MinimumReviewersForFile(path string) int       { return 1 }
 
 var approvers = map[string]sets.String{
 	"doc/README.md": {

--- a/pkg/repoowners/repoowners.go
+++ b/pkg/repoowners/repoowners.go
@@ -55,6 +55,7 @@ type Config struct {
 	Reviewers         []string `json:"reviewers,omitempty"`
 	RequiredReviewers []string `json:"required_reviewers,omitempty"`
 	Labels            []string `json:"labels,omitempty"`
+	MinimumReviewers  *int     `json:"minimum_reviewers,omitempty"`
 }
 
 // SimpleConfig holds options and Config applied to everything under the containing directory
@@ -65,7 +66,7 @@ type SimpleConfig struct {
 
 // Empty checks if a SimpleConfig could be considered empty
 func (s *SimpleConfig) Empty() bool {
-	return len(s.Approvers) == 0 && len(s.Reviewers) == 0 && len(s.RequiredReviewers) == 0 && len(s.Labels) == 0
+	return len(s.Approvers) == 0 && len(s.Reviewers) == 0 && len(s.RequiredReviewers) == 0 && len(s.Labels) == 0 && s.MinimumReviewers == nil
 }
 
 // FullConfig contains Filters which apply specific Config to files matching its regexp
@@ -158,6 +159,7 @@ type RepoOwner interface {
 	LeafReviewers(path string) sets.String
 	Reviewers(path string) sets.String
 	RequiredReviewers(path string) sets.String
+	MinimumReviewersForFile(path string) int
 }
 
 var _ RepoOwner = &RepoOwners{}
@@ -170,6 +172,7 @@ type RepoOwners struct {
 	reviewers         map[string]map[*regexp.Regexp]sets.String
 	requiredReviewers map[string]map[*regexp.Regexp]sets.String
 	labels            map[string]map[*regexp.Regexp]sets.String
+	minimumReviewers  map[string]map[*regexp.Regexp]int
 	options           map[string]dirOptions
 
 	baseDir      string
@@ -387,6 +390,7 @@ func loadOwnersFrom(baseDir string, mdYaml bool, aliases RepoAliases, dirExclude
 		reviewers:         make(map[string]map[*regexp.Regexp]sets.String),
 		requiredReviewers: make(map[string]map[*regexp.Regexp]sets.String),
 		labels:            make(map[string]map[*regexp.Regexp]sets.String),
+		minimumReviewers:  make(map[string]map[*regexp.Regexp]int),
 		options:           make(map[string]dirOptions),
 
 		dirExcludes: dirExcludes,
@@ -554,6 +558,18 @@ func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *C
 		}
 		o.labels[path][re] = sets.NewString(config.Labels...)
 	}
+
+	if config.MinimumReviewers != nil {
+		minReviewers := *config.MinimumReviewers
+		if minReviewers < 1 {
+			o.log.WithField("path", path).Warnf("minimum_reviewers value %d is invalid, must be >= 1; defaulting to 1", minReviewers)
+			minReviewers = 1
+		}
+		if o.minimumReviewers[path] == nil {
+			o.minimumReviewers[path] = make(map[*regexp.Regexp]int)
+		}
+		o.minimumReviewers[path][re] = minReviewers
+	}
 }
 
 func (o *RepoOwners) applyOptionsToPath(path string, opts dirOptions) {
@@ -669,6 +685,58 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 		d = canonicalize(d)
 	}
 	return out
+}
+
+// MinimumReviewersForFile returns the minimum number of reviewers required to approve the requested file.
+// This is determined by the OWNERS file closest to the requested file.
+// If pkg/OWNERS has 2 minimum reviewers and pkg/util/OWNERS has 3 minimum reviewers this will return 3 for the path pkg/util/sets/file.go
+// If no minimum reviewers can be found then 1 is returned (the default behavior).
+func (o *RepoOwners) MinimumReviewersForFile(path string) int {
+	d := path
+	if !o.enableMDYAML || !strings.HasSuffix(path, ".md") {
+		d = filepath.Dir(d)
+		d = canonicalize(d)
+	}
+
+	var foundMinReviewer *int
+	for {
+		relative, err := filepath.Rel(d, path)
+		if err != nil {
+			o.log.WithError(err).WithField("path", path).Errorf("Unable to find relative path between %q and path.", d)
+			foundMinReviewer = nil
+			break
+		}
+		var defaultValue *int
+		for re, s := range o.minimumReviewers[d] {
+			if re == nil {
+				// Store default value but check regex patterns first
+				defaultValue = &s
+				continue
+			}
+			if re.MatchString(relative) {
+				// Take the max of all matching regex patterns for deterministic behavior
+				if foundMinReviewer == nil || s > *foundMinReviewer {
+					foundMinReviewer = &s
+				}
+			}
+		}
+		// If no regex matched but we have a default, use it
+		if foundMinReviewer == nil && defaultValue != nil {
+			foundMinReviewer = defaultValue
+		}
+		if foundMinReviewer != nil || d == baseDirConvention {
+			break
+		}
+		if o.options[d].NoParentOwners {
+			break
+		}
+		d = filepath.Dir(d)
+		d = canonicalize(d)
+	}
+	if foundMinReviewer == nil {
+		return 1
+	}
+	return *foundMinReviewer
 }
 
 // LeafApprovers returns a set of users who are the closest approvers to the

--- a/pkg/repoowners/repoowners_test.go
+++ b/pkg/repoowners/repoowners_test.go
@@ -18,6 +18,7 @@ package repoowners
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -58,6 +59,7 @@ reviewers:
 - jakub
 required_reviewers:
 - ben
+minimum_reviewers: 2
 labels:
 - src-code`),
 		"src/dir/conformance/OWNERS": []byte(`options:
@@ -331,6 +333,7 @@ func TestLoadRepoOwners(t *testing.T) {
 		extraBranchesAndFiles map[string]map[string][]byte
 
 		expectedApprovers, expectedReviewers, expectedRequiredReviewers, expectedLabels map[string]map[string]sets.String
+		expectedMinRequiredReviewers                                                    map[string]map[string]int
 
 		expectedOptions map[string]dirOptions
 	}{
@@ -353,6 +356,9 @@ func TestLoadRepoOwners(t *testing.T) {
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
+			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
 			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
@@ -380,6 +386,9 @@ func TestLoadRepoOwners(t *testing.T) {
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
+			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
 			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
@@ -410,6 +419,9 @@ func TestLoadRepoOwners(t *testing.T) {
 				"":             patternAll("EVERYTHING"),
 				"src/dir":      patternAll("src-code"),
 				"docs/file.md": patternAll("docs"),
+			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
 			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
@@ -444,6 +456,9 @@ func TestLoadRepoOwners(t *testing.T) {
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
 			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
+			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
 					NoParentOwners: true,
@@ -476,6 +491,9 @@ func TestLoadRepoOwners(t *testing.T) {
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
 			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
+			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
 					NoParentOwners: true,
@@ -502,6 +520,9 @@ func TestLoadRepoOwners(t *testing.T) {
 			expectedLabels: map[string]map[string]sets.String{
 				"":        patternAll("EVERYTHING"),
 				"src/dir": patternAll("src-code"),
+			},
+			expectedMinRequiredReviewers: map[string]map[string]int{
+				"src/dir": {"": 2},
 			},
 			expectedOptions: map[string]dirOptions{
 				"src/dir/conformance": {
@@ -544,7 +565,7 @@ func TestLoadRepoOwners(t *testing.T) {
 			continue
 		}
 
-		check := func(field string, expected map[string]map[string]sets.String, got map[string]map[*regexp.Regexp]sets.String) {
+		checkStringSet := func(field string, expected map[string]map[string]sets.String, got map[string]map[*regexp.Regexp]sets.String) {
 			converted := map[string]map[string]sets.String{}
 			for path, m := range got {
 				converted[path] = map[string]sets.String{}
@@ -560,10 +581,29 @@ func TestLoadRepoOwners(t *testing.T) {
 				t.Errorf("Expected %s to be:\n%+v\ngot:\n%+v.", field, expected, converted)
 			}
 		}
-		check("approvers", test.expectedApprovers, ro.approvers)
-		check("reviewers", test.expectedReviewers, ro.reviewers)
-		check("required_reviewers", test.expectedRequiredReviewers, ro.requiredReviewers)
-		check("labels", test.expectedLabels, ro.labels)
+
+		checkInt := func(field string, expected map[string]map[string]int, got map[string]map[*regexp.Regexp]int) {
+			converted := map[string]map[string]int{}
+			for path, m := range got {
+				converted[path] = map[string]int{}
+				for re, s := range m {
+					var pattern string
+					if re != nil {
+						pattern = re.String()
+					}
+					converted[path][pattern] = s
+				}
+			}
+			if !reflect.DeepEqual(expected, converted) {
+				t.Errorf("Expected %s to be:\n%+v\ngot:\n%+v.", field, expected, converted)
+			}
+		}
+
+		checkStringSet("approvers", test.expectedApprovers, ro.approvers)
+		checkStringSet("reviewers", test.expectedReviewers, ro.reviewers)
+		checkStringSet("required_reviewers", test.expectedRequiredReviewers, ro.requiredReviewers)
+		checkStringSet("labels", test.expectedLabels, ro.labels)
+		checkInt("min_required_reviewers", test.expectedMinRequiredReviewers, ro.minimumReviewers)
 		if !reflect.DeepEqual(test.expectedOptions, ro.options) {
 			t.Errorf("Expected options to be:\n%#v\ngot:\n%#v.", test.expectedOptions, ro.options)
 		}
@@ -856,5 +896,119 @@ func TestExpandAliases(t *testing.T) {
 				got.List(),
 			)
 		}
+	}
+}
+
+func TestMinimumReviewersForFile(t *testing.T) {
+	const (
+		// No min reviewers
+		baseDir = ""
+		// Min reviewers set to 1
+		secondDir = "a"
+		// Min reviewers set to 2
+		thirdDir = "a/b"
+		// Min reviewers set to 3
+		fourthDir = "a/b/c"
+		// Dir with NoParentOwners - no min reviewers set, should not inherit from parent
+		noParentDir = "a/b/noparent"
+		// Dir with regex filters
+		filterDir = "filtered"
+	)
+
+	goFileRegex := regexp.MustCompile(`\.go$`)
+	mdFileRegex := regexp.MustCompile(`\.md$`)
+	// Overlapping regexes - both match main.go
+	mainFileRegex := regexp.MustCompile(`^main`)
+	allFilesRegex := regexp.MustCompile(`.*`)
+
+	ro := &RepoOwners{
+		minimumReviewers: map[string]map[*regexp.Regexp]int{
+			secondDir: {nil: 1},
+			thirdDir:  {nil: 2},
+			fourthDir: {nil: 3},
+			filterDir: {
+				goFileRegex: 3,
+				mdFileRegex: 1,
+				nil:         2, // default
+			},
+			// Dir with overlapping regex patterns - should take max
+			"overlap": {
+				mainFileRegex: 2, // matches main.go
+				allFilesRegex: 4, // also matches main.go - should take this (max)
+				nil:           1, // default
+			},
+		},
+		options: map[string]dirOptions{
+			noParentDir: {
+				NoParentOwners: true,
+			},
+		},
+	}
+	testCases := []struct {
+		name                      string
+		filePath                  string
+		expectedRequiredApprovers int
+	}{
+		{
+			name:                      "Modified Base Dir",
+			filePath:                  filepath.Join(baseDir, "main.go"),
+			expectedRequiredApprovers: 1,
+		},
+		{
+			name:                      "Modified Second Dir",
+			filePath:                  filepath.Join(secondDir, "main.go"),
+			expectedRequiredApprovers: ro.minimumReviewers[secondDir][nil],
+		},
+		{
+			name:                      "Modified Third Dir",
+			filePath:                  filepath.Join(thirdDir, "main.go"),
+			expectedRequiredApprovers: ro.minimumReviewers[thirdDir][nil],
+		},
+		{
+			name:                      "Modified Nested Dir Without OWNERS (default to fourth dir)",
+			filePath:                  filepath.Join(fourthDir, "d", "main.go"),
+			expectedRequiredApprovers: ro.minimumReviewers[fourthDir][nil],
+		},
+		{
+			name:                      "Modified Nonexistent Dir (default to Base Dir)",
+			filePath:                  filepath.Join("nonexistent", "main.go"),
+			expectedRequiredApprovers: 1,
+		},
+		{
+			name:                      "NoParentOwners stops inheritance - should return default 1",
+			filePath:                  filepath.Join(noParentDir, "main.go"),
+			expectedRequiredApprovers: 1,
+		},
+		{
+			name:                      "Regex filter matches .go file",
+			filePath:                  filepath.Join(filterDir, "main.go"),
+			expectedRequiredApprovers: 3,
+		},
+		{
+			name:                      "Regex filter matches .md file",
+			filePath:                  filepath.Join(filterDir, "README.md"),
+			expectedRequiredApprovers: 1,
+		},
+		{
+			name:                      "Regex filter no match uses default",
+			filePath:                  filepath.Join(filterDir, "data.txt"),
+			expectedRequiredApprovers: 2,
+		},
+		{
+			name:                      "Overlapping regex patterns takes max value",
+			filePath:                  filepath.Join("overlap", "main.go"),
+			expectedRequiredApprovers: 4, // both mainFileRegex(2) and allFilesRegex(4) match, should take max
+		},
+		{
+			name:                      "Overlapping regex - only one matches",
+			filePath:                  filepath.Join("overlap", "other.go"),
+			expectedRequiredApprovers: 4, // only allFilesRegex matches
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ro.MinimumReviewersForFile(tc.filePath)
+			assert.Equal(t, tc.expectedRequiredApprovers, actual)
+		})
 	}
 }


### PR DESCRIPTION
This PR adds the ability to set a minimum amount of reviewers required to Approve a pull request.

There are cases where certain directories in a repository are more sensitive than others and therefore require more stringent review procedures. For example, in the cluster definitions repository you may want a minimum of two approvals on your production namespace but only one approval on your staging namespace.

This is currently semi-achievable on GitHub by defining branch protections that require a min of two reviewers before merging, issues with this are that: 
1. Lighthouse is unaware of this protection so repeatedly tries to merge PRs with one approval
2. This applies to an entire branch so any change on the branch will require two approvals

### Logic Changes
A new field minimum_reviewers has been added to OWNERS files. This integer defines how many approvers are required for that directory.                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                   Finding minimum_reviewers for a file:                                                                                                                                                                                                                                                                            The relevant OWNERS file for a given changed file is found by starting at the changed file and moving up directories until an OWNERS file is found. The first one found defines the minimum reviewers required for that changed file. E.g. if pkg/OWNERS has 2 minimum reviewers and pkg/util/OWNERS has 3       
minimum reviewers, this will return 3 for the path pkg/util/sets/file.go.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   Per-directory requirements:                                                                                                                                                                                                                                                                                      Each OWNERS directory must independently meet its own minimum_reviewers requirement. This works in conjunction with the existing OWNERS approval logic - each directory that covers changed files must have enough registered approvers.                                                                         
                                                                                                                                                                                                                                                                                                                   For example, if a PR changes files in both pkg/ (requiring 2 approvers) and cmd/ (requiring 1 approver):                                                                                                                                                                                                         
 - You need at least 2 registered approvers from pkg/OWNERS                                                                                                                                                                                                                                                       
 - You need at least 1 registered approver from cmd/OWNERS                                                                                                                                                                                                                                                        
 - An approver listed in both OWNERS files can count toward both directories                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                  If no minimum_reviewers is specified for a directory, it defaults to 1 (preserving existing behaviour). 

### Testing
Updated and added additional unit tests.

Ran this PR image in a cluster and is working as expected:
![image](https://github.com/user-attachments/assets/7260977d-6ee7-4fa2-a797-4ae3423fa8ff)
![image](https://github.com/user-attachments/assets/e08cfd7c-e358-4298-aeb0-b305af167827)
![image](https://github.com/user-attachments/assets/03615c96-024c-4857-b5a6-b8615e1f9e31)
![image](https://github.com/user-attachments/assets/14d70f09-302f-47e8-ae82-124ae9888e45)
