### PR TITLE
fix(tekton): reconstruct rerun LighthouseJob from PipelineRun so status is reported

### DIFF
--- a/cmd/tektoncontroller/main.go
+++ b/cmd/tektoncontroller/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	if o.enableRerunStatusUpdate {
-		rerunPipelineRunReconciler := tektonengine.NewRerunPipelineRunReconciler(mgr.GetClient(), mgr.GetScheme(), o.maxConcurrentReconciles)
+		rerunPipelineRunReconciler := tektonengine.NewRerunPipelineRunReconciler(mgr.GetClient(), mgr.GetAPIReader(), mgr.GetScheme(), o.maxConcurrentReconciles)
 		if err = rerunPipelineRunReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithError(err).Fatal("Unable to create RerunPipelineRun controller")
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/go-stack/stack v1.8.1
 	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
 	github.com/gorilla/sessions v1.4.0
 	github.com/h2non/gock v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -71,6 +70,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.1 // indirect
 	github.com/google/cel-go v0.28.1 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect

--- a/pkg/engines/tekton/activity_test.go
+++ b/pkg/engines/tekton/activity_test.go
@@ -202,11 +202,11 @@ func TestTerminalActivitySyncedWithPipelineRun(t *testing.T) {
 		Status: v1alpha1.LighthouseJobStatus{
 			ReportURL: "https://dash/pipeline",
 			Activity: &v1alpha1.ActivityRecord{
-				Name:             "foo-pr",
-				Status:           v1alpha1.SuccessState,
-				StartTime:        &now,
-				CompletionTime:   &now,
-				Stages:           []*v1alpha1.ActivityStageOrStep{{Name: "build"}},
+				Name:           "foo-pr",
+				Status:         v1alpha1.SuccessState,
+				StartTime:      &now,
+				CompletionTime: &now,
+				Stages:         []*v1alpha1.ActivityStageOrStep{{Name: "build"}},
 			},
 		},
 	}

--- a/pkg/engines/tekton/controller_test.go
+++ b/pkg/engines/tekton/controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
+	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	"github.com/stretchr/testify/assert"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -264,4 +265,49 @@ func loadObservedPipeline(dir string) (*pipelinev1.Pipeline, error) {
 		return p, err
 	}
 	return nil, nil
+}
+
+func TestReconcileEmptyStateNoPipelineRun(t *testing.T) {
+	ns := "jx"
+	jobName := "myorg-myrepo-main-abc12"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	job := &lighthousev1alpha1.LighthouseJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: ns,
+		},
+		Spec: lighthousev1alpha1.LighthouseJobSpec{
+			Type:    configjob.PresubmitJob,
+			Context: "pr-build",
+			Refs: &lighthousev1alpha1.Refs{
+				Org:  "myorg",
+				Repo: "myrepo",
+			},
+		},
+		Status: lighthousev1alpha1.LighthouseJobStatus{
+			State: "", // Explicitly empty state!
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(job).Build()
+	fake.AddIndex(c, &pipelinev1.PipelineRun{}, jobOwnerKey, tektonControllerIndexFunc)
+
+	tektonfakeClient := tektonfake.NewSimpleClientset()
+
+	reconciler := NewLighthouseJobReconciler(c, c, scheme, tektonfakeClient, dashboardBaseURL, dashboardTemplate, ns, false, 1)
+
+	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: jobName},
+	})
+	require.NoError(t, err)
+
+	// Verify no PipelineRun was created by the Reconciler
+	var pipelineRunList pipelinev1.PipelineRunList
+	err = c.List(context.TODO(), &pipelineRunList, client.InNamespace(ns))
+	require.NoError(t, err)
+	assert.Len(t, pipelineRunList.Items, 0, "No PipelineRun should be created when LighthouseJob state is empty")
 }

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -22,6 +22,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// lighthouseJobKind is the Kind of the LighthouseJob CRD, used to match owner references.
+const lighthouseJobKind = "LighthouseJob"
+
+// lighthouseJobOwnerName returns the name of the controller LighthouseJob owning pr,
+// or "" if pr has no such owner (caller should then reconstruct).
+func lighthouseJobOwnerName(pr *pipelinev1.PipelineRun) string {
+	owner := metav1.GetControllerOf(pr)
+	if owner == nil || owner.APIVersion != apiGVStr || owner.Kind != lighthouseJobKind {
+		return ""
+	}
+	return owner.Name
+}
+
 // RerunPipelineRunReconciler reconciles PipelineRun objects with the rerun label.
 //
 // It operates along two paths:
@@ -250,10 +263,14 @@ func (r *RerunPipelineRunReconciler) resolveParentLighthouseJob(ctx context.Cont
 	}
 
 	// get rerun pipelinerun parent lighthousejob
+	parentName := lighthouseJobOwnerName(&rerunPipelineRunParent)
+	if parentName == "" {
+		r.logger.Infof("Parent PipelineRun %s has no LighthouseJob controller owner, will reconstruct.", rerunPipelineRunParentName)
+		return nil, nil
+	}
 	var parentPipelineRunParentLighthouseJob lighthousev1alpha1.LighthouseJob
