### PR TITLE
fix(keeper): resolve base SHA via GetRef when PR list omits it

### DIFF
--- a/pkg/keeper/keeper.go
+++ b/pkg/keeper/keeper.go
@@ -1571,6 +1571,13 @@ func (c *DefaultController) dividePool(pool map[string]PullRequest, pjs []v1alph
 		}
 		fn := poolKey(org, repo, branch)
 		if sps[fn] == nil {
+			if baseSHA == "" {
+				resolved, err := c.spc.GetRef(org, repo, "heads/"+branch)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to resolve base SHA for %s/%s@%s", org, repo, branch)
+				}
+				baseSHA = resolved
+			}
 			sps[fn] = &subpool{
 				log: c.logger.WithFields(logrus.Fields{
 					"org":       org,


### PR DESCRIPTION
GitLab's MR list endpoint does not return diff_refs / base_sha, so pr.BaseRef.Target.OID can be empty when keeper iterates the pool. This caused dividePool to seed sp.sha with "", which then propagated into LighthouseJob.Spec.Refs.BaseSHA and produced malformed PULL_REFS (e.g. "main,<pr-num>:<sha>:<ref>" instead of "main:<sha>,<pr-num>:<sha>:<ref>"), failing step-git-merge.

Resolve the base SHA via GetRef("heads/"+branch) when missing — once per unique subpool (typically one per repo since most PRs target the same branch), not per PR.