### PR TITLE
fix(keeper,poller,webhooks): set shareProcessNamespace in pod

### DIFF
--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -31,6 +31,7 @@ spec:
     spec:
       serviceAccountName: {{ template "keeper.name" . }}
       terminationGracePeriodSeconds: {{ .Values.keeper.terminationGracePeriodSeconds }}
+      shareProcessNamespace: true
       containers:
       - name: {{ template "keeper.name" . }}
         image: {{ tpl .Values.keeper.image.repository . }}:{{ tpl .Values.keeper.image.tag . }}

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: {{ template "poller.name" . }}
       terminationGracePeriodSeconds: {{ .Values.poller.terminationGracePeriodSeconds }}
+      shareProcessNamespace: true
       containers:
       - name: {{ template "poller.name" . }}
         image: {{ tpl .Values.poller.image.repository . }}:{{ tpl .Values.poller.image.tag . }}

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "webhooks.name" . }}
+      shareProcessNamespace: true
       containers:
       - name: {{ template "webhooks.name" . }}
         image: {{ tpl .Values.webhooks.image.repository . }}:{{ tpl .Values.webhooks.image.tag . }}


### PR DESCRIPTION
### Changes
* Set `shareProcessNamespace: true` in pod specs for keeper, poller and webhooks

### Context
The git module uses `exec.Command()` to execute `git` commands. The spawned `git` processes will sometimes create subprocesses during batch picking (e.g.: `git fetch` -> `git-upload-pack`).

When `git` exits, the subprocesses are re-parented to PID 1 of the container. This is currently the application itself, which doesn't implement reaping. The defunct subprocesses accumulate and can eventually exhaust the PID limit of the  underlying node. Setting `shareProcessNamespace: true` moves PID 1 responsibility to the pod's shared pause container, which does properly reap zombies across all containers in the pod.

Setting `shareProcessNamespace: true` moves PID 1 responsibility to the pod's shared pause container, which does properly reap zombies across all containers in the pod. Only `keeper`, `poller`, and `webhooks` are affected — `foghorn` and the engine controllers make no subprocess calls.