-	parentPipelineRunRef := rerunPipelineRunParent.OwnerReferences[0]
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: rerunPipelineRun.Namespace, Name: parentPipelineRunRef.Name}, &parentPipelineRunParentLighthouseJob); err != nil {
-		r.logger.Warningf("Unable to get Rerun Parent PipelineRun Parent LighthouseJob %s: %v", parentPipelineRunRef.Name, err)
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: rerunPipelineRun.Namespace, Name: parentName}, &parentPipelineRunParentLighthouseJob); err != nil {
+		r.logger.Warningf("Unable to get Rerun Parent PipelineRun Parent LighthouseJob %s: %v", parentName, err)
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
 		// on deleted requests.

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -137,6 +137,14 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		rerunLhJob.Name = rerunPipelineRun.Name
 
+		// Fast path keeps the full-fidelity clone of the parent LighthouseJob and only
+		// *ensures* the canonical lighthouse labels/annotations are present (filling any
+		// gap) WITHOUT removing metadata the parent legitimately carried. The
+		// reconstruction path is best-effort and may legitimately diverge (fewer
+		// labels/annotations) — that divergence is accepted and documented.
+		rerunLhJob.Labels = ensureEntries(rerunLhJob.Labels, canonicalRerunLabels(&rerunPipelineRun))
+		rerunLhJob.Annotations = ensureEntries(rerunLhJob.Annotations, canonicalRerunAnnotations(&rerunPipelineRun))
+
 		rerunLhJob.ResourceVersion = ""
 		rerunLhJob.UID = ""
 	}

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -22,7 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// RerunPipelineRunReconciler reconciles PipelineRun objects with the rerun label
+// RerunPipelineRunReconciler reconciles PipelineRun objects with the rerun label.
+//
+// It operates along two paths:
+//  1. Fast path: if the parent PipelineRun and LighthouseJob exist, it clones the parent LighthouseJob
+//     (clearing its Status to prevent carrying over a stale terminal state) and assigns it.
+//  2. Reconstruction path: if either parent resource has been archived/deleted, it reconstructs
+//     a new LighthouseJob solely from the metadata (labels, annotations) on the rerun PipelineRun itself.
 type RerunPipelineRunReconciler struct {
 	client                  client.Client
 	apiReader               client.Reader

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -83,24 +83,43 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
+	// Resolve the parent LighthouseJob
 	parentPipelineRunParentLighthouseJob, err := r.resolveParentLighthouseJob(ctx, &rerunPipelineRun)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	var rerunLhJob *lighthousev1alpha1.LighthouseJob
+
 	if parentPipelineRunParentLighthouseJob == nil {
-		return ctrl.Result{}, nil
+		r.logger.Infof("Parent PipelineRun or LighthouseJob not found. Attempting reconstruction from rerun PipelineRun %s", req.NamespacedName)
+		spec, err := rerunSpecFromPipelineRun(&rerunPipelineRun)
+		if err != nil {
+			// Missing required labels is a permanent condition.
+			// Drop it instead of returning an error.
+			var missingLabelsErr *ErrMissingRequiredLabels
+			if errors.As(err, &missingLabelsErr) {
+				r.logger.Warnf("Cannot reconstruct LighthouseJob for rerun PipelineRun %s, dropping: %v", req.NamespacedName, err)
+				return ctrl.Result{}, nil
+			}
+			// Defensive catch-all for any other unexpected reconstruction errors.
+			r.logger.Errorf("Failed to reconstruct LighthouseJobSpec: %v", err)
+			return ctrl.Result{}, err
+		}
+		rerunLhJob = newReconstructedLighthouseJob(&rerunPipelineRun, spec)
+	} else {
+		r.logger.Infof("Parent LighthouseJob found. Cloning LighthouseJob %s", parentPipelineRunParentLighthouseJob.Name)
+		// Clone the LighthouseJob
+		rerunLhJob = parentPipelineRunParentLighthouseJob.DeepCopy()
+
+		// Trim existing r-xxxxx suffix and append a new one
+		re := regexp.MustCompile(`-r-[a-f0-9]{5}$`)
+		baseName := re.ReplaceAllString(parentPipelineRunParentLighthouseJob.Name, "")
+		rerunLhJob.Name = fmt.Sprintf("%s-%s", baseName, fmt.Sprintf("r-%s", uuid.NewString()[:5]))
+
+		rerunLhJob.ResourceVersion = ""
+		rerunLhJob.UID = ""
 	}
-
-	// Clone the LighthouseJob
-	rerunLhJob := parentPipelineRunParentLighthouseJob.DeepCopy()
-
-	// Trim existing r-xxxxx suffix and append a new one
-	re := regexp.MustCompile(`-r-[a-f0-9]{5}$`)
-	baseName := re.ReplaceAllString(parentPipelineRunParentLighthouseJob.Name, "")
-	rerunLhJob.Name = fmt.Sprintf("%s-%s", baseName, fmt.Sprintf("r-%s", uuid.NewString()[:5]))
-
-	rerunLhJob.ResourceVersion = ""
-	rerunLhJob.UID = ""
 
 	// Create the new LighthouseJob
 	if err := r.client.Create(ctx, rerunLhJob); err != nil {

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -112,6 +112,9 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Clone the LighthouseJob
 		rerunLhJob = parentPipelineRunParentLighthouseJob.DeepCopy()
 
+		// Clear the status so a completed parent doesn't immediately mark the rerun job as terminal
+		rerunLhJob.Status = lighthousev1alpha1.LighthouseJobStatus{}
+
 		// Trim existing r-xxxxx suffix and append a new one
 		re := regexp.MustCompile(`-r-[a-f0-9]{5}$`)
 		baseName := re.ReplaceAllString(parentPipelineRunParentLighthouseJob.Name, "")

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -3,14 +3,13 @@ package tekton
 import (
 	"context"
 	"fmt"
-	"regexp"
 
-	"github.com/google/uuid"
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,15 +25,17 @@ import (
 // RerunPipelineRunReconciler reconciles PipelineRun objects with the rerun label
 type RerunPipelineRunReconciler struct {
 	client                  client.Client
+	apiReader               client.Reader
 	logger                  *logrus.Entry
 	scheme                  *runtime.Scheme
 	maxConcurrentReconciles int
 }
 
 // NewRerunPipelineRunReconciler creates a new RerunPipelineRunReconciler
-func NewRerunPipelineRunReconciler(client client.Client, scheme *runtime.Scheme, maxConcurrentReconciles int) *RerunPipelineRunReconciler {
+func NewRerunPipelineRunReconciler(client client.Client, apiReader client.Reader, scheme *runtime.Scheme, maxConcurrentReconciles int) *RerunPipelineRunReconciler {
 	return &RerunPipelineRunReconciler{
 		client:                  client,
+		apiReader:               apiReader,
 		logger:                  logrus.NewEntry(logrus.StandardLogger()).WithField("controller", "RerunPipelineRunController"),
 		scheme:                  scheme,
 		maxConcurrentReconciles: maxConcurrentReconciles,
@@ -115,10 +116,7 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Clear the status so a completed parent doesn't immediately mark the rerun job as terminal
 		rerunLhJob.Status = lighthousev1alpha1.LighthouseJobStatus{}
 
-		// Trim existing r-xxxxx suffix and append a new one
-		re := regexp.MustCompile(`-r-[a-f0-9]{5}$`)
-		baseName := re.ReplaceAllString(parentPipelineRunParentLighthouseJob.Name, "")
-		rerunLhJob.Name = fmt.Sprintf("%s-%s", baseName, fmt.Sprintf("r-%s", uuid.NewString()[:5]))
+		rerunLhJob.Name = rerunPipelineRun.Name
 
 		rerunLhJob.ResourceVersion = ""
 		rerunLhJob.UID = ""
@@ -126,8 +124,20 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Create the new LighthouseJob
 	if err := r.client.Create(ctx, rerunLhJob); err != nil {
-		r.logger.Errorf("Failed to create new LighthouseJob: %s", err)
-		return ctrl.Result{}, err
+		if apierrors.IsAlreadyExists(err) {
+			// A previous reconciliation of this same rerun PipelineRun already created
+			// the job (the name is deterministic). Adopt it. We read it through the
+			// uncached apiReader on purpose: the object was just created and may not be
+			// visible in the cache yet, which is exactly the race this branch handles.
+			r.logger.Warnf("LighthouseJob %s already exists, adopting it to set ownerReference", rerunLhJob.Name)
+			if err := r.apiReader.Get(ctx, types.NamespacedName{Namespace: rerunLhJob.Namespace, Name: rerunLhJob.Name}, rerunLhJob); err != nil {
+				r.logger.Errorf("Failed to get existing LighthouseJob %s: %s", rerunLhJob.Name, err)
+				return ctrl.Result{}, err
+			}
+		} else {
+			r.logger.Errorf("Failed to create new LighthouseJob: %s", err)
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Prepare the ownerReference.
@@ -148,11 +158,20 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// updates ownerReference of the PipelineRun re-run.
 	f := func(job *pipelinev1.PipelineRun) error {
-		// Set the ownerReference for passed-in job, so it's re-applied to the refreshed object
-		job.OwnerReferences = append(job.OwnerReferences, ownerReference)
-		// Patch the PipelineRun with the new ownerReference
-		if err := r.client.Update(ctx, job); err != nil {
-			return errors.Wrapf(err, "failed to update PipelineRun with ownerReference")
+		// Check if ownerReference already exists to be idempotent
+		exists := false
+		for _, ref := range job.OwnerReferences {
+			if ref.UID == ownerReference.UID {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			job.OwnerReferences = append(job.OwnerReferences, ownerReference)
+			// Patch the PipelineRun with the new ownerReference
+			if err := r.client.Update(ctx, job); err != nil {
+				return errors.Wrapf(err, "failed to update PipelineRun with ownerReference")
+			}
 		}
 		return nil
 	}

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -140,6 +140,13 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	if rerunLhJob.Status.StartTime.IsZero() {
+		rerunLhJob.Status.StartTime = metav1.Now()
+		if err := r.client.Status().Update(ctx, rerunLhJob); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to set LighthouseJob StartTime")
+		}
+	}
+
 	// Prepare the ownerReference.
 	// client.Get does not return TypeMeta from LighthouseJob, so
 	// derive the GVK from the scheme instead.

--- a/pkg/engines/tekton/pipelinerun_rerun_controller.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller.go
@@ -83,37 +83,12 @@ func (r *RerunPipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	// Extract Rerun PipelineRun Parent Name
-	rerunPipelineRunParentName, ok := rerunPipelineRun.Labels[util.DashboardTektonRerun]
-	if !ok {
+	parentPipelineRunParentLighthouseJob, err := r.resolveParentLighthouseJob(ctx, &rerunPipelineRun)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if parentPipelineRunParentLighthouseJob == nil {
 		return ctrl.Result{}, nil
-	}
-
-	// Get Rerun PipelineRun parent PipelineRun
-	var rerunPipelineRunParent pipelinev1.PipelineRun
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: rerunPipelineRunParentName}, &rerunPipelineRunParent); err != nil {
-		r.logger.Warningf("Unable to get Rerun Parent PipelineRun %s: %v", rerunPipelineRunParentName, err)
-		// we'll ignore not-found errors, since they can't be fixed by an immediate
-		// requeue (we'll need to wait for a new notification), and we can get them
-		// on deleted requests.
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	// Check if the Rerun Parent PipelineRun doesn't already have an ownerReference set
-	if len(rerunPipelineRunParent.OwnerReferences) == 0 {
-		r.logger.Infof("Parent PipelineRun %s doesn't already have an ownerReference set, skipping.", rerunPipelineRunParentName)
-		return ctrl.Result{}, nil
-	}
-
-	// get rerun pipelinerun parent lighthousejob
-	var parentPipelineRunParentLighthouseJob lighthousev1alpha1.LighthouseJob
-	parentPipelineRunRef := rerunPipelineRunParent.OwnerReferences[0]
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: parentPipelineRunRef.Name}, &parentPipelineRunParentLighthouseJob); err != nil {
-		r.logger.Warningf("Unable to get Rerun Parent PipelineRun Parent LighthouseJob %s: %v", parentPipelineRunRef.Name, err)
-		// we'll ignore not-found errors, since they can't be fixed by an immediate
-		// requeue (we'll need to wait for a new notification), and we can get them
-		// on deleted requests.
-		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	// Clone the LighthouseJob
@@ -195,4 +170,41 @@ func (r *RerunPipelineRunReconciler) retryModifyPipelineRun(ctx context.Context,
 			return client.IgnoreNotFound(err)
 		}
 	}
+}
+
+func (r *RerunPipelineRunReconciler) resolveParentLighthouseJob(ctx context.Context, rerunPipelineRun *pipelinev1.PipelineRun) (*lighthousev1alpha1.LighthouseJob, error) {
+	// Extract Rerun PipelineRun Parent Name
+	rerunPipelineRunParentName, ok := rerunPipelineRun.Labels[util.DashboardTektonRerun]
+	if !ok {
+		return nil, nil
+	}
+
+	// Get Rerun PipelineRun parent PipelineRun
+	var rerunPipelineRunParent pipelinev1.PipelineRun
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: rerunPipelineRun.Namespace, Name: rerunPipelineRunParentName}, &rerunPipelineRunParent); err != nil {
+		r.logger.Warningf("Unable to get Rerun Parent PipelineRun %s: %v", rerunPipelineRunParentName, err)
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	// Check if the Rerun Parent PipelineRun doesn't already have an ownerReference set
+	if len(rerunPipelineRunParent.OwnerReferences) == 0 {
+		r.logger.Infof("Parent PipelineRun %s doesn't already have an ownerReference set, skipping.", rerunPipelineRunParentName)
+		return nil, nil
+	}
+
+	// get rerun pipelinerun parent lighthousejob
+	var parentPipelineRunParentLighthouseJob lighthousev1alpha1.LighthouseJob
+	parentPipelineRunRef := rerunPipelineRunParent.OwnerReferences[0]
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: rerunPipelineRun.Namespace, Name: parentPipelineRunRef.Name}, &parentPipelineRunParentLighthouseJob); err != nil {
+		r.logger.Warningf("Unable to get Rerun Parent PipelineRun Parent LighthouseJob %s: %v", parentPipelineRunRef.Name, err)
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	return &parentPipelineRunParentLighthouseJob, nil
 }

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -105,9 +105,11 @@ func TestReconcileArchivedRerunReconstructsLighthouseJob(t *testing.T) {
 				util.BaseSHALabel:                "basesha456",
 				util.BranchLabel:                 "PR-42",
 				util.PullLabel:                   "42",
+				"team":                           "platform", // non-lighthouse: must be dropped by best-effort reconstruction
 			},
 			Annotations: map[string]string{
 				util.LighthouseJobAnnotation: "myorg-myrepo-pr-build",
+				"custom.company.io/note":     "keep-me", // non-canonical: must be dropped
 			},
 		},
 	}
@@ -127,6 +129,15 @@ func TestReconcileArchivedRerunReconstructsLighthouseJob(t *testing.T) {
 	require.Len(t, jobs.Items, 1, "Exactly one LighthouseJob should be reconstructed and created")
 
 	job := jobs.Items[0]
+
+	// Reconstruction is best-effort: it recovers the canonical lighthouse labels/annotations…
+	assert.Contains(t, job.Annotations, util.LighthouseJobAnnotation)
+	assert.Contains(t, job.Labels, configjob.LighthouseJobTypeLabel)
+	// …but discards any non-canonical metadata carried on the rerun PipelineRun
+	// (accepted, documented divergence with the fast/clone path).
+	assert.NotContains(t, job.Labels, "team")
+	assert.NotContains(t, job.Annotations, "custom.company.io/note")
+
 	// Verify it has empty status
 	assert.Empty(t, job.Status.State, "Reconstructed job should have an empty state")
 	assert.Nil(t, job.Status.CompletionTime, "Reconstructed job should have no completion time")
@@ -370,7 +381,18 @@ func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
 	// The original LighthouseJob with a terminal status
 	now := metav1.Now()
 	originalJob := &lighthousev1alpha1.LighthouseJob{
-		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"team":                             "platform", // custom, non-lighthouse
+				"lighthouse.jenkins-x.io/type":     string(configjob.PresubmitJob),
+				configjob.CreatedByLighthouseLabel: "true",
+			},
+			Annotations: map[string]string{
+				"custom.company.io/note": "keep-me", // custom annotation
+			},
+		},
 		Status: lighthousev1alpha1.LighthouseJobStatus{
 			State:          lighthousev1alpha1.SuccessState,
 			CompletionTime: &now,
@@ -396,7 +418,16 @@ func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rerunPRName,
 			Namespace: ns,
-			Labels:    map[string]string{util.DashboardTektonRerun: parentPRName},
+			Labels: map[string]string{
+				util.DashboardTektonRerun:          parentPRName,
+				"dashboard.tekton.dev/random":      "discard",
+				"lighthouse.jenkins-x.io/type":     string(configjob.PresubmitJob),
+				configjob.CreatedByLighthouseLabel: "true",
+			},
+			Annotations: map[string]string{
+				util.LighthouseJobAnnotation: "myorg-myrepo-pr-build",
+				"some-other-annotation":      "discard",
+			},
 		},
 	}
 
@@ -424,6 +455,19 @@ func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
 	// Assert the cloned job's status was cleared
 	assert.Empty(t, clonedJob.Status.State, "Cloned job should have an empty state")
 	assert.Nil(t, clonedJob.Status.CompletionTime, "Cloned job should have a nil completion time")
+
+	// Fast path = full-fidelity clone + guaranteed canonical entries (merge, no removal).
+	// 1) Parent-owned custom metadata is PRESERVED:
+	assert.Equal(t, "platform", clonedJob.Labels["team"], "custom parent label must be preserved on the clone")
+	assert.Equal(t, "keep-me", clonedJob.Annotations["custom.company.io/note"], "custom parent annotation must be preserved")
+	// 2) Canonical lighthouse metadata is present (either inherited or filled from the PR):
+	assert.Contains(t, clonedJob.Labels, "lighthouse.jenkins-x.io/type")
+	assert.Contains(t, clonedJob.Labels, configjob.CreatedByLighthouseLabel)
+	assert.Contains(t, clonedJob.Annotations, util.LighthouseJobAnnotation)
+	// 3) Non-canonical labels/annotations that live only on the rerun PR are NOT injected:
+	assert.NotContains(t, clonedJob.Labels, util.DashboardTektonRerun)
+	assert.NotContains(t, clonedJob.Labels, "dashboard.tekton.dev/random")
+	assert.NotContains(t, clonedJob.Annotations, "some-other-annotation")
 
 	// Verify the original job was NOT modified (deep copy protected it)
 	var fetchedOriginalJob lighthousev1alpha1.LighthouseJob

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
+	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,67 @@ func TestRerunReconcileSetsOwnerReferenceGVK(t *testing.T) {
 	assert.NotEmpty(t, ref.Name, "owner reference should point at the newly created rerun LighthouseJob")
 }
 
+func TestReconcileArchivedRerunReconstructsLighthouseJob(t *testing.T) {
+	ns := "jx"
+	rerunPRName := "myorg-myrepo-main-abc12-2-rerun"
+	parentPRName := "myorg-myrepo-main-abc12-1"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	// The rerun PipelineRun. The parent PR does NOT exist in the fake client.
+	rerunPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rerunPRName,
+			Namespace: ns,
+			Labels: map[string]string{
+				util.DashboardTektonRerun:        parentPRName,
+				configjob.LighthouseJobTypeLabel: string(configjob.PresubmitJob),
+				util.ContextLabel:                "pr-build",
+				util.OrgLabel:                    "myorg",
+				util.RepoLabel:                   "myrepo",
+				util.LastCommitSHALabel:          "sha123",
+				util.BaseSHALabel:                "basesha456",
+				util.BranchLabel:                 "PR-42",
+				util.PullLabel:                   "42",
+			},
+			Annotations: map[string]string{
+				util.LighthouseJobAnnotation: "myorg-myrepo-pr-build",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+
+	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
+	})
+	require.NoError(t, err, "Reconcile should succeed for an archived rerun")
+
+	// Verify the LighthouseJob was created
+	var jobs lighthousev1alpha1.LighthouseJobList
+	err = c.List(context.TODO(), &jobs, client.InNamespace(ns))
+	require.NoError(t, err)
+	require.Len(t, jobs.Items, 1, "Exactly one LighthouseJob should be reconstructed and created")
+
+	job := jobs.Items[0]
+	// Verify it has empty status
+	assert.Empty(t, job.Status.State, "Reconstructed job should have an empty state")
+	assert.Nil(t, job.Status.CompletionTime, "Reconstructed job should have no completion time")
+
+	// Verify the rerun PipelineRun now has an OwnerReference pointing to this new job
+	var updatedPR pipelinev1.PipelineRun
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: rerunPRName}, &updatedPR)
+	require.NoError(t, err)
+	require.Len(t, updatedPR.OwnerReferences, 1)
+
+	ownerRef := updatedPR.OwnerReferences[0]
+	assert.Equal(t, job.Name, ownerRef.Name)
+	assert.Equal(t, "LighthouseJob", ownerRef.Kind)
+}
+
 // TestResolveParentLighthouseJob exercises resolveParentLighthouseJob in isolation,
 // covering the three "not resolvable" branches and the nominal resolution.
 func TestResolveParentLighthouseJob(t *testing.T) {
@@ -92,7 +154,7 @@ func TestResolveParentLighthouseJob(t *testing.T) {
 		require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
 		require.NoError(t, pipelinev1.AddToScheme(scheme))
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-		return NewRerunPipelineRunReconciler(c, c, scheme, 1)
+		return NewRerunPipelineRunReconciler(c, scheme, 1)
 	}
 	rerunPR := func() *pipelinev1.PipelineRun {
 		return &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
@@ -157,4 +219,42 @@ func TestResolveParentLighthouseJob(t *testing.T) {
 		require.NotNil(t, lj)
 		assert.Equal(t, jobName, lj.Name)
 	})
+}
+
+func TestReconcileMissingRequiredLabelsDrops(t *testing.T) {
+	ns := "jx"
+	rerunPRName := "myorg-myrepo-main-abc12-2-rerun"
+	parentPRName := "myorg-myrepo-main-abc12-1"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	// The rerun PipelineRun is missing util.ContextLabel and others
+	rerunPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rerunPRName,
+			Namespace: ns,
+			Labels: map[string]string{
+				util.DashboardTektonRerun: parentPRName,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+
+	res, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
+	})
+
+	// Must NOT return an error (which would cause a requeue), must just drop it.
+	require.NoError(t, err, "Missing required labels is an unrecoverable error and should be dropped without returning an error to the controller")
+	assert.Equal(t, ctrl.Result{}, res)
+
+	// Verify NO LighthouseJob was created
+	var jobs lighthousev1alpha1.LighthouseJobList
+	err = c.List(context.TODO(), &jobs, client.InNamespace(ns))
+	require.NoError(t, err)
+	assert.Len(t, jobs.Items, 0, "No LighthouseJob should be created when required labels are missing")
 }

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -62,8 +62,8 @@ func TestRerunReconcileSetsOwnerReferenceGVK(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job, parentPR, rerunPR).Build()
-	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(job, parentPR, rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
 
 	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
@@ -112,8 +112,8 @@ func TestReconcileArchivedRerunReconstructsLighthouseJob(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rerunPR).Build()
-	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
 
 	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
@@ -153,8 +153,8 @@ func TestResolveParentLighthouseJob(t *testing.T) {
 		scheme := runtime.NewScheme()
 		require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
 		require.NoError(t, pipelinev1.AddToScheme(scheme))
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-		return NewRerunPipelineRunReconciler(c, scheme, 1)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(objs...).Build()
+		return NewRerunPipelineRunReconciler(c, c, scheme, 1)
 	}
 	rerunPR := func() *pipelinev1.PipelineRun {
 		return &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
@@ -242,7 +242,7 @@ func TestReconcileMissingRequiredLabelsDrops(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(rerunPR).Build()
-	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
 
 	res, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
@@ -257,6 +257,103 @@ func TestReconcileMissingRequiredLabelsDrops(t *testing.T) {
 	err = c.List(context.TODO(), &jobs, client.InNamespace(ns))
 	require.NoError(t, err)
 	assert.Len(t, jobs.Items, 0, "No LighthouseJob should be created when required labels are missing")
+}
+
+// TestReconcileRerunIsIdempotent guards against the duplicate-LighthouseJob regression:
+// reconciling the same rerun PipelineRun twice must create exactly one job, and StartTime
+// must be set so lighthouse-gc-jobs does not GC the still-running job.
+func TestReconcileRerunIsIdempotent(t *testing.T) {
+	ns := "jx"
+	rerunPRName := "myorg-myrepo-main-abc12-2-rerun"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	rerunPR := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
+		Name: rerunPRName, Namespace: ns,
+		Labels: map[string]string{
+			util.DashboardTektonRerun:        "myorg-myrepo-main-abc12-1",
+			configjob.LighthouseJobTypeLabel: string(configjob.PresubmitJob),
+			util.ContextLabel:                "pr-build",
+			util.OrgLabel:                    "myorg",
+			util.RepoLabel:                   "myrepo",
+			util.LastCommitSHALabel:          "sha123",
+		},
+		Annotations: map[string]string{util.LighthouseJobAnnotation: "myorg-myrepo-pr-build"},
+	}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).
+		WithObjects(rerunPR).
+		Build()
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName}}
+
+	_, err := reconciler.Reconcile(context.TODO(), req)
+	require.NoError(t, err)
+
+	var jobs lighthousev1alpha1.LighthouseJobList
+	require.NoError(t, c.List(context.TODO(), &jobs, client.InNamespace(ns)))
+	require.Len(t, jobs.Items, 1)
+
+	// A second reconcile (e.g. a re-queued event) must not create a duplicate.
+	_, err = reconciler.Reconcile(context.TODO(), req)
+	require.NoError(t, err)
+	require.NoError(t, c.List(context.TODO(), &jobs, client.InNamespace(ns)))
+	assert.Len(t, jobs.Items, 1, "reconciling twice must not create a duplicate LighthouseJob")
+
+	var updated pipelinev1.PipelineRun
+	require.NoError(t, c.Get(context.TODO(), req.NamespacedName, &updated))
+	assert.Len(t, updated.OwnerReferences, 1)
+}
+
+// TestReconcileAdoptsExistingLighthouseJob exercises the AlreadyExists/apiReader adoption
+// path: a job with the deterministic name already exists (prior reconcile whose owner
+// reference write is not yet visible) and must be adopted, not duplicated.
+func TestReconcileAdoptsExistingLighthouseJob(t *testing.T) {
+	ns := "jx"
+	rerunPRName := "myorg-myrepo-main-abc12-2-rerun"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	existing := &lighthousev1alpha1.LighthouseJob{ObjectMeta: metav1.ObjectMeta{Name: rerunPRName, Namespace: ns}}
+	rerunPR := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
+		Name: rerunPRName, Namespace: ns,
+		Labels: map[string]string{
+			util.DashboardTektonRerun:        "myorg-myrepo-main-abc12-1",
+			configjob.LighthouseJobTypeLabel: string(configjob.PresubmitJob),
+			util.ContextLabel:                "pr-build",
+			util.OrgLabel:                    "myorg",
+			util.RepoLabel:                   "myrepo",
+			util.LastCommitSHALabel:          "sha123",
+		},
+		Annotations: map[string]string{util.LighthouseJobAnnotation: "myorg-myrepo-pr-build"},
+	}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).
+		WithObjects(existing, rerunPR).
+		Build()
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
+
+	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
+	})
+	require.NoError(t, err)
+
+	var jobs lighthousev1alpha1.LighthouseJobList
+	require.NoError(t, c.List(context.TODO(), &jobs, client.InNamespace(ns)))
+	assert.Len(t, jobs.Items, 1, "the existing job must be adopted, not duplicated")
+
+	var updated pipelinev1.PipelineRun
+	require.NoError(t, c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: rerunPRName}, &updated))
+	require.Len(t, updated.OwnerReferences, 1)
+	assert.Equal(t, rerunPRName, updated.OwnerReferences[0].Name)
 }
 
 func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
@@ -302,8 +399,8 @@ func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(originalJob, parentPR, rerunPR).Build()
-	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&lighthousev1alpha1.LighthouseJob{}).WithObjects(originalJob, parentPR, rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, c, scheme, 1)
 
 	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -258,3 +258,78 @@ func TestReconcileMissingRequiredLabelsDrops(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, jobs.Items, 0, "No LighthouseJob should be created when required labels are missing")
 }
+
+func TestReconcileLiveRerunClearsStaleStatus(t *testing.T) {
+	ns := "jx"
+	jobName := "myorg-myrepo-main-abc12"
+	parentPRName := "myorg-myrepo-main-abc12-1"
+	rerunPRName := "myorg-myrepo-main-abc12-2-rerun"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+	require.NoError(t, pipelinev1.AddToScheme(scheme))
+
+	// The original LighthouseJob with a terminal status
+	now := metav1.Now()
+	originalJob := &lighthousev1alpha1.LighthouseJob{
+		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: ns},
+		Status: lighthousev1alpha1.LighthouseJobStatus{
+			State:          lighthousev1alpha1.SuccessState,
+			CompletionTime: &now,
+		},
+	}
+
+	// The parent PR, owned by the original job
+	parentPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      parentPRName,
+			Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "lighthouse.jenkins.io/v1alpha1",
+				Kind:       "LighthouseJob",
+				Name:       jobName,
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	// The rerun PR
+	rerunPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rerunPRName,
+			Namespace: ns,
+			Labels:    map[string]string{util.DashboardTektonRerun: parentPRName},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(originalJob, parentPR, rerunPR).Build()
+	reconciler := NewRerunPipelineRunReconciler(c, scheme, 1)
+
+	_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: rerunPRName},
+	})
+	require.NoError(t, err, "Reconcile should succeed for a live rerun")
+
+	// Find the newly cloned job
+	var updatedPR pipelinev1.PipelineRun
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: rerunPRName}, &updatedPR)
+	require.NoError(t, err)
+	require.Len(t, updatedPR.OwnerReferences, 1)
+
+	clonedJobName := updatedPR.OwnerReferences[0].Name
+	assert.Equal(t, rerunPRName, clonedJobName, "The new job should have the same name as the rerun PipelineRun")
+
+	var clonedJob lighthousev1alpha1.LighthouseJob
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: clonedJobName}, &clonedJob)
+	require.NoError(t, err)
+
+	// Assert the cloned job's status was cleared
+	assert.Empty(t, clonedJob.Status.State, "Cloned job should have an empty state")
+	assert.Nil(t, clonedJob.Status.CompletionTime, "Cloned job should have a nil completion time")
+
+	// Verify the original job was NOT modified (deep copy protected it)
+	var fetchedOriginalJob lighthousev1alpha1.LighthouseJob
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: jobName}, &fetchedOriginalJob)
+	require.NoError(t, err)
+	assert.Equal(t, lighthousev1alpha1.SuccessState, fetchedOriginalJob.Status.State, "Original job's status should not be mutated")
+}

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -297,6 +297,7 @@ func TestReconcileRerunIsIdempotent(t *testing.T) {
 	var jobs lighthousev1alpha1.LighthouseJobList
 	require.NoError(t, c.List(context.TODO(), &jobs, client.InNamespace(ns)))
 	require.Len(t, jobs.Items, 1)
+	assert.False(t, jobs.Items[0].Status.StartTime.IsZero(), "StartTime should be set on creation")
 
 	// A second reconcile (e.g. a re-queued event) must not create a duplicate.
 	_, err = reconciler.Reconcile(context.TODO(), req)

--- a/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
+++ b/pkg/engines/tekton/pipelinerun_rerun_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -77,4 +78,83 @@ func TestRerunReconcileSetsOwnerReferenceGVK(t *testing.T) {
 	assert.Equal(t, "lighthouse.jenkins.io/v1alpha1", ref.APIVersion, "owner reference apiVersion must be derived from the scheme, not the fetched object's empty TypeMeta")
 	assert.Equal(t, "LighthouseJob", ref.Kind, "owner reference kind must be derived from the scheme, not the fetched object's empty TypeMeta")
 	assert.NotEmpty(t, ref.Name, "owner reference should point at the newly created rerun LighthouseJob")
+}
+
+// TestResolveParentLighthouseJob exercises resolveParentLighthouseJob in isolation,
+// covering the three "not resolvable" branches and the nominal resolution.
+func TestResolveParentLighthouseJob(t *testing.T) {
+	ns := "jx"
+	parentPRName := "myorg-myrepo-main-abc12-1"
+	jobName := "myorg-myrepo-main-abc12"
+
+	newReconciler := func(objs ...client.Object) *RerunPipelineRunReconciler {
+		scheme := runtime.NewScheme()
+		require.NoError(t, lighthousev1alpha1.AddToScheme(scheme))
+		require.NoError(t, pipelinev1.AddToScheme(scheme))
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		return NewRerunPipelineRunReconciler(c, c, scheme, 1)
+	}
+	rerunPR := func() *pipelinev1.PipelineRun {
+		return &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
+			Name: "rerun", Namespace: ns,
+			Labels: map[string]string{util.DashboardTektonRerun: parentPRName},
+		}}
+	}
+
+	t.Run("no rerun label returns nil", func(t *testing.T) {
+		r := newReconciler()
+		pr := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: ns}}
+		lj, err := r.resolveParentLighthouseJob(context.TODO(), pr)
+		require.NoError(t, err)
+		assert.Nil(t, lj)
+	})
+
+	t.Run("parent PipelineRun missing returns nil", func(t *testing.T) {
+		r := newReconciler()
+		lj, err := r.resolveParentLighthouseJob(context.TODO(), rerunPR())
+		require.NoError(t, err)
+		assert.Nil(t, lj)
+	})
+
+	t.Run("parent without ownerReference returns nil", func(t *testing.T) {
+		parentPR := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: parentPRName, Namespace: ns}}
+		r := newReconciler(parentPR)
+		lj, err := r.resolveParentLighthouseJob(context.TODO(), rerunPR())
+		require.NoError(t, err)
+		assert.Nil(t, lj)
+	})
+
+	t.Run("parent with non-LighthouseJob controller owner returns nil", func(t *testing.T) {
+		parentPR := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
+			Name: parentPRName, Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "Pipeline",
+				Name:       "some-pipeline",
+				Controller: ptr.To(true),
+			}},
+		}}
+		r := newReconciler(parentPR)
+		lj, err := r.resolveParentLighthouseJob(context.TODO(), rerunPR())
+		require.NoError(t, err)
+		assert.Nil(t, lj, "a non-LighthouseJob controller owner must trigger reconstruction, not a wrong-kind lookup")
+	})
+
+	t.Run("resolves the parent LighthouseJob", func(t *testing.T) {
+		job := &lighthousev1alpha1.LighthouseJob{ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: ns}}
+		parentPR := &pipelinev1.PipelineRun{ObjectMeta: metav1.ObjectMeta{
+			Name: parentPRName, Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "lighthouse.jenkins.io/v1alpha1",
+				Kind:       "LighthouseJob",
+				Name:       jobName,
+				Controller: ptr.To(true),
+			}},
+		}}
+		r := newReconciler(job, parentPR)
+		lj, err := r.resolveParentLighthouseJob(context.TODO(), rerunPR())
+		require.NoError(t, err)
+		require.NotNil(t, lj)
+		assert.Equal(t, jobName, lj.Name)
+	})
 }

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -1,0 +1,99 @@
+package tekton
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
+	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
+	"github.com/jenkins-x/lighthouse/pkg/util"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+// ErrMissingRequiredLabels is returned when a PipelineRun is missing labels
+// required to reconstruct a LighthouseJob.
+type ErrMissingRequiredLabels struct {
+	Missing []string
+}
+
+func (e *ErrMissingRequiredLabels) Error() string {
+	return fmt.Sprintf("missing required labels for reconstruction: %s", strings.Join(e.Missing, ", "))
+}
+
+// isPullRequestType returns true if the job type is associated with a pull request (presubmit or batch).
+func isPullRequestType(jobType configjob.PipelineKind) bool {
+	return jobType == configjob.PresubmitJob || jobType == configjob.BatchJob
+}
+
+// rerunSpecFromPipelineRun reconstructs a LighthouseJobSpec entirely from the metadata
+// (labels, annotations, and Spec) of a rerun PipelineRun.
+func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.LighthouseJobSpec, error) {
+	labels := pr.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	requiredLabels := []string{
+		configjob.LighthouseJobTypeLabel,
+		util.ContextLabel,
+		util.OrgLabel,
+		util.RepoLabel,
+		util.LastCommitSHALabel,
+	}
+
+	var missing []string
+	for _, req := range requiredLabels {
+		if _, ok := labels[req]; !ok {
+			missing = append(missing, req)
+		}
+	}
+
+	if len(missing) > 0 {
+		return lighthousev1alpha1.LighthouseJobSpec{}, &ErrMissingRequiredLabels{Missing: missing}
+	}
+
+	annotations := pr.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	prSpecCopy := pr.Spec.DeepCopy()
+
+	baseRef := labels[util.BranchLabel]
+	if isPullRequestType(configjob.PipelineKind(labels[configjob.LighthouseJobTypeLabel])) {
+		// Foghorn only needs BaseSHA and Pulls for PR reporting.
+		// The PR branch name is stored in BranchLabel but BaseRef must remain empty for presubmit/batch
+		// to match the original jobutil.LabelsAndAnnotationsForJob behavior.
+		baseRef = ""
+	}
+
+	spec := lighthousev1alpha1.LighthouseJobSpec{
+		Agent:           configjob.TektonPipelineAgent,
+		Type:            configjob.PipelineKind(labels[configjob.LighthouseJobTypeLabel]),
+		Namespace:       pr.Namespace,
+		Context:         labels[util.ContextLabel],
+		Job:             annotations[util.LighthouseJobAnnotation],
+		PipelineRunSpec: prSpecCopy,
+		Refs: &lighthousev1alpha1.Refs{
+			Org:      labels[util.OrgLabel],
+			Repo:     labels[util.RepoLabel],
+			BaseSHA:  labels[util.BaseSHALabel],
+			BaseRef:  baseRef,
+			CloneURI: annotations[util.CloneURIAnnotation],
+		},
+	}
+
+	if pullStr, ok := labels[util.PullLabel]; ok && pullStr != "" {
+		if pullNumber, err := strconv.Atoi(pullStr); err == nil {
+			spec.Refs.Pulls = []lighthousev1alpha1.Pull{
+				{
+					Number: pullNumber,
+					SHA:    labels[util.LastCommitSHALabel],
+				},
+			}
+		}
+	}
+
+	return spec, nil
+}

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -7,7 +7,6 @@ import (
 
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
-	"github.com/jenkins-x/lighthouse/pkg/jobutil"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,9 +114,9 @@ func newReconstructedLighthouseJob(pr *pipelinev1.PipelineRun, spec lighthousev1
 			Kind:       "LighthouseJob",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: jobutil.GenerateName(&spec),
-			Namespace:    pr.Namespace,
-			Labels:       ljLabels,
+			Name:      pr.Name,
+			Namespace: pr.Namespace,
+			Labels:    ljLabels,
 		},
 		Spec:   spec,
 		Status: lighthousev1alpha1.LighthouseJobStatus{},

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -7,8 +7,10 @@ import (
 
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
+	"github.com/jenkins-x/lighthouse/pkg/jobutil"
 	"github.com/jenkins-x/lighthouse/pkg/util"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ErrMissingRequiredLabels is returned when a PipelineRun is missing labels
@@ -96,4 +98,28 @@ func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.Li
 	}
 
 	return spec, nil
+}
+
+// newReconstructedLighthouseJob creates a new LighthouseJob from a rerun PipelineRun and a reconstructed spec.
+func newReconstructedLighthouseJob(pr *pipelinev1.PipelineRun, spec lighthousev1alpha1.LighthouseJobSpec) *lighthousev1alpha1.LighthouseJob {
+	ljLabels := make(map[string]string)
+	for k, v := range pr.GetLabels() {
+		if strings.HasPrefix(k, "lighthouse.jenkins-x.io/") || k == configjob.CreatedByLighthouseLabel {
+			ljLabels[k] = v
+		}
+	}
+
+	return &lighthousev1alpha1.LighthouseJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "lighthouse.jenkins.io/v1alpha1",
+			Kind:       "LighthouseJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: jobutil.GenerateName(&spec),
+			Namespace:    pr.Namespace,
+			Labels:       ljLabels,
+		},
+		Spec:   spec,
+		Status: lighthousev1alpha1.LighthouseJobStatus{},
+	}
 }

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -29,6 +29,16 @@ func isPullRequestType(jobType configjob.PipelineKind) bool {
 
 // rerunSpecFromPipelineRun reconstructs a LighthouseJobSpec entirely from the metadata
 // (labels, annotations, and Spec) of a rerun PipelineRun.
+//
+// A successful reconstruction requires the following strict set of labels to be present
+// on the rerun PipelineRun:
+// - lighthouse.jenkins-x.io/type (type of job: presubmit, postsubmit, etc.)
+// - lighthouse.jenkins-x.io/context (reporting context)
+// - lighthouse.jenkins-x.io/refs.org (repository organization)
+// - lighthouse.jenkins-x.io/refs.repo (repository name)
+// - lighthouse.jenkins-x.io/lastCommitSHA (the commit SHA to report status against)
+//
+// If any of these are missing, it returns an ErrMissingRequiredLabels.
 func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.LighthouseJobSpec, error) {
 	labels := pr.GetLabels()
 	if labels == nil {
@@ -100,6 +110,12 @@ func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.Li
 }
 
 // newReconstructedLighthouseJob creates a new LighthouseJob from a rerun PipelineRun and a reconstructed spec.
+//
+// Empty Status Rationale:
+// The returned LighthouseJob is deliberately created with a zero-value Status (empty State).
+//   - For the fast path, clearing the status prevents inheriting a terminal state (like Success) from the parent.
+//   - More importantly, leaving State empty guarantees that the LighthouseJobReconciler (which looks for TriggeredState)
+//     will NOT spawn a duplicate PipelineRun during the brief window before the OwnerReference is fully indexed.
 func newReconstructedLighthouseJob(pr *pipelinev1.PipelineRun, spec lighthousev1alpha1.LighthouseJobSpec) *lighthousev1alpha1.LighthouseJob {
 	ljLabels := make(map[string]string)
 	for k, v := range pr.GetLabels() {

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -112,6 +112,46 @@ func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.Li
 	return spec, nil
 }
 
+// canonicalRerunLabels returns the exact set of labels that should be present on a LighthouseJob
+// created from a rerun PipelineRun. It preserves only the lighthouse and 'created-by' labels.
+func canonicalRerunLabels(pr *pipelinev1.PipelineRun) map[string]string {
+	labels := make(map[string]string)
+	for k, v := range pr.GetLabels() {
+		if strings.HasPrefix(k, util.LighthouseLabelPrefix) || k == configjob.CreatedByLighthouseLabel {
+			labels[k] = v
+		}
+	}
+	return labels
+}
+
+// canonicalRerunAnnotations returns the exact set of annotations that should be present on a LighthouseJob
+// created from a rerun PipelineRun.
+func canonicalRerunAnnotations(pr *pipelinev1.PipelineRun) map[string]string {
+	annotations := make(map[string]string)
+	prAnnotations := pr.GetAnnotations()
+	if v, ok := prAnnotations[util.LighthouseJobAnnotation]; ok {
+		annotations[util.LighthouseJobAnnotation] = v
+	}
+	if v, ok := prAnnotations[util.CloneURIAnnotation]; ok {
+		annotations[util.CloneURIAnnotation] = v
+	}
+	return annotations
+}
+
+// ensureEntries returns dst augmented with the entries from src whose keys are not
+// already present. Existing entries in dst are never overwritten nor removed.
+func ensureEntries(dst, src map[string]string) map[string]string {
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for k, v := range src {
+		if _, ok := dst[k]; !ok {
+			dst[k] = v
+		}
+	}
+	return dst
+}
+
 // newReconstructedLighthouseJob creates a new LighthouseJob from a rerun PipelineRun and a reconstructed spec.
 //
 // Empty Status Rationale:
@@ -120,22 +160,16 @@ func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.Li
 //   - More importantly, leaving State empty guarantees that the LighthouseJobReconciler (which looks for TriggeredState)
 //     will NOT spawn a duplicate PipelineRun during the brief window before the OwnerReference is fully indexed.
 func newReconstructedLighthouseJob(pr *pipelinev1.PipelineRun, spec lighthousev1alpha1.LighthouseJobSpec) *lighthousev1alpha1.LighthouseJob {
-	ljLabels := make(map[string]string)
-	for k, v := range pr.GetLabels() {
-		if strings.HasPrefix(k, "lighthouse.jenkins-x.io/") || k == configjob.CreatedByLighthouseLabel {
-			ljLabels[k] = v
-		}
-	}
-
 	return &lighthousev1alpha1.LighthouseJob{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: lighthousev1alpha1.SchemeGroupVersion.String(),
 			Kind:       lighthouseJobKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pr.Name,
-			Namespace: pr.Namespace,
-			Labels:    ljLabels,
+			Name:        pr.Name,
+			Namespace:   pr.Namespace,
+			Labels:      canonicalRerunLabels(pr),
+			Annotations: canonicalRerunAnnotations(pr),
 		},
 		Spec:   spec,
 		Status: lighthousev1alpha1.LighthouseJobStatus{},

--- a/pkg/engines/tekton/rerun_reconstruct.go
+++ b/pkg/engines/tekton/rerun_reconstruct.go
@@ -8,6 +8,7 @@ import (
 	lighthousev1alpha1 "github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
 	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/sirupsen/logrus"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -103,6 +104,8 @@ func rerunSpecFromPipelineRun(pr *pipelinev1.PipelineRun) (lighthousev1alpha1.Li
 					SHA:    labels[util.LastCommitSHALabel],
 				},
 			}
+		} else {
+			logrus.Warnf("Failed to parse pull number %q from label %s: %v", pullStr, util.PullLabel, err)
 		}
 	}
 
@@ -126,8 +129,8 @@ func newReconstructedLighthouseJob(pr *pipelinev1.PipelineRun, spec lighthousev1
 
 	return &lighthousev1alpha1.LighthouseJob{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "lighthouse.jenkins.io/v1alpha1",
-			Kind:       "LighthouseJob",
+			APIVersion: lighthousev1alpha1.SchemeGroupVersion.String(),
+			Kind:       lighthouseJobKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pr.Name,

--- a/pkg/engines/tekton/rerun_reconstruct_test.go
+++ b/pkg/engines/tekton/rerun_reconstruct_test.go
@@ -1,0 +1,96 @@
+package tekton
+
+import (
+	"errors"
+	"testing"
+
+	configjob "github.com/jenkins-x/lighthouse/pkg/config/job"
+	"github.com/jenkins-x/lighthouse/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func basePipelineRun() *pipelinev1.PipelineRun {
+	return &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myorg-myrepo-main-abc12-2-rerun",
+			Namespace: "jx",
+			Labels: map[string]string{
+				configjob.LighthouseJobTypeLabel: string(configjob.PostsubmitJob),
+				util.ContextLabel:                "build",
+				util.OrgLabel:                    "myorg",
+				util.RepoLabel:                   "myrepo",
+				util.LastCommitSHALabel:          "sha123",
+				util.BaseSHALabel:                "basesha456",
+				util.BranchLabel:                 "main",
+			},
+			Annotations: map[string]string{
+				util.LighthouseJobAnnotation: "myorg-myrepo-build",
+				util.CloneURIAnnotation:      "https://github.com/myorg/myrepo.git",
+			},
+		},
+	}
+}
+
+func TestRerunSpecFromPipelineRun_Postsubmit(t *testing.T) {
+	spec, err := rerunSpecFromPipelineRun(basePipelineRun())
+	require.NoError(t, err)
+	assert.Equal(t, configjob.TektonPipelineAgent, spec.Agent)
+	assert.Equal(t, configjob.PostsubmitJob, spec.Type)
+	assert.Equal(t, "build", spec.Context)
+	assert.Equal(t, "myorg-myrepo-build", spec.Job)
+	require.NotNil(t, spec.Refs)
+	assert.Equal(t, "myorg", spec.Refs.Org)
+	assert.Equal(t, "myrepo", spec.Refs.Repo)
+	assert.Equal(t, "basesha456", spec.Refs.BaseSHA)
+	assert.Equal(t, "main", spec.Refs.BaseRef, "postsubmit keeps the base ref")
+	assert.Equal(t, "https://github.com/myorg/myrepo.git", spec.Refs.CloneURI)
+	assert.Empty(t, spec.Refs.Pulls)
+}
+
+func TestRerunSpecFromPipelineRun_PresubmitClearsBaseRefAndSetsPulls(t *testing.T) {
+	pr := basePipelineRun()
+	pr.Labels[configjob.LighthouseJobTypeLabel] = string(configjob.PresubmitJob)
+	pr.Labels[util.BranchLabel] = "PR-42"
+	pr.Labels[util.PullLabel] = "42"
+
+	spec, err := rerunSpecFromPipelineRun(pr)
+	require.NoError(t, err)
+	assert.Empty(t, spec.Refs.BaseRef, "presubmit must clear the base ref")
+	require.Len(t, spec.Refs.Pulls, 1)
+	assert.Equal(t, 42, spec.Refs.Pulls[0].Number)
+	assert.Equal(t, "sha123", spec.Refs.Pulls[0].SHA)
+}
+
+func TestRerunSpecFromPipelineRun_BatchClearsBaseRef(t *testing.T) {
+	pr := basePipelineRun()
+	pr.Labels[configjob.LighthouseJobTypeLabel] = string(configjob.BatchJob)
+
+	spec, err := rerunSpecFromPipelineRun(pr)
+	require.NoError(t, err)
+	assert.Empty(t, spec.Refs.BaseRef)
+}
+
+func TestRerunSpecFromPipelineRun_NonNumericPullIgnored(t *testing.T) {
+	pr := basePipelineRun()
+	pr.Labels[configjob.LighthouseJobTypeLabel] = string(configjob.PresubmitJob)
+	pr.Labels[util.PullLabel] = "not-a-number"
+
+	spec, err := rerunSpecFromPipelineRun(pr)
+	require.NoError(t, err)
+	assert.Empty(t, spec.Refs.Pulls)
+}
+
+func TestRerunSpecFromPipelineRun_MissingRequiredLabels(t *testing.T) {
+	pr := basePipelineRun()
+	delete(pr.Labels, util.ContextLabel)
+	delete(pr.Labels, util.OrgLabel)
+
+	_, err := rerunSpecFromPipelineRun(pr)
+	require.Error(t, err)
+	var missing *ErrMissingRequiredLabels
+	require.True(t, errors.As(err, &missing))
+	assert.ElementsMatch(t, []string{util.ContextLabel, util.OrgLabel}, missing.Missing)
+}

