### PR TITLE
fix(repo-owners): include path itself in OWNERS walk

### DIFF
--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -39,7 +38,7 @@ import (
 	"github.com/jenkins-x/lighthouse/pkg/labels"
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
 	"github.com/jenkins-x/lighthouse/pkg/plugins/approve/approvers"
-	"github.com/jenkins-x/lighthouse/pkg/repoowners"
+	fakeowners "github.com/jenkins-x/lighthouse/pkg/repoowners/fake"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -148,34 +147,6 @@ func newFakeSCMProviderClient(hasLabel, humanApproved, labelComments bool, files
 	return fakeClient, fc
 }
 
-type fakeRepo struct {
-	approvers, leafApprovers map[string]sets.String
-	approverOwners           map[string]string
-	minimumReviewers         map[string]int
-}
-
-func (fr fakeRepo) MinimumReviewersForFile(path string) int {
-	dir := filepath.Dir(path)
-	if dir == "." {
-		dir = ""
-	}
-	if n, ok := fr.minimumReviewers[dir]; ok {
-		return n
-	}
-	return 1
-}
-func (fr fakeRepo) Approvers(path string) sets.String {
-	return fr.approvers[path]
-}
-func (fr fakeRepo) LeafApprovers(path string) sets.String {
-	return fr.leafApprovers[path]
-}
-func (fr fakeRepo) FindApproverOwnersForFile(path string) string {
-	return fr.approverOwners[path]
-}
-func (fr fakeRepo) IsNoParentOwners(path string) bool {
-	return false
-}
 
 func TestHandle(t *testing.T) {
 	// This function does not need to test IsApproved, that is tested in approvers/approvers_test.go.
@@ -1297,28 +1268,12 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 		},
 	}
 
-	fr := fakeRepo{
-		approvers: map[string]sets.String{
-			"a":   sets.NewString("alice"),
-			"a/b": sets.NewString("alice", "bob"),
-			"c":   sets.NewString("cblecker", "cjwagner"),
-			"d":   sets.NewString("derek", "jerry"),
-		},
-		leafApprovers: map[string]sets.String{
-			"a":   sets.NewString("alice"),
-			"a/b": sets.NewString("bob"),
-			"c":   sets.NewString("cblecker", "cjwagner"),
-			"d":   sets.NewString("derek", "jerry"),
-		},
-		approverOwners: map[string]string{
-			"a/a.go":   "a",
-			"a/aa.go":  "a",
-			"a/b/b.go": "a/b",
-			"c/c.go":   "c",
-			"d/d.go":   "d",
-		},
-		minimumReviewers: map[string]int{
-			"d": 2,
+	fr := &fakeowners.FakeRepoOwners{
+		Dirs: map[string]fakeowners.DirOwners{
+			"a":   {Approvers: sets.NewString("alice")},
+			"a/b": {Approvers: sets.NewString("bob")},
+			"c":   {Approvers: sets.NewString("cblecker", "cjwagner")},
+			"d":   {Approvers: sets.NewString("derek", "jerry"), MinimumReviewers: 2},
 		},
 	}
 
@@ -1438,40 +1393,6 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 
 // TODO: cache approvers 'GetFilesApprovers' and 'GetCCs' since these are called repeatedly and are
 // expensive.
-
-type fakeOwnersClient struct{}
-
-func (foc fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
-	return fakeRepoOwners{}, nil
-}
-
-type fakeRepoOwners struct {
-	fakeRepo
-}
-
-func (fro fakeRepoOwners) FindLabelsForFile(path string) sets.String {
-	return sets.NewString()
-}
-
-func (fro fakeRepoOwners) FindReviewersOwnersForFile(path string) string {
-	return ""
-}
-
-func (fro fakeRepoOwners) LeafReviewers(path string) sets.String {
-	return sets.NewString()
-}
-
-func (fro fakeRepoOwners) Reviewers(path string) sets.String {
-	return sets.NewString()
-}
-
-func (fro fakeRepoOwners) RequiredReviewers(path string) sets.String {
-	return sets.NewString()
-}
-
-func (fro fakeRepoOwners) MinimumReviewersForFile(path string) int {
-	return 1
-}
 
 func TestHandleGenericComment(t *testing.T) {
 	tests := []struct {
@@ -1664,7 +1585,7 @@ func TestHandleGenericComment(t *testing.T) {
 				return handleGenericComment(
 					logrus.WithField("plugin", "approve"),
 					fakeClient,
-					fakeOwnersClient{},
+					&fakeowners.Client{},
 					&url.URL{
 						Scheme: "https",
 						Host:   "github.com",
@@ -1883,7 +1804,7 @@ func TestHandleReview(t *testing.T) {
 		err := handleReview(
 			logrus.WithField("plugin", "approve"),
 			fakeClient,
-			fakeOwnersClient{},
+			&fakeowners.Client{},
 			&url.URL{
 				Scheme: "https",
 				Host:   "github.com",
@@ -2024,7 +1945,7 @@ func TestHandlePullRequest(t *testing.T) {
 		err := handlePullRequest(
 			logrus.WithField("plugin", "approve"),
 			fakeClient,
-			fakeOwnersClient{},
+			&fakeowners.Client{},
 			&url.URL{
 				Scheme: "https",
 				Host:   "github.com",

--- a/pkg/plugins/approve/approvers/approvers_test.go
+++ b/pkg/plugins/approve/approvers/approvers_test.go
@@ -782,8 +782,8 @@ func TestIsApprovedWithMinReviewers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			fakeRepo := createFakeRepo(test.leafApprovers)
-			fakeRepo.minReviewersMap = test.minReviewersMap
-			fakeRepo.noParentOwnersMap = test.noParentOwnersMap
+			setMinReviewers(fakeRepo, test.minReviewersMap)
+			setNoParent(fakeRepo, test.noParentOwnersMap)
 			testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: fakeRepo, seed: test.testSeed, log: logrus.WithField("plugin", "some_plugin")})
 			for approver := range test.currentlyApproved {
 				testApprovers.AddApprover(approver, "REFERENCE", false)

--- a/pkg/plugins/approve/approvers/owners_test.go
+++ b/pkg/plugins/approve/approvers/owners_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	fakeowners "github.com/jenkins-x/lighthouse/pkg/repoowners/fake"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -31,68 +32,50 @@ const (
 	TestSeed = int64(0)
 )
 
-type FakeRepo struct {
-	approversMap      map[string]sets.String
-	leafApproversMap  map[string]sets.String
-	noParentOwnersMap map[string]bool
-	minReviewersMap   map[string]int
-}
-
-func (f FakeRepo) MinimumReviewersForFile(path string) int {
-	dir := filepath.Dir(path)
-	dir = canonicalize(dir)
-	if out, ok := f.minReviewersMap[dir]; ok {
-		return out
-	}
-	return 1
-}
-
-func (f FakeRepo) Approvers(path string) sets.String {
-	return f.approversMap[path]
-}
-
-func (f FakeRepo) LeafApprovers(path string) sets.String {
-	return f.leafApproversMap[path]
-}
-
-func (f FakeRepo) FindApproverOwnersForFile(path string) string {
-	for dir := path; dir != "."; dir = filepath.Dir(dir) {
-		if _, ok := f.leafApproversMap[dir]; ok {
-			return dir
+// createFakeRepo builds a *fakeowners.FakeRepoOwners from a map of
+// leaf approvers keyed by either an OWNERS directory (e.g. "a/b") or
+// an individual file with a YAML owners header (e.g. "b/README.md").
+// Keys with a file extension are routed to the per-file overlay; the
+// rest populate Dirs. Approver names are lowercased to match the real
+// implementation, which normalizes logins.
+func createFakeRepo(leafApproversByKey map[string]sets.String) *fakeowners.FakeRepoOwners {
+	dirs := map[string]fakeowners.DirOwners{}
+	files := map[string]fakeowners.DirOwners{}
+	for k, a := range leafApproversByKey {
+		entry := fakeowners.DirOwners{Approvers: setToLower(a)}
+		if filepath.Ext(k) != "" {
+			files[k] = entry
+		} else {
+			dirs[k] = entry
 		}
 	}
-	return ""
+	return &fakeowners.FakeRepoOwners{Dirs: dirs, Files: files}
 }
 
-func (f FakeRepo) IsNoParentOwners(path string) bool {
-	return f.noParentOwnersMap[path]
-}
-
-func canonicalize(path string) string {
-	if path == "." {
-		return ""
+// setMinReviewers folds a directory-keyed minimum-reviewers map into the
+// fake's Dirs, preserving any approvers already set at those directories.
+func setMinReviewers(f *fakeowners.FakeRepoOwners, m map[string]int) {
+	if f.Dirs == nil {
+		f.Dirs = map[string]fakeowners.DirOwners{}
 	}
-	return strings.TrimSuffix(path, "/")
+	for d, n := range m {
+		cfg := f.Dirs[d]
+		cfg.MinimumReviewers = n
+		f.Dirs[d] = cfg
+	}
 }
 
-func createFakeRepo(la map[string]sets.String) FakeRepo {
-	// github doesn't use / at the root
-	a := map[string]sets.String{}
-	for dir, approvers := range la {
-		la[dir] = setToLower(approvers)
-		a[dir] = setToLower(approvers)
-		startingPath := dir
-		for {
-			dir = canonicalize(filepath.Dir(dir))
-			if parentApprovers, ok := la[dir]; ok {
-				a[startingPath] = a[startingPath].Union(setToLower(parentApprovers))
-			}
-			if dir == "" {
-				break
-			}
-		}
+// setNoParent folds a directory-keyed NoParentOwners map into the fake's
+// Dirs, preserving any approvers already set at those directories.
+func setNoParent(f *fakeowners.FakeRepoOwners, m map[string]bool) {
+	if f.Dirs == nil {
+		f.Dirs = map[string]fakeowners.DirOwners{}
 	}
-	return FakeRepo{approversMap: a, leafApproversMap: la}
+	for d, v := range m {
+		cfg := f.Dirs[d]
+		cfg.NoParentOwners = v
+		f.Dirs[d] = cfg
+	}
 }
 
 func setToLower(s sets.String) sets.String {
@@ -101,76 +84,6 @@ func setToLower(s sets.String) sets.String {
 		lowered.Insert(strings.ToLower(elem))
 	}
 	return lowered
-}
-
-func TestCreateFakeRepo(t *testing.T) {
-	rootApprovers := sets.NewString("Alice", "Bob")
-	aApprovers := sets.NewString("Art", "Anne")
-	bApprovers := sets.NewString("Bill", "Ben", "Barbara")
-	cApprovers := sets.NewString("Chris", "Carol")
-	eApprovers := sets.NewString("Eve", "Erin")
-	edcApprovers := eApprovers.Union(cApprovers)
-	FakeRepoMap := map[string]sets.String{
-		"":        rootApprovers,
-		"a":       aApprovers,
-		"b":       bApprovers,
-		"c":       cApprovers,
-		"a/combo": edcApprovers,
-	}
-	fakeRepo := createFakeRepo(FakeRepoMap)
-
-	tests := []struct {
-		testName              string
-		ownersFile            string
-		expectedLeafApprovers sets.String
-		expectedApprovers     sets.String
-	}{
-		{
-			testName:              "Root Owners",
-			ownersFile:            "",
-			expectedApprovers:     rootApprovers,
-			expectedLeafApprovers: rootApprovers,
-		},
-		{
-			testName:              "A Owners",
-			ownersFile:            "a",
-			expectedLeafApprovers: aApprovers,
-			expectedApprovers:     aApprovers.Union(rootApprovers),
-		},
-		{
-			testName:              "B Owners",
-			ownersFile:            "b",
-			expectedLeafApprovers: bApprovers,
-			expectedApprovers:     bApprovers.Union(rootApprovers),
-		},
-		{
-			testName:              "C Owners",
-			ownersFile:            "c",
-			expectedLeafApprovers: cApprovers,
-			expectedApprovers:     cApprovers.Union(rootApprovers),
-		},
-		{
-			testName:              "Combo Owners",
-			ownersFile:            "a/combo",
-			expectedLeafApprovers: edcApprovers,
-			expectedApprovers:     edcApprovers.Union(aApprovers).Union(rootApprovers),
-		},
-	}
-
-	for _, test := range tests {
-		calculatedLeafApprovers := fakeRepo.LeafApprovers(test.ownersFile)
-		calculatedApprovers := fakeRepo.Approvers(test.ownersFile)
-
-		test.expectedLeafApprovers = setToLower(test.expectedLeafApprovers)
-		if !calculatedLeafApprovers.Equal(test.expectedLeafApprovers) {
-			t.Errorf("Failed for test %v.  Expected Leaf Approvers: %v. Actual Leaf Approvers %v", test.testName, test.expectedLeafApprovers, calculatedLeafApprovers)
-		}
-
-		test.expectedApprovers = setToLower(test.expectedApprovers)
-		if !calculatedApprovers.Equal(test.expectedApprovers) {
-			t.Errorf("Failed for test %v.  Expected Approvers: %v. Actual Approvers %v", test.testName, test.expectedApprovers, calculatedApprovers)
-		}
-	}
 }
 
 func TestGetLeafApprovers(t *testing.T) {
@@ -732,7 +645,9 @@ func TestRemoveSubdirs(t *testing.T) {
 		if test.noParentOwners == nil {
 			test.noParentOwners = map[string]bool{}
 		}
-		o := &Owners{repo: FakeRepo{noParentOwnersMap: test.noParentOwners}}
+		fakeRepo := &fakeowners.FakeRepoOwners{}
+		setNoParent(fakeRepo, test.noParentOwners)
+		o := &Owners{repo: fakeRepo}
 		o.removeSubdirs(test.directories)
 		if !reflect.DeepEqual(test.expected, test.directories) {
 			t.Errorf("Failed to remove subdirectories for test %v.  Expected files: %q. Found %q", test.testName, test.expected.List(), test.directories.List())

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -30,28 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/jenkins-x/lighthouse/pkg/plugins"
-	"github.com/jenkins-x/lighthouse/pkg/repoowners"
+	fakeowners "github.com/jenkins-x/lighthouse/pkg/repoowners/fake"
 )
-
-type fakeOwnersClient struct {
-	approvers map[string]sets.String
-	reviewers map[string]sets.String
-}
-
-var _ repoowners.Interface = &fakeOwnersClient{}
-
-func (f *fakeOwnersClient) LoadRepoAliases(org, repo, base string) (repoowners.RepoAliases, error) {
-	return nil, nil
-}
-
-func (f *fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
-	return &fakeRepoOwners{approvers: f.approvers, reviewers: f.reviewers}, nil
-}
-
-type fakeRepoOwners struct {
-	approvers map[string]sets.String
-	reviewers map[string]sets.String
-}
 
 type fakePruner struct {
 	SCMProviderClient   *fake.Data
@@ -66,33 +46,19 @@ func (fp *fakePruner) PruneComments(pr bool, shouldPrune func(*scm.Comment) bool
 	}
 }
 
-var _ repoowners.RepoOwner = &fakeRepoOwners{}
-
-func (f *fakeRepoOwners) FindApproverOwnersForFile(path string) string  { return "" }
-func (f *fakeRepoOwners) FindReviewersOwnersForFile(path string) string { return "" }
-func (f *fakeRepoOwners) FindLabelsForFile(path string) sets.String     { return nil }
-func (f *fakeRepoOwners) IsNoParentOwners(path string) bool             { return false }
-func (f *fakeRepoOwners) LeafApprovers(path string) sets.String         { return nil }
-func (f *fakeRepoOwners) Approvers(path string) sets.String             { return f.approvers[path] }
-func (f *fakeRepoOwners) LeafReviewers(path string) sets.String         { return nil }
-func (f *fakeRepoOwners) Reviewers(path string) sets.String             { return f.reviewers[path] }
-func (f *fakeRepoOwners) RequiredReviewers(path string) sets.String     { return nil }
-func (f *fakeRepoOwners) MinimumReviewersForFile(path string) int       { return 1 }
-
-var approvers = map[string]sets.String{
-	"doc/README.md": {
-		"cjwagner": {},
-		"jessica":  {},
-	},
-}
-
-var reviewers = map[string]sets.String{
-	"doc/README.md": {
-		"alice": {},
-		"bob":   {},
-		"mark":  {},
-		"sam":   {},
-	},
+// docOwnersClient returns a fake repoowners client seeded with an OWNERS
+// file at doc/ that lists approvers and reviewers for doc/README.md.
+func docOwnersClient() *fakeowners.Client {
+	return &fakeowners.Client{
+		Owners: &fakeowners.FakeRepoOwners{
+			Dirs: map[string]fakeowners.DirOwners{
+				"doc": {
+					Approvers: sets.NewString("cjwagner", "jessica"),
+					Reviewers: sets.NewString("alice", "bob", "mark", "sam"),
+				},
+			},
+		},
+	}
 }
 
 func TestLGTMComment(t *testing.T) {
@@ -336,7 +302,7 @@ func TestLGTMComment(t *testing.T) {
 			if tc.hasLGTM {
 				fc.PullRequestLabelsAdded = []string{fakeLabel}
 			}
-			oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
+			oc := docOwnersClient()
 			pc := &plugins.Configuration{}
 			if tc.skipCollab {
 				pc.Owners.SkipCollaborators = []string{"org/repo"}
@@ -511,7 +477,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 			Body: removeLGTMLabelNoti,
 		}
 		fc.PullRequestComments[5] = append(fc.PullRequestComments[5], ic)
-		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
+		oc := docOwnersClient()
 		pc := &plugins.Configuration{}
 		fp := &fakePruner{
 			SCMProviderClient:   fc,
@@ -711,7 +677,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 		if tc.hasLGTM {
 			fc.PullRequestLabelsAdded = append(fc.PullRequestLabelsAdded, "org/repo#5:"+LGTMLabel)
 		}
-		oc := &fakeOwnersClient{approvers: approvers, reviewers: reviewers}
+		oc := docOwnersClient()
 		pc := &plugins.Configuration{}
 		pc.Lgtm = append(pc.Lgtm, plugins.Lgtm{
 			Repos:         []string{"org/repo"},
@@ -1116,7 +1082,7 @@ func TestAddTreeHashComment(t *testing.T) {
 			commit := &scm.Commit{}
 			commit.Tree.Sha = treeSHA
 			fc.Commits[SHA] = commit
-			_ = handle(true, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", pluginName), &fakePruner{})
+			_ = handle(true, pc, &fakeowners.Client{}, rc, fakeClient, logrus.WithField("plugin", pluginName), &fakePruner{})
 			found := false
 			for _, body := range fc.PullRequestCommentsAdded {
 				if addLGTMLabelNotificationRe.MatchString(body) {
@@ -1172,7 +1138,7 @@ func TestRemoveTreeHashComment(t *testing.T) {
 		SCMProviderClient:   fc,
 		PullRequestComments: fc.PullRequestComments[101],
 	}
-	_ = handle(false, pc, &fakeOwnersClient{}, rc, fakeClient, logrus.WithField("plugin", pluginName), fp)
+	_ = handle(false, pc, &fakeowners.Client{}, rc, fakeClient, logrus.WithField("plugin", pluginName), fp)
 	found := false
 	for _, body := range fc.PullRequestCommentsDeleted {
 		if addLGTMLabelNotificationRe.MatchString(body) {

--- a/pkg/plugins/owners-label/owners-label_test.go
+++ b/pkg/plugins/owners-label/owners-label_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/lighthouse/pkg/labels"
+	fakeowners "github.com/jenkins-x/lighthouse/pkg/repoowners/fake"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -42,23 +43,15 @@ func formatLabels(labels ...string) []string {
 	return r
 }
 
-type fakeOwnersClient struct {
-	labels map[string]sets.String
-}
-
-func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
-	return foc.labels[path]
-}
-
 // TestHandle tests that the handle function requests reviews from the correct number of unique users.
 func TestHandle(t *testing.T) {
-	foc := &fakeOwnersClient{
-		labels: map[string]sets.String{
-			"a.go": sets.NewString(labels.LGTM, labels.Approved, "kind/docs"),
-			"b.go": sets.NewString(labels.LGTM),
-			"c.go": sets.NewString(labels.LGTM, "dnm/frozen-docs"),
-			"d.sh": sets.NewString("dnm/bash"),
-			"e.sh": sets.NewString("dnm/bash"),
+	foc := &fakeowners.FakeRepoOwners{
+		Files: map[string]fakeowners.DirOwners{
+			"a.go": {Labels: sets.NewString(labels.LGTM, labels.Approved, "kind/docs")},
+			"b.go": {Labels: sets.NewString(labels.LGTM)},
+			"c.go": {Labels: sets.NewString(labels.LGTM, "dnm/frozen-docs")},
+			"d.sh": {Labels: sets.NewString("dnm/bash")},
+			"e.sh": {Labels: sets.NewString("dnm/bash")},
 		},
 	}
 

--- a/pkg/repoowners/fake/fake.go
+++ b/pkg/repoowners/fake/fake.go
@@ -1,0 +1,206 @@
+// Package fake provides a shared test double for repoowners.RepoOwner
+// that emulates the hierarchical OWNERS-file semantics of the real
+// implementation. Tests supply the leaf OWNERS content per directory and
+// the fake performs the same upward walk the real implementation does.
+package fake
+
+import (
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/jenkins-x/lighthouse/pkg/repoowners"
+)
+
+// DirOwners is the parsed content of a single OWNERS file at a directory.
+// Fields left zero-valued behave as absent from the file.
+type DirOwners struct {
+	Approvers         sets.String
+	Reviewers         sets.String
+	RequiredReviewers sets.String
+	Labels            sets.String
+	// MinimumReviewers mirrors the OWNERS `minimum_reviewers` field.
+	// A value of 0 means the field is unset for this directory.
+	MinimumReviewers int
+	// NoParentOwners mirrors the OWNERS `options.no_parent_owners` field:
+	// when true, entry lookups stop walking upward past this directory.
+	NoParentOwners bool
+}
+
+// FakeRepoOwners implements repoowners.RepoOwner with an in-memory,
+// directory-keyed OWNERS tree. Given a file path it walks up parent
+// directories the same way the real implementation does.
+//
+// Directory keys are canonical relative paths without leading or trailing
+// slashes; the repo root is the empty string "".
+//
+// Files provides an optional per-file overlay: entries there behave like
+// the closest OWNERS (real-impl analogue is a `.md` YAML header or a
+// FullConfig regex filter that matches exactly one path). The upward
+// directory walk still runs on top of a Files match.
+type FakeRepoOwners struct {
+	Dirs  map[string]DirOwners
+	Files map[string]DirOwners
+}
+
+var _ repoowners.RepoOwner = (*FakeRepoOwners)(nil)
+
+// Client implements repoowners.Interface. LoadRepoOwners always returns
+// the same underlying FakeRepoOwners so tests can inspect state.
+type Client struct {
+	Owners *FakeRepoOwners
+}
+
+var _ repoowners.Interface = (*Client)(nil)
+
+// LoadRepoAliases returns the aliases map. FakeRepoOwners does not model
+// aliases separately from expanded owner sets; tests should supply
+// already-expanded logins in DirOwners.
+func (c *Client) LoadRepoAliases(org, repo, base string) (repoowners.RepoAliases, error) {
+	return nil, nil
+}
+
+// LoadRepoOwners returns the shared FakeRepoOwners instance, allocating
+// an empty one on demand so callers can rely on a non-nil return.
+func (c *Client) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+	if c.Owners == nil {
+		c.Owners = &FakeRepoOwners{}
+	}
+	return c.Owners, nil
+}
+
+// canonicalize matches repoowners.canonicalize so upward walks land on the
+// same directory keys the real implementation would produce.
+func canonicalize(path string) string {
+	if path == "." {
+		return ""
+	}
+	return strings.TrimSuffix(path, "/")
+}
+
+// dirOf returns the canonical directory containing path.
+func dirOf(path string) string {
+	return canonicalize(filepath.Dir(path))
+}
+
+// entriesForFile walks upward from the file's directory, unioning the
+// selected field from each DirOwners it visits. Stops at the repo root or
+// at the first directory with NoParentOwners set. If leafOnly is true it
+// returns as soon as any entries have been collected.
+func (f *FakeRepoOwners) entriesForFile(path string, extract func(DirOwners) sets.String, leafOnly bool) sets.String {
+	out := sets.NewString()
+	if cfg, ok := f.Files[path]; ok {
+		out.Insert(extract(cfg).UnsortedList()...)
+		if leafOnly && out.Len() > 0 {
+			return out
+		}
+		if cfg.NoParentOwners {
+			return out
+		}
+	}
+	d := dirOf(path)
+	for {
+		if cfg, ok := f.Dirs[d]; ok {
+			out.Insert(extract(cfg).UnsortedList()...)
+			if leafOnly && out.Len() > 0 {
+				return out
+			}
+			if cfg.NoParentOwners {
+				return out
+			}
+		}
+		if d == "" {
+			return out
+		}
+		d = dirOf(d)
+	}
+}
+
+// findOwnersForFile returns the deepest path with a non-empty extracted
+// field: first the file itself if it has a per-file overlay entry, then
+// each ancestor directory. Matches the real implementation's behaviour
+// where the repo-root OWNERS is not considered for this lookup.
+func (f *FakeRepoOwners) findOwnersForFile(path string, extract func(DirOwners) sets.String) string {
+	if cfg, ok := f.Files[path]; ok && extract(cfg).Len() > 0 {
+		return path
+	}
+	d := dirOf(path)
+	for d != "" {
+		if cfg, ok := f.Dirs[d]; ok && extract(cfg).Len() > 0 {
+			return d
+		}
+		d = dirOf(d)
+	}
+	return ""
+}
+
+// FindApproverOwnersForFile returns the deepest ancestor directory whose
+// OWNERS file lists approvers, or "" if none is found (excluding root).
+func (f *FakeRepoOwners) FindApproverOwnersForFile(path string) string {
+	return f.findOwnersForFile(path, func(d DirOwners) sets.String { return d.Approvers })
+}
+
+// FindReviewersOwnersForFile returns the deepest ancestor directory whose
+// OWNERS file lists reviewers, or "" if none is found (excluding root).
+func (f *FakeRepoOwners) FindReviewersOwnersForFile(path string) string {
+	return f.findOwnersForFile(path, func(d DirOwners) sets.String { return d.Reviewers })
+}
+
+// FindLabelsForFile returns the union of labels applied to path by
+// OWNERS files in the file's directory and its ancestors.
+func (f *FakeRepoOwners) FindLabelsForFile(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.Labels }, false)
+}
+
+// IsNoParentOwners reports whether the OWNERS file at dir has the
+// no_parent_owners option set.
+func (f *FakeRepoOwners) IsNoParentOwners(dir string) bool {
+	return f.Dirs[canonicalize(dir)].NoParentOwners
+}
+
+// LeafApprovers returns approvers from the closest OWNERS ancestor only.
+func (f *FakeRepoOwners) LeafApprovers(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.Approvers }, true)
+}
+
+// Approvers returns approvers from every OWNERS ancestor of path.
+func (f *FakeRepoOwners) Approvers(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.Approvers }, false)
+}
+
+// LeafReviewers returns reviewers from the closest OWNERS ancestor only.
+func (f *FakeRepoOwners) LeafReviewers(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.Reviewers }, true)
+}
+
+// Reviewers returns reviewers from every OWNERS ancestor of path.
+func (f *FakeRepoOwners) Reviewers(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.Reviewers }, false)
+}
+
+// RequiredReviewers returns required reviewers from every OWNERS ancestor of path.
+func (f *FakeRepoOwners) RequiredReviewers(path string) sets.String {
+	return f.entriesForFile(path, func(d DirOwners) sets.String { return d.RequiredReviewers }, false)
+}
+
+// MinimumReviewersForFile walks up from path returning the closest
+// MinimumReviewers value; returns 1 (the real implementation's default)
+// if no ancestor sets one.
+func (f *FakeRepoOwners) MinimumReviewersForFile(path string) int {
+	d := dirOf(path)
+	for {
+		if cfg, ok := f.Dirs[d]; ok {
+			if cfg.MinimumReviewers > 0 {
+				return cfg.MinimumReviewers
+			}
+			if cfg.NoParentOwners {
+				return 1
+			}
+		}
+		if d == "" {
+			return 1
+		}
+		d = dirOf(d)
+	}
+}

--- a/pkg/repoowners/fake/fake.go
+++ b/pkg/repoowners/fake/fake.go
@@ -99,7 +99,7 @@ func (f *FakeRepoOwners) entriesForFile(path string, extract func(DirOwners) set
 			return out
 		}
 	}
-	d := dirOf(path)
+	d := path
 	for {
 		if cfg, ok := f.Dirs[d]; ok {
 			out.Insert(extract(cfg).UnsortedList()...)
@@ -125,7 +125,7 @@ func (f *FakeRepoOwners) findOwnersForFile(path string, extract func(DirOwners) 
 	if cfg, ok := f.Files[path]; ok && extract(cfg).Len() > 0 {
 		return path
 	}
-	d := dirOf(path)
+	d := path
 	for d != "" {
 		if cfg, ok := f.Dirs[d]; ok && extract(cfg).Len() > 0 {
 			return d
@@ -186,9 +186,11 @@ func (f *FakeRepoOwners) RequiredReviewers(path string) sets.String {
 
 // MinimumReviewersForFile walks up from path returning the closest
 // MinimumReviewers value; returns 1 (the real implementation's default)
-// if no ancestor sets one.
+// if no ancestor sets one. The walk starts at path itself so callers
+// that pass a dir path (rather than a file path) get the entry at that
+// directory rather than at its parent.
 func (f *FakeRepoOwners) MinimumReviewersForFile(path string) int {
-	d := dirOf(path)
+	d := path
 	for {
 		if cfg, ok := f.Dirs[d]; ok {
 			if cfg.MinimumReviewers > 0 {

--- a/pkg/repoowners/fake/fake.go
+++ b/pkg/repoowners/fake/fake.go
@@ -58,7 +58,7 @@ var _ repoowners.Interface = (*Client)(nil)
 // aliases separately from expanded owner sets; tests should supply
 // already-expanded logins in DirOwners.
 func (c *Client) LoadRepoAliases(org, repo, base string) (repoowners.RepoAliases, error) {
-	return nil, nil
+	return repoowners.RepoAliases{}, nil
 }
 
 // LoadRepoOwners returns the shared FakeRepoOwners instance, allocating

--- a/pkg/repoowners/fake/fake_test.go
+++ b/pkg/repoowners/fake/fake_test.go
@@ -1,0 +1,84 @@
+package fake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func newFake() *FakeRepoOwners {
+	return &FakeRepoOwners{
+		Dirs: map[string]DirOwners{
+			"": {
+				Approvers: sets.NewString("root-approver"),
+				Reviewers: sets.NewString("root-reviewer"),
+				Labels:    sets.NewString("root-label"),
+			},
+			"a": {
+				Approvers:        sets.NewString("alice"),
+				Reviewers:        sets.NewString("aria"),
+				Labels:           sets.NewString("area/a"),
+				MinimumReviewers: 2,
+			},
+			"a/b": {
+				Approvers: sets.NewString("bob"),
+				Reviewers: sets.NewString("bella"),
+			},
+			"c": {
+				Approvers:      sets.NewString("carol"),
+				NoParentOwners: true,
+			},
+		},
+	}
+}
+
+func TestApproversWalksUp(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, sets.NewString("root-approver", "alice", "bob"), f.Approvers("a/b/x.go"))
+}
+
+func TestLeafApproversStopsAtClosest(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, sets.NewString("bob"), f.LeafApprovers("a/b/x.go"))
+	assert.Equal(t, sets.NewString("alice"), f.LeafApprovers("a/x.go"))
+}
+
+func TestNoParentOwnersStopsWalk(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, sets.NewString("carol"), f.Approvers("c/x.go"))
+}
+
+func TestFindApproverOwnersForFileSkipsRoot(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, "a/b", f.FindApproverOwnersForFile("a/b/x.go"))
+	assert.Equal(t, "a", f.FindApproverOwnersForFile("a/x.go"))
+	// No non-root ancestor lists approvers for a top-level file, so we get "".
+	assert.Equal(t, "", f.FindApproverOwnersForFile("x.go"))
+}
+
+func TestFindLabelsForFileWalksUp(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, sets.NewString("root-label", "area/a"), f.FindLabelsForFile("a/x.go"))
+}
+
+func TestMinimumReviewersUsesClosestAncestor(t *testing.T) {
+	f := newFake()
+	assert.Equal(t, 2, f.MinimumReviewersForFile("a/b/x.go"))
+	assert.Equal(t, 1, f.MinimumReviewersForFile("x.go"))
+}
+
+func TestIsNoParentOwners(t *testing.T) {
+	f := newFake()
+	assert.True(t, f.IsNoParentOwners("c"))
+	assert.False(t, f.IsNoParentOwners("a"))
+	assert.False(t, f.IsNoParentOwners("nonexistent"))
+}
+
+func TestClientReturnsOwners(t *testing.T) {
+	owners := newFake()
+	c := &Client{Owners: owners}
+	got, err := c.LoadRepoOwners("org", "repo", "main")
+	assert.NoError(t, err)
+	assert.Same(t, owners, got)
+}

--- a/pkg/repoowners/repoowners.go
+++ b/pkg/repoowners/repoowners.go
@@ -648,18 +648,14 @@ func (o *RepoOwners) IsNoParentOwners(path string) bool {
 }
 
 // entriesForFile returns a set of users who are assignees to the
-// requested file. The path variable should be a full path to a filename
-// and not directory as the final directory will be discounted if enableMDYAML is true
-// leafOnly indicates whether only the OWNERS deepest in the tree (closest to the file)
-// should be returned or if all OWNERS in filepath should be returned
+// requested path. path may be a file (typical caller) or a directory
+// (e.g. the OWNERS-file location returned by FindApproverOwnersForFile).
+// The walk starts at path itself so that .md files with a YAML header
+// (keyed by their exact file path) contribute as the leaf entry, and so
+// that dir inputs return entries at that directory rather than at its
+// parent. leafOnly returns as soon as any level of the walk contributes.
 func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.Regexp]sets.String, leafOnly bool) sets.String {
 	d := path
-	if !o.enableMDYAML || !strings.HasSuffix(path, ".md") {
-		// if path is a directory, this will remove the leaf directory, and returns "." for topmost dir
-		d = filepath.Dir(d)
-		d = canonicalize(d)
-	}
-
 	out := sets.NewString()
 	for {
 		relative, err := filepath.Rel(d, path)
@@ -693,11 +689,6 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 // If no minimum reviewers can be found then 1 is returned (the default behavior).
 func (o *RepoOwners) MinimumReviewersForFile(path string) int {
 	d := path
-	if !o.enableMDYAML || !strings.HasSuffix(path, ".md") {
-		d = filepath.Dir(d)
-		d = canonicalize(d)
-	}
-
 	var foundMinReviewer *int
 	for {
 		relative, err := filepath.Rel(d, path)


### PR DESCRIPTION
Seen issues with OWNERS files in sub-directories where lighthouse doesn't honour the OWNERS for a set of changed files within a sub dir. Seems that some places are passing in file paths when the should be passing in directories meaning the filepath.Dir() was being called on the dir containing the OWNERS file and so calculating for the wrong directory.

This bug has been covered up by the fact that all uses of fake owners in test cases are using different fake owners and some don't behave in the same way as the actual implementation. I've refactored the tests for various plugins so that they use the same fake owners. This shows all the failing tests due to the dir/path mix up.

I've then fixed the path/dir bug by including the path itself in the OWNERS walk. This means that both cases are handled correctly if path or dir is passed in as we always run from the bottom of the path/dir.

Note:
It appears this bug has been here since day 1 (~6 years) so I'm guessing that I'm the only person using the sub dir OWNERS logic 😂
