### PR TITLE
fix(watcher): detect if k8s API supports WatchListClient feature

### DIFF
--- a/pkg/watcher/configmap_watcher.go
+++ b/pkg/watcher/configmap_watcher.go
@@ -189,16 +189,22 @@ func (w *ConfigMapWatcher) createWatcher() error {
 	if w.watch != nil {
 		w.watch.Stop()
 	}
-	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return w.kubeClient.CoreV1().ConfigMaps(w.namespace).List(context.TODO(), metav1.ListOptions{})
+	listWatch := &cache.ListWatch{
+		// Forward the options supplied by the reflector.
+		// If WatchListClient feature is enabled (default on k8s 1.35), reflector sets the bookmark here.
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			return w.kubeClient.CoreV1().ConfigMaps(w.namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return w.kubeClient.CoreV1().ConfigMaps(w.namespace).Watch(context.TODO(), metav1.ListOptions{})
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return w.kubeClient.CoreV1().ConfigMaps(w.namespace).Watch(ctx, options)
 		},
 	}
+	// Reflector detects clients that _don't_ support WatchList semantics
+	// If so, WatchList is disabled, falling back to classic LIST+WATCH
+	ListerWatcher := cache.ToListWatcherWithWatchListSemantics(listWatch, w.kubeClient)
+
 	var informer cache.Controller
-	_, informer, w.watch, _ = watchtools.NewIndexerInformerWatcher(lw, &v1.ConfigMap{})
+	_, informer, w.watch, _ = watchtools.NewIndexerInformerWatcher(ListerWatcher, &v1.ConfigMap{})
 	if ok := cache.WaitForCacheSync(w.stopCh, informer.HasSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/watcher/configmap_watcher.go
+++ b/pkg/watcher/configmap_watcher.go
@@ -201,10 +201,10 @@ func (w *ConfigMapWatcher) createWatcher() error {
 	}
 	// Reflector detects clients that _don't_ support WatchList semantics
 	// If so, WatchList is disabled, falling back to classic LIST+WATCH
-	ListerWatcher := cache.ToListWatcherWithWatchListSemantics(listWatch, w.kubeClient)
+	listerWatcher := cache.ToListWatcherWithWatchListSemantics(listWatch, w.kubeClient)
 
 	var informer cache.Controller
-	_, informer, w.watch, _ = watchtools.NewIndexerInformerWatcher(ListerWatcher, &v1.ConfigMap{})
+	_, informer, w.watch, _ = watchtools.NewIndexerInformerWatcher(listerWatcher, &v1.ConfigMap{})
 	if ok := cache.WaitForCacheSync(w.stopCh, informer.HasSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/watcher/configmap_watcher_test.go
+++ b/pkg/watcher/configmap_watcher_test.go
@@ -1,0 +1,65 @@
+package watcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+// recordingCallback captures the latest value passed to a ConfigMapEntryCallback.
+type recordingCallback struct {
+	values chan string
+}
+
+func (c *recordingCallback) record(value string) {
+	c.values <- value
+}
+
+// TestNewConfigMapWatcherSyncsAndInvokesCallback verifies the watcher's cache
+// syncs (no "failed to wait for caches to sync") and that the initial ConfigMap
+// is delivered to the callback. With the WatchListClient feature default-on (k8s
+// 1.35+, client-go v0.36.2), this only passes because createWatcher forwards the
+// reflector options and wraps the ListWatch so the fake client — which reports
+// unsupported WatchList semantics — falls back to classic LIST+WATCH.
+func TestNewConfigMapWatcherSyncsAndInvokesCallback(t *testing.T) {
+	ns := "jx"
+	kubeClient := kubefake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.ProwConfigMapName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			util.ProwConfigFilename: "initial-config",
+		},
+	})
+
+	rec := &recordingCallback{values: make(chan string, 1)}
+	callbacks := []ConfigMapCallback{
+		&ConfigMapEntryCallback{
+			Name:     util.ProwConfigMapName,
+			Key:      util.ProwConfigFilename,
+			Callback: rec.record,
+		},
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	w, err := NewConfigMapWatcher(kubeClient, ns, callbacks, stopCh)
+	require.NoError(t, err, "watcher should start without a cache-sync failure")
+	require.NotNil(t, w)
+	defer w.Stop()
+
+	select {
+	case value := <-rec.values:
+		assert.Equal(t, "initial-config", value)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for ConfigMap callback to fire")
+	}
+}

--- a/pkg/watcher/configmap_watcher_test.go
+++ b/pkg/watcher/configmap_watcher_test.go
@@ -12,7 +12,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-// recordingCallback captures the latest value passed to a ConfigMapEntryCallback.
+// recordingCallback captures values passed to a ConfigMapEntryCallback.
 type recordingCallback struct {
 	values chan string
 }


### PR DESCRIPTION
### Changes

* Edit `createWatcher` to:
  * Use `ListWithContextFunc` and `WatchFuncWithContext` within `ListWatch` object
  * Use `cache.ToListWatcherWithWatchListSemantics()` within `watchtools.NewIndexerInformerWatcher`
* Create `configmap_watcher_test.go` to test these changes

### Context

lighthouse is failing in gsm, with errors like `Warning: event bookmark expired`.

@Skisocks found and fixed a similar issue here - https://github.com/jenkins-x/jx-helpers/pull/453

The fix here is broadly the same. The reason this failed for gsm (which supports this feature!) is that the old `createWatcher()` built a `cache.ListWatch` whose `ListFunc`/`WatchFunc` discarded the options the reflector passed in and sent an empty `metav1.ListOptions{}`, meaning the expected bookmark never arrives to lighthouse.