### PR TITLE
feat(webhooks): add ingressKind and HTTPRoute template

### DIFF
--- a/charts/lighthouse/templates/webhooks-httproute.yaml
+++ b/charts/lighthouse/templates/webhooks-httproute.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.webhooks.ingress.enabled .Values.webhooks.httproute.enabled }}
+{{- fail "webhooks.ingress.enabled and webhooks.httproute.enabled are mutually exclusive - enable only one" }}
+{{- end }}
 {{- if .Values.webhooks.httproute.enabled }}
 {{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" }}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/lighthouse/templates/webhooks-httproute.yaml
+++ b/charts/lighthouse/templates/webhooks-httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.webhooks.httproute.enabled }}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" }}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ template "webhooks.name" . }}
+  labels:
+    app: {{ template "webhooks.name" . }}
+  annotations:
+    {{- toYaml .Values.webhooks.httproute.annotations | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.webhooks.httproute.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.webhooks.httproute.hosts }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ default (include "webhooks.name" .) .Values.webhooks.serviceName }}
+          port: {{ .Values.webhooks.service.externalPort }}
+{{- end }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -222,6 +222,23 @@ webhooks:
       # webhooks.ingress.tls.secretName -- Specify webhooks ingress tls secretName
       secretName: ""
 
+  httproute:
+    # webhooks.httproute.enabled -- Enable webhooks httproute
+    enabled: false
+
+    # webhooks.httproute.annotations -- Webhooks httproute annotations
+    annotations: {}
+
+    # webhooks.httproute.parentRefs -- List of parent Gateways the HTTPRoute binds to
+    # TLS is configured on the parent Gateway listener, not the HTTPRoute
+    parentRefs: []
+    # - name: envoy-gateway
+    #   namespace: envoy-gateway-system
+    #   sectionName: https
+
+    # webhooks.httproute.hosts -- Webhooks httproute host names
+    hosts: []
+
   # webhooks.customDeploymentTriggerCommand -- deployments can configure the ability to allow custom lighthouse triggers
   # using their own unique chat prefix, for example extending the default `/test` trigger prefix let them specify
   # `customDeploymentTriggerPrefix: foo` which means they can also use their own custom trigger /foo mycoolthing


### PR DESCRIPTION
### Changes
* Add `webhooks-httproute.yaml` template and default values to support Gateway API  
* Add `webhooks.ingressKind` for switching between ingress and httproute

### Context

Gateway API uses a `HTTPRoute` resource as a replacement for `Ingress`.

The `webhooks.ingressKind` key allows users to switch between the two implementation branches while remaining backward-compatible.

`httproute` users must provide a valid `parentRef` to a separately-managed `Gateway` resource. TLS configuration is the responsibility of the Gateway, so is not required here.

Part of https://github.com/jenkins-x/jx/issues/8962