### PR TITLE
chore(deps): update go-scm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/h2non/gock v1.0.9
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/jenkins-x/go-scm v1.14.47
+	github.com/jenkins-x/go-scm v1.14.53
 	github.com/mattn/go-zglob v0.0.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.1
@@ -127,7 +127,7 @@ replace (
 	github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v38.2.0+incompatible
 
 	// lets override the go-scm version from tektoncd
-	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.14.47
+	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.14.53
 
 	// gomodules.xyz breaks in Athens proxying
 	gomodules.xyz/jsonpatch/v2 => github.com/gomodules/jsonpatch/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/jenkins-x/go-scm v1.14.47 h1:TOKaR1JaY1SGpDNK3WuHOGLavktW1GUb1+5jKLjDIsc=
-github.com/jenkins-x/go-scm v1.14.47/go.mod h1:1RPxLZndnvu31XhFZ+RTvXiHmMX70HkQ17bRupTQxGs=
+github.com/jenkins-x/go-scm v1.14.53 h1:Utc9FbHzCuyXQ9F7gmXxNLUwG70Fp2niNS+m8+eGXcY=
+github.com/jenkins-x/go-scm v1.14.53/go.mod h1:1RPxLZndnvu31XhFZ+RTvXiHmMX70HkQ17bRupTQxGs=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/pkg/keeper/keeper_test.go
+++ b/pkg/keeper/keeper_test.go
@@ -658,7 +658,7 @@ func (f *fgc) GetFile(owner, repo, filepath, commit string) ([]byte, error) {
 func (f *fgc) ListFiles(owner, repo, filepath, commit string) ([]*scm.FileEntry, error) {
 	ctx := context.Background()
 	fullName := scm.Join(owner, repo)
-	answer, _, err := f.fakeClient.Contents.List(ctx, fullName, filepath, commit)
+	answer, _, err := f.fakeClient.Contents.List(ctx, fullName, filepath, commit, &scm.ListOptions{})
 	return answer, err
 }
 

--- a/pkg/plugins/trigger/periodic.go
+++ b/pkg/plugins/trigger/periodic.go
@@ -433,7 +433,7 @@ func (pa *PeriodicAgent) filterPeriodics(enabled map[string]*bool) map[string]*b
 	enable := true
 	hasPeriodics := make(map[string]*bool)
 	for fullName := range enabled {
-		list, _, err := pa.SCMClient.Contents.List(context.TODO(), fullName, ".lighthouse", "HEAD")
+		list, _, err := pa.SCMClient.Contents.List(context.TODO(), fullName, ".lighthouse", "HEAD", &scm.ListOptions{})
 		if err != nil {
 			continue
 		}

--- a/pkg/scmprovider/content.go
+++ b/pkg/scmprovider/content.go
@@ -26,6 +26,6 @@ func (c *Client) GetFile(owner, repo, filepath, commit string) ([]byte, error) {
 func (c *Client) ListFiles(owner, repo, filepath, commit string) ([]*scm.FileEntry, error) {
 	ctx := context.Background()
 	fullName := c.repositoryName(owner, repo)
-	answer, _, err := c.client.Contents.List(ctx, fullName, filepath, commit)
+	answer, _, err := c.client.Contents.List(ctx, fullName, filepath, commit, &scm.ListOptions{})
 	return answer, err
 }


### PR DESCRIPTION
Latest go-scm add `ListOptions` to `Contents.List` interface (https://github.com/jenkins-x/go-scm/pull/470). Added an empty `ListOptions` to satisfy the interface & update go-scm.

Resolves broken PRs https://github.com/jenkins-x/lighthouse/pull/1634.