### PR TITLE
feat: allow display report completion duration

### DIFF
--- a/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
+++ b/docs/config/plugins/github-com-jenkins-x-lighthouse-pkg-plugins.md
@@ -202,18 +202,19 @@ Size specifies configuration for the size plugin, defining lower bounds (in # li
 
 Trigger specifies a configuration for a single trigger.<br /><br />The configuration for the trigger plugin is defined as a list of these structures.
 
-| Stanza | Type | Required | Description |
-|---|---|---|---|
-| `repos` | []string | No | Repos is either of the form org/repos or just org. |
-| `trusted_org` | string | No | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org. |
-| `trusted_apps` | []string | No | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
-| `join_org_url` | string | No | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg. |
-| `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
-| `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |
-| `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
-| `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
-| `skip_report_comment` | bool | No | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs. |
-| `skip_report_running_status` | bool | No | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of the LighthouseJobs. |
+| Stanza                            | Type     | Required | Description                                                                                                                                                                                                                           |
+|-----------------------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `repos`                           | []string | No       | Repos is either of the form org/repos or just org.                                                                                                                                                                                    |
+| `trusted_org`                     | string   | No       | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org.                                                                                                    |
+| `trusted_apps`                    | []string | No       | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
+| `join_org_url`                    | string   | No       | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg.                |
+| `only_org_members`                | bool     | No       | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators.                                                                                           |
+| `ignore_ok_to_test`               | bool     | No       | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users.                                                                                                |
+| `elide_skipped_contexts`          | bool     | No       | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run.                                                                                                                           |
+| `skip_draft_pr`                   | bool     | No       | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added.                                                                                                                                  |
+| `skip_report_comment`             | bool     | No       | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs.                                                                                                              |
+| `skip_report_running_status`      | bool     | No       | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of the LighthouseJobs.                                                                                              |
+| `show_report_completion_duration` | bool     | No       | ShowReportCompletionDuration when enabled, show completion duration in report status in the SCM provider based on StartTime and CompletionTime of the PipelineActivity.                                                               |
 
 ## Welcome
 

--- a/docs/plugins/Plugins config.md
+++ b/docs/plugins/Plugins config.md
@@ -207,18 +207,20 @@ Size specifies configuration for the size plugin, defining lower bounds (in # li
 
 Trigger specifies a configuration for a single trigger.<br /><br />The configuration for the trigger plugin is defined as a list of these structures.
 
-| Variable Name | Stanza | Type | Required | Description |
-|---|---|---|---|---|
-| Repos | `repos` | []string | No | Repos is either of the form org/repos or just org. |
-| TrustedOrg | `trusted_org` | string | No | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org. |
-| TrustedApps | `trusted_apps` | []string | No | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
-| JoinOrgURL | `join_org_url` | string | No | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg. |
-| OnlyOrgMembers | `only_org_members` | bool | No | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators. |
-| IgnoreOkToTest | `ignore_ok_to_test` | bool | No | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users. |
-| ElideSkippedContexts | `elide_skipped_contexts` | bool | No | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run. |
-| SkipDraftPR | `skip_draft_pr` | bool | No | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added. |
-| SkipReportComment | `skip_report_comment` | bool | No | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs. |
-| SkipReportRunningStatus | `skip_report_running_status` | bool | No | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of<br />the LighthouseJobs. |
+| Variable Name                | Stanza                            | Type     | Required | Description                                                                                                                                                                                                                           |
+|------------------------------|-----------------------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Repos                        | `repos`                           | []string | No       | Repos is either of the form org/repos or just org.                                                                                                                                                                                    |
+| TrustedOrg                   | `trusted_org`                     | string   | No       | TrustedOrg is the org whose members' PRs will be automatically built<br />for PRs to the above repos. The default is the PR's org.                                                                                                    |
+| TrustedApps                  | `trusted_apps`                    | []string | No       | TrustedApps is the explicit list of GitHub apps whose PRs will be automatically<br />considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.<br/>By default, trigger will ignore this list. |
+| JoinOrgURL                   | `join_org_url`                    | string   | No       | JoinOrgURL is a link that redirects users to a location where they<br />should be able to read more about joining the organization in order<br />to become trusted members. Defaults to the Github link of TrustedOrg.                |
+| OnlyOrgMembers               | `only_org_members`                | bool     | No       | OnlyOrgMembers requires PRs and/or /ok-to-test comments to come from org members.<br />By default, trigger also include repo collaborators.                                                                                           |
+| IgnoreOkToTest               | `ignore_ok_to_test`               | bool     | No       | IgnoreOkToTest makes trigger ignore /ok-to-test comments.<br />This is a security mitigation to only allow testing from trusted users.                                                                                                |
+| ElideSkippedContexts         | `elide_skipped_contexts`          | bool     | No       | ElideSkippedContexts makes trigger not post "Skipped" contexts for jobs<br />that could run but do not run.                                                                                                                           |
+| SkipDraftPR                  | `skip_draft_pr`                   | bool     | No       | SkipDraftPR when enabled, skips triggering pipelines for draft PRs<br />unless /ok-to-test is added.                                                                                                                                  |
+| SkipReportComment            | `skip_report_comment`             | bool     | No       | SkipReportComment when enabled, skips report comments in the SCM provider based on the state of<br />the LighthouseJobs.                                                                                                              |
+| SkipReportRunningStatus      | `skip_report_running_status`      | bool     | No       | SkipReportRunningStatus when enabled, skips report status in the SCM provider based on the current and last state of<br />the LighthouseJobs.                                                                                         |
+| ShowReportCompletionDuration | `show_report_completion_duration` | bool     | No       | when enabled, show completion duration in report status in the SCM provider based on StartTime and CompletionTime of the PipelineActivity.                                                                                            |
+
 
 ## Welcome
 

--- a/pkg/foghorn/controller.go
+++ b/pkg/foghorn/controller.go
@@ -185,7 +185,8 @@ func (r *LighthouseJobReconciler) reportStatus(activity *lighthousev1alpha1.Acti
 	gitURL := activity.GitURL
 	activityStatus := activity.Status
 	skipReportRunningStatus := r.pluginConfig.Config().TriggerFor(owner, repo).SkipReportRunningStatus
-	statusInfo := toScmStatusDescriptionRunningStages(activity, util.GitKind(r.jobConfig.Config), skipReportRunningStatus)
+	showReportCompletionDuration := r.pluginConfig.Config().TriggerFor(owner, repo).ShowReportCompletionDuration
+	statusInfo := toScmStatusDescriptionRunningStages(activity, util.GitKind(r.jobConfig.Config), skipReportRunningStatus, showReportCompletionDuration)
 
 	fields := map[string]interface{}{
 		"name":        activity.Name,
@@ -197,12 +198,11 @@ func (r *LighthouseJobReconciler) reportStatus(activity *lighthousev1alpha1.Acti
 		"gitBranch":   activity.Branch,
 		"gitStatus":   statusInfo.scmStatus.String(),
 		"buildNumber": activity.BuildIdentifier,
-		"duration":    durationString(activity.StartTime, activity.CompletionTime),
+		"duration":    statusInfo.completionDuration,
 	}
 	if gitURL == "" {
 		r.logger.WithFields(fields).Debugf("Cannot report pipeline %s as we have no git SHA", activity.Name)
 		return
-
 	}
 	if sha == "" {
 		r.logger.WithFields(fields).Debugf("Cannot report pipeline %s as we have no git SHA", activity.Name)
@@ -284,16 +284,18 @@ func (r *LighthouseJobReconciler) reportStatus(activity *lighthousev1alpha1.Acti
 }
 
 type reportStatusInfo struct {
-	scmStatus     scm.State
-	description   string
-	runningStages string
+	scmStatus          scm.State
+	description        string
+	runningStages      string
+	completionDuration string
 }
 
-func toScmStatusDescriptionRunningStages(activity *lighthousev1alpha1.ActivityRecord, gitKind string, skipReportRunningStatus bool) reportStatusInfo {
+func toScmStatusDescriptionRunningStages(activity *lighthousev1alpha1.ActivityRecord, gitKind string, skipReportRunningStatus bool, showReportCompletionDuration bool) reportStatusInfo {
 	info := reportStatusInfo{
-		description:   "",
-		runningStages: "",
-		scmStatus:     scm.StateUnknown,
+		description:        "",
+		runningStages:      "",
+		scmStatus:          scm.StateUnknown,
+		completionDuration: durationString(activity.StartTime, activity.CompletionTime),
 	}
 	switch activity.Status {
 	case lighthousev1alpha1.SuccessState:
@@ -311,6 +313,10 @@ func toScmStatusDescriptionRunningStages(activity *lighthousev1alpha1.ActivityRe
 	default:
 		info.scmStatus = scm.StateUnknown
 		info.description = "Pipeline in unknown state"
+	}
+
+	if showReportCompletionDuration && info.completionDuration != "" {
+		info.description = fmt.Sprintf("%s (%s)", info.description, info.completionDuration)
 	}
 
 	if skipReportRunningStatus {

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -295,6 +295,9 @@ type Trigger struct {
 	// SkipReportRunningStatus when enabled, skips report status in the SCM provider
 	// based on the current and last state of the LighthouseJobs.
 	SkipReportRunningStatus bool `json:"skip_report_running_status,omitempty"`
+	// ShowReportCompletionDuration when enabled, show completion duration in report status in the SCM provider
+	// based on StartTime and CompletionTime of the PipelineActivity.
+	ShowReportCompletionDuration bool `json:"show_report_completion_duration,omitempty"`
 }
 
 // Milestone contains the configuration options for the milestone and


### PR DESCRIPTION
This PR is intended to allow you to show completion duration in the description of the report done in the Forghon controller while keeping the SCM status.

example : 
![image](https://github.com/user-attachments/assets/a52efd9d-a1fe-4ee9-863d-8b96e0ca2954)