--- a/pkg/keeper/status_test.go
+++ b/pkg/keeper/status_test.go
@@ -537,10 +537,10 @@ func TestBucketedGraphQLStatusSearch(t *testing.T) {
 			wantInQuery:   []string{`org:"my-org"`},
 		},
 		{
-			name:      "repos within bucket size produces single repo query",
-			orgs:      sets.New[string](),
-			repos:     sets.New[string]("org/repo0", "org/repo1"),
-			wantCalls: 1,
+			name:        "repos within bucket size produces single repo query",
+			orgs:        sets.New[string](),
+			repos:       sets.New[string]("org/repo0", "org/repo1"),
+			wantCalls:   1,
 			wantInQuery: []string{`repo:"org/repo0"`, `repo:"org/repo1"`},
 		},
 		{
@@ -558,8 +558,8 @@ func TestBucketedGraphQLStatusSearch(t *testing.T) {
 			wantInQuery:   []string{`org:"my-org"`, `repo:"other-org/repo"`},
 		},
 		{
-			name: "org exceptions are included in org query",
-			orgs: sets.New[string]("my-org"),
+			name:  "org exceptions are included in org query",
+			orgs:  sets.New[string]("my-org"),
 			repos: sets.New[string](),
 			orgExceptions: map[string]sets.String{
 				"my-org": sets.NewString("my-org/excluded-repo"),

--- a/pkg/repoowners/repoowners_test.go
+++ b/pkg/repoowners/repoowners_test.go
@@ -18,12 +18,13 @@ package repoowners
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jenkins-x/lighthouse/pkg/gittest"
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -19,6 +19,9 @@ const (
 	// use for GitHub API calls when present.
 	GitHubAppAPIUserFilename = "username"
 
+	// LighthouseLabelPrefix is the prefix used for all Lighthouse labels and annotations.
+	LighthouseLabelPrefix = "lighthouse.jenkins-x.io/"
+
 	// LighthousePipelineActivityNameLabel is added to the LighthouseJob with
 	// the name of the PipelineActivity corresponding to it.
 	LighthousePipelineActivityNameLabel = "lighthouse.jenkins-x.io/activityName"


### PR DESCRIPTION
#### What this PR does / why we need it

Re-running a PipelineRun from the Tekton Dashboard did not update the git commit status: it stayed stuck on the previous run's result.

The rerun controller only worked when **both** the parent PipelineRun **and** its owning LighthouseJob still existed, so it could copy their OwnerReference onto the new run. In practice the parent resources are frequently already garbage-collected/archived when a user clicks "Rerun", leaving the rerun PipelineRun with no LighthouseJob to attach to — so Foghorn never reported a fresh status.

This PR makes the rerun controller self-sufficient and idempotent. It now handles two paths:

1. **Fast path** — the parent LighthouseJob still exists: it is cloned and its `Status` is cleared so a completed parent doesn't mark the rerun as terminal. The clone keeps the parent's full metadata, and the canonical lighthouse labels/annotations are *ensured* present (filled from the rerun PipelineRun without overwriting anything the parent legitimately carried).
2. **Reconstruction path** — a parent has been archived/deleted: the LighthouseJob is rebuilt entirely from the rerun PipelineRun's own labels, annotations and `PipelineRunSpec`. This is a best-effort recovery: only the canonical lighthouse labels/annotations are carried over. Metadata may therefore legitimately diverge from the fast path — this divergence is accepted and documented.

Additional correctness/robustness:

- The parent LighthouseJob is resolved through the PipelineRun's **controller** owner reference (`metav1.GetControllerOf`, matched on the lighthouse GVK/Kind) instead of assuming `OwnerReferences[0]`; when no such owner is found the controller falls back to the reconstruction path.
- Deterministic LighthouseJob name + `IsAlreadyExists` handling → exactly one LighthouseJob per rerun (idempotent, no duplicates).
- The job is created with an empty `State`, preventing the LighthouseJobReconciler from spawning a duplicate PipelineRun before the OwnerReference is indexed.
- `Status.StartTime` is set on creation (via the status subresource) so `gc-jobs` does not prematurely delete a still-running rerun job.
- The OwnerReference GVK is derived from the scheme (typed clients return an empty `TypeMeta`) and is applied idempotently.
- Reruns that can never be reconstructed (missing required labels) are dropped instead of being requeued forever.

The reconciled object is read from the cache (hot path); the uncached `APIReader` is only used on the rare adoption path to avoid a cache-staleness race without adding API load. The behaviour stays gated behind the existing `--enable-rerun-status-update` flag